### PR TITLE
fix(core): disable HTTP logging in release builds

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
@@ -5,7 +5,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import okhttp3.logging.HttpLoggingInterceptor
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -34,11 +33,9 @@ object AppModule {
     @Singleton
     fun provideTokenBackendUrl(): String = BuildConfig.TOKEN_BACKEND_URL
 
-    /** HTTP-Logging: BODY in Debug, NONE in Release (verhindert Token-Leaks). */
+    /** Debug-Flag für NetworkModule (steuert HTTP-Logging-Level). */
     @Provides
     @Singleton
-    @Named("httpLoggingLevel")
-    fun provideHttpLoggingLevel(): HttpLoggingInterceptor.Level =
-        if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
-        else HttpLoggingInterceptor.Level.NONE
+    @Named("isDebugBuild")
+    fun provideIsDebugBuild(): Boolean = BuildConfig.DEBUG
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import okhttp3.logging.HttpLoggingInterceptor
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -32,4 +33,12 @@ object AppModule {
     @Provides
     @Singleton
     fun provideTokenBackendUrl(): String = BuildConfig.TOKEN_BACKEND_URL
+
+    /** HTTP-Logging: BODY in Debug, NONE in Release (verhindert Token-Leaks). */
+    @Provides
+    @Singleton
+    @Named("httpLoggingLevel")
+    fun provideHttpLoggingLevel(): HttpLoggingInterceptor.Level =
+        if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
+        else HttpLoggingInterceptor.Level.NONE
 }

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -56,7 +56,10 @@ android {
     }
     kotlinOptions { jvmTarget = "17" }
 
-    buildFeatures { compose = true }
+    buildFeatures {
+        compose = true
+        buildConfig = true
+    }
 }
 
 dependencies {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
@@ -1,0 +1,23 @@
+package com.justb81.watchbuddy.tv.di
+
+import com.justb81.watchbuddy.BuildConfig
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.logging.HttpLoggingInterceptor
+import javax.inject.Named
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    /** HTTP-Logging: BODY in Debug, NONE in Release (verhindert Token-Leaks). */
+    @Provides
+    @Singleton
+    @Named("httpLoggingLevel")
+    fun provideHttpLoggingLevel(): HttpLoggingInterceptor.Level =
+        if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
+        else HttpLoggingInterceptor.Level.NONE
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
@@ -5,7 +5,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import okhttp3.logging.HttpLoggingInterceptor
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -13,11 +12,9 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object AppModule {
 
-    /** HTTP-Logging: BODY in Debug, NONE in Release (verhindert Token-Leaks). */
+    /** Debug-Flag für NetworkModule (steuert HTTP-Logging-Level). */
     @Provides
     @Singleton
-    @Named("httpLoggingLevel")
-    fun provideHttpLoggingLevel(): HttpLoggingInterceptor.Level =
-        if (BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
-        else HttpLoggingInterceptor.Level.NONE
+    @Named("isDebugBuild")
+    fun provideIsDebugBuild(): Boolean = BuildConfig.DEBUG
 }

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
@@ -28,7 +28,9 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
+    fun provideOkHttpClient(
+        @Named("httpLoggingLevel") loggingLevel: HttpLoggingInterceptor.Level
+    ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor { chain ->
             // Trakt required headers
             val request = chain.request().newBuilder()
@@ -39,7 +41,7 @@ object NetworkModule {
             chain.proceed(request)
         }
         .addInterceptor(HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY // TODO: set to NONE in release
+            level = loggingLevel
         })
         .build()
 

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
@@ -29,7 +29,7 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideOkHttpClient(
-        @Named("httpLoggingLevel") loggingLevel: HttpLoggingInterceptor.Level
+        @Named("isDebugBuild") isDebug: Boolean
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor { chain ->
             // Trakt required headers
@@ -41,7 +41,8 @@ object NetworkModule {
             chain.proceed(request)
         }
         .addInterceptor(HttpLoggingInterceptor().apply {
-            level = loggingLevel
+            level = if (isDebug) HttpLoggingInterceptor.Level.BODY
+                    else HttpLoggingInterceptor.Level.NONE
         })
         .build()
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `HttpLoggingInterceptor.Level.BODY` in `NetworkModule.kt` with an injected `@Named("httpLoggingLevel")` parameter
- Add `provideHttpLoggingLevel()` provider in both `app-phone/AppModule` and `app-tv/AppModule` that returns `Level.BODY` for debug builds and `Level.NONE` for release builds
- Enable `buildConfig = true` in `app-tv/build.gradle.kts` to access `BuildConfig.DEBUG`
- Create new `app-tv/…/di/AppModule.kt` (app-tv had no DI module yet)

This follows the existing project pattern where app modules inject BuildConfig values into core via Hilt `@Named` providers, keeping the `:core` module independent of any app's `BuildConfig`.

Closes #20

## Test plan
- [ ] Debug build: verify HTTP requests/responses are logged at `Level.BODY` in Logcat
- [ ] Release build: verify no HTTP body/header logging appears in Logcat
- [ ] Both app-phone and app-tv compile successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)