### PR TITLE
feat(phone): persist Trakt token in EncryptedSharedPreferences

### DIFF
--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -126,6 +126,9 @@ dependencies {
     // WorkManager (background model updates)
     implementation(libs.work.runtime)
 
+    // Security / Encrypted Storage
+    implementation(libs.security.crypto)
+
     // Image loading
     implementation(libs.coil)
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/AuthModule.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/AuthModule.kt
@@ -1,0 +1,19 @@
+package com.justb81.watchbuddy.phone.auth
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AuthModule {
+
+    @Provides
+    @Singleton
+    fun provideTokenRepository(@ApplicationContext context: Context): TokenRepository =
+        TokenRepository(context)
+}

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRepository.kt
@@ -1,0 +1,58 @@
+package com.justb81.watchbuddy.phone.auth
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+class TokenRepository(context: Context) {
+
+    private val prefs: SharedPreferences
+
+    init {
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        prefs = EncryptedSharedPreferences.create(
+            context,
+            "watchbuddy_tokens",
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+    }
+
+    fun saveTokens(accessToken: String, refreshToken: String, expiresIn: Int) {
+        val expiresAt = System.currentTimeMillis() + expiresIn * 1_000L
+        prefs.edit()
+            .putString(KEY_ACCESS_TOKEN, accessToken)
+            .putString(KEY_REFRESH_TOKEN, refreshToken)
+            .putLong(KEY_EXPIRES_AT, expiresAt)
+            .apply()
+    }
+
+    fun getAccessToken(): String? = prefs.getString(KEY_ACCESS_TOKEN, null)
+
+    fun getRefreshToken(): String? = prefs.getString(KEY_REFRESH_TOKEN, null)
+
+    fun isTokenValid(): Boolean {
+        val token = getAccessToken() ?: return false
+        if (token.isBlank()) return false
+        val expiresAt = prefs.getLong(KEY_EXPIRES_AT, 0L)
+        return System.currentTimeMillis() < expiresAt
+    }
+
+    fun clearTokens() {
+        prefs.edit()
+            .remove(KEY_ACCESS_TOKEN)
+            .remove(KEY_REFRESH_TOKEN)
+            .remove(KEY_EXPIRES_AT)
+            .apply()
+    }
+
+    private companion object {
+        const val KEY_ACCESS_TOKEN = "access_token"
+        const val KEY_REFRESH_TOKEN = "refresh_token"
+        const val KEY_EXPIRES_AT = "expires_at"
+    }
+}

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/MainActivity.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/MainActivity.kt
@@ -4,18 +4,31 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.ui.navigation.PhoneNavGraph
+import com.justb81.watchbuddy.phone.ui.navigation.PhoneRoute
 import com.justb81.watchbuddy.phone.ui.theme.WatchBuddyTheme
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject lateinit var tokenRepository: TokenRepository
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        val startDestination = if (tokenRepository.isTokenValid()) {
+            PhoneRoute.Home.route
+        } else {
+            PhoneRoute.Onboarding.route
+        }
+
         setContent {
             WatchBuddyTheme {
-                PhoneNavGraph()
+                PhoneNavGraph(startDestination = startDestination)
             }
         }
     }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.phone.auth.TokenRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -24,7 +25,8 @@ data class HomeUiState(
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     application: Application,
-    private val traktApi: TraktApiService
+    private val traktApi: TraktApiService,
+    private val tokenRepository: TokenRepository
 ) : AndroidViewModel(application) {
 
     private val _uiState = MutableStateFlow(HomeUiState(isLoading = true))
@@ -36,8 +38,9 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
             try {
-                // TODO: pull token from Keystore
-                val shows = traktApi.getWatchedShows("Bearer TODO")
+                val accessToken = tokenRepository.getAccessToken()
+                    ?: throw IllegalStateException("No access token available")
+                val shows = traktApi.getWatchedShows("Bearer $accessToken")
                 _uiState.value = _uiState.value.copy(
                     isLoading    = false,
                     shows        = shows,

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
@@ -16,7 +16,7 @@ sealed class PhoneRoute(val route: String) {
 
 @Composable
 fun PhoneNavGraph(
-    startDestination: String = PhoneRoute.Onboarding.route  // TODO: check token → skip to Home
+    startDestination: String = PhoneRoute.Onboarding.route
 ) {
     val navController = rememberNavController()
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
@@ -9,6 +9,7 @@ import com.justb81.watchbuddy.core.trakt.DeviceCodeResponse
 import com.justb81.watchbuddy.core.trakt.ProxyTokenRequest
 import com.justb81.watchbuddy.core.trakt.TokenProxyService
 import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.phone.auth.TokenRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -42,7 +43,8 @@ class OnboardingViewModel @Inject constructor(
     private val traktApi: TraktApiService,
     /** Null, wenn TOKEN_BACKEND_URL in BuildConfig leer ist. */
     private val tokenProxy: TokenProxyService?,
-    @Named("traktClientId") private val clientId: String
+    @Named("traktClientId") private val clientId: String,
+    private val tokenRepository: TokenRepository
 ) : AndroidViewModel(application) {
 
     private val _state = MutableStateFlow<OnboardingState>(OnboardingState.Idle)
@@ -116,7 +118,11 @@ class OnboardingViewModel @Inject constructor(
                     val token = tokenProxy!!.exchangeDeviceCode(
                         ProxyTokenRequest(code = response.device_code)
                     )
-                    // TODO: Token im Android Keystore persistieren
+                    tokenRepository.saveTokens(
+                        accessToken  = token.access_token,
+                        refreshToken = token.refresh_token,
+                        expiresIn    = token.expires_in
+                    )
                     val profile = traktApi.getProfile("Bearer ${token.access_token}")
                     countdownJob?.cancel()
                     pollingJob?.cancel()

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -32,7 +33,8 @@ data class SettingsUiState(
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     application: Application,
-    private val llmOrchestrator: LlmOrchestrator
+    private val llmOrchestrator: LlmOrchestrator,
+    private val tokenRepository: TokenRepository
 ) : AndroidViewModel(application) {
 
     private val _uiState = MutableStateFlow(SettingsUiState(
@@ -81,7 +83,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun disconnectTrakt() {
-        // TODO: clear tokens from Keystore
+        tokenRepository.clearTokens()
         _uiState.value = _uiState.value.copy(traktUsername = null)
     }
 


### PR DESCRIPTION
## Summary

- **TokenRepository**: New class using `EncryptedSharedPreferences` with `MasterKey` (AES256_GCM) to securely store access token, refresh token, and expiry timestamp in the Android Keystore
- **AuthModule**: Hilt module providing `TokenRepository` as a `@Singleton`
- **OnboardingViewModel**: Persists tokens after successful device code exchange via the token proxy
- **HomeViewModel**: Reads access token from `TokenRepository` instead of the hardcoded `"Bearer TODO"` placeholder
- **SettingsViewModel**: Clears tokens from the Keystore when the user disconnects Trakt
- **MainActivity**: Determines `startDestination` (Onboarding vs Home) based on `tokenRepository.isTokenValid()` — users with a valid token skip onboarding on app restart

Closes #7

## Test plan

- [ ] Fresh install → Onboarding screen is shown
- [ ] Complete Trakt device code flow → token is persisted, navigates to Home
- [ ] Kill and restart app → Home screen is shown directly (token survives restart)
- [ ] Settings → Disconnect Trakt → token is cleared, next restart shows Onboarding
- [ ] Verify token expiry: set clock forward past `expires_at` → Onboarding is shown
- [ ] Home screen loads watched shows using stored token (no more "Bearer TODO")

🤖 Generated with [Claude Code](https://claude.com/claude-code)