### PR TITLE
feat(phone): implement LLM provider routing in RecapGenerator

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/AiCoreLlmProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/AiCoreLlmProvider.kt
@@ -1,0 +1,32 @@
+package com.justb81.watchbuddy.phone.llm
+
+import android.content.Context
+
+/**
+ * LLM provider backed by Android AICore (Gemini Nano).
+ *
+ * AICore is available on Android 14+ with supported hardware (Pixel 8+ class).
+ * The model is managed by Google Play Services — no manual download required.
+ *
+ * TODO: Replace stub with real AICore GenerativeModel calls once
+ *       com.google.android.gms:play-services-aicore is added as a dependency.
+ *       API reference: https://developer.android.com/ai/aicore
+ */
+class AiCoreLlmProvider(
+    private val context: Context
+) : LlmProvider {
+
+    override val displayName: String = "AICore (Gemini Nano)"
+
+    override suspend fun generate(prompt: String): String {
+        // TODO: Implement with play-services-aicore GenerativeModel API:
+        //   val generativeModel = GenerativeModel.newBuilder()
+        //       .setModelName("gemini-nano")
+        //       .build()
+        //   val response = generativeModel.generateContent(prompt)
+        //   return response.text ?: throw IllegalStateException("AICore returned empty response")
+        throw UnsupportedOperationException(
+            "AICore provider not yet implemented — add play-services-aicore dependency"
+        )
+    }
+}

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/FallbackProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/FallbackProvider.kt
@@ -1,0 +1,42 @@
+package com.justb81.watchbuddy.phone.llm
+
+import com.justb81.watchbuddy.core.model.TmdbEpisode
+
+/**
+ * Fallback "provider" that builds a simple HTML recap from TMDB episode synopses
+ * without any LLM inference. Used when no LLM backend is available.
+ */
+class FallbackProvider(
+    private val episodes: List<TmdbEpisode>
+) : LlmProvider {
+
+    override val displayName: String = "TMDB Synopsis Fallback"
+
+    override suspend fun generate(prompt: String): String {
+        val slides = episodes.takeLast(6).mapIndexed { index, ep ->
+            val label = "S${ep.season_number.toString().padStart(2, '0')}" +
+                    "E${ep.episode_number.toString().padStart(2, '0')}"
+            val overview = ep.overview ?: "—"
+            """
+            <div class="slide" style="animation-delay:${index * 4}s">
+              <img data-tmdb-still="$label" alt="$label">
+              <h3>${ep.name} ($label)</h3>
+              <p>$overview</p>
+            </div>
+            """.trimIndent()
+        }
+
+        return """
+        <div style="font-family:sans-serif;color:white;padding:16px;">
+          <style>
+            .slide { opacity:0; animation: fadeSlide 4s ease-in-out forwards; margin-bottom:24px; }
+            @keyframes fadeSlide { 0%{opacity:0;transform:translateY(20px)} 10%{opacity:1;transform:translateY(0)} 90%{opacity:1} 100%{opacity:0} }
+            img { width:100%;border-radius:8px;margin-bottom:8px; }
+            h3 { margin:4px 0; }
+            p { font-size:14px;line-height:1.4; }
+          </style>
+          ${slides.joinToString("\n")}
+        </div>
+        """.trimIndent()
+    }
+}

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProvider.kt
@@ -1,0 +1,15 @@
+package com.justb81.watchbuddy.phone.llm
+
+/**
+ * Abstraction for on-device and remote LLM inference backends.
+ *
+ * Implementations are tried in cascade order (AICore -> MediaPipe -> Remote -> Fallback)
+ * by [LlmProviderFactory].
+ */
+interface LlmProvider {
+    /** Run inference and return the generated text. Throws on failure. */
+    suspend fun generate(prompt: String): String
+
+    /** Human-readable name shown in settings / logs. */
+    val displayName: String
+}

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
@@ -1,0 +1,98 @@
+package com.justb81.watchbuddy.phone.llm
+
+import android.content.Context
+import android.util.Log
+import com.justb81.watchbuddy.core.model.LlmBackend
+import com.justb81.watchbuddy.core.model.TmdbEpisode
+import dagger.hilt.android.qualifiers.ApplicationContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Creates [LlmProvider] instances based on [LlmOrchestrator.selectConfig] and
+ * implements a cascade fallback:  AICore -> MediaPipe -> Remote Ollama -> TMDB Fallback.
+ *
+ * Each provider is attempted in order. If a provider throws, the next one is tried.
+ */
+@Singleton
+class LlmProviderFactory @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val llmOrchestrator: LlmOrchestrator
+) {
+    companion object {
+        private const val TAG = "LlmProviderFactory"
+        // TODO: make configurable via DataStore / Settings UI
+        private const val DEFAULT_OLLAMA_URL = "http://localhost:11434"
+    }
+
+    /**
+     * Runs inference with cascade fallback.
+     *
+     * @param prompt       The LLM prompt
+     * @param episodes     Watched episodes (used by FallbackProvider)
+     * @param ollamaUrl    Optional Ollama server URL override
+     * @return Generated text from the first provider that succeeds
+     */
+    suspend fun generateWithCascade(
+        prompt: String,
+        episodes: List<TmdbEpisode>,
+        ollamaUrl: String? = null
+    ): String {
+        val config = llmOrchestrator.selectConfig()
+        val providers = buildProviderCascade(config, episodes, ollamaUrl)
+
+        for (provider in providers) {
+            try {
+                Log.d(TAG, "Trying provider: ${provider.displayName}")
+                val result = provider.generate(prompt)
+                Log.d(TAG, "Success with provider: ${provider.displayName}")
+                return result
+            } catch (e: Exception) {
+                Log.w(TAG, "Provider ${provider.displayName} failed: ${e.message}")
+            }
+        }
+
+        // All providers failed — return minimal fallback
+        Log.e(TAG, "All LLM providers failed, returning empty fallback")
+        return buildMinimalFallback()
+    }
+
+    private fun buildProviderCascade(
+        config: LlmOrchestrator.LlmConfig,
+        episodes: List<TmdbEpisode>,
+        ollamaUrl: String?
+    ): List<LlmProvider> {
+        val providers = mutableListOf<LlmProvider>()
+
+        when (config.backend) {
+            LlmBackend.AICORE -> {
+                providers += AiCoreLlmProvider(context)
+                // Fall through to MediaPipe if AICore fails
+                config.modelVariant?.let {
+                    providers += MediaPipeLlmProvider(context, it)
+                }
+            }
+            LlmBackend.MEDIAPIPE_GPU, LlmBackend.MEDIAPIPE_CPU -> {
+                config.modelVariant?.let {
+                    providers += MediaPipeLlmProvider(context, it)
+                }
+            }
+            LlmBackend.NONE -> { /* skip on-device, go straight to remote/fallback */ }
+        }
+
+        // Remote Ollama as next-to-last resort
+        val url = ollamaUrl ?: DEFAULT_OLLAMA_URL
+        providers += RemoteOllamaProvider(url)
+
+        // TMDB synopsis fallback is always last
+        providers += FallbackProvider(episodes)
+
+        return providers
+    }
+
+    private fun buildMinimalFallback(): String = """
+        <div style="display:flex;align-items:center;justify-content:center;height:100%;color:white;font-family:sans-serif;">
+          <p>Recap konnte nicht generiert werden.</p>
+        </div>
+    """.trimIndent()
+}

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/MediaPipeLlmProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/MediaPipeLlmProvider.kt
@@ -1,0 +1,51 @@
+package com.justb81.watchbuddy.phone.llm
+
+import android.content.Context
+import com.google.mediapipe.tasks.genai.llminference.LlmInference
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * LLM provider backed by MediaPipe LLM Inference API with a local Gemma model.
+ *
+ * The model file (e.g. gemma-4-e2b-it-int4.task) must be present in the app's
+ * internal files directory before calling [generate]. Model download is handled
+ * separately by WorkManager (see SettingsViewModel.downloadModel).
+ */
+class MediaPipeLlmProvider(
+    private val context: Context,
+    private val modelVariant: LlmOrchestrator.ModelVariant
+) : LlmProvider {
+
+    override val displayName: String = "MediaPipe (${modelVariant.fileName})"
+
+    private var inference: LlmInference? = null
+
+    private fun getOrCreateInference(): LlmInference {
+        inference?.let { return it }
+
+        val modelPath = File(context.filesDir, modelVariant.fileName).absolutePath
+        if (!File(modelPath).exists()) {
+            throw IllegalStateException(
+                "Model file not found: ${modelVariant.fileName}. Download it first via Settings."
+            )
+        }
+
+        val options = LlmInference.LlmInferenceOptions.builder()
+            .setModelPath(modelPath)
+            .setMaxTokens(1024)
+            .build()
+
+        return LlmInference.createFromOptions(context, options).also { inference = it }
+    }
+
+    override suspend fun generate(prompt: String): String = withContext(Dispatchers.IO) {
+        val llm = getOrCreateInference()
+        val result = llm.generateResponse(prompt)
+        if (result.isNullOrBlank()) {
+            throw IllegalStateException("MediaPipe returned empty response")
+        }
+        result
+    }
+}

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/RecapGenerator.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/RecapGenerator.kt
@@ -1,6 +1,7 @@
 package com.justb81.watchbuddy.phone.llm
 
 import android.app.Application
+import android.util.Log
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.locale.LocaleHelper
 import com.justb81.watchbuddy.core.model.TmdbEpisode
@@ -21,9 +22,10 @@ import javax.inject.Singleton
 @Singleton
 class RecapGenerator @Inject constructor(
     private val application: Application,
-    private val llmOrchestrator: LlmOrchestrator
+    private val llmProviderFactory: LlmProviderFactory
 ) {
     companion object {
+        private const val TAG = "RecapGenerator"
         // TMDB still placeholder pattern: data-tmdb-still="S{season}E{episode}"
         private val STILL_PLACEHOLDER_REGEX = Regex("""data-tmdb-still="S(\d+)E(\d+)"""")
     }
@@ -41,7 +43,7 @@ class RecapGenerator @Inject constructor(
         apiKey: String
     ): String {
         val prompt = buildPrompt(show, watchedEpisodes, targetEpisode)
-        val rawHtml = inferWithLlm(prompt)
+        val rawHtml = inferWithLlm(prompt, watchedEpisodes)
         return replaceTmdbPlaceholders(rawHtml, watchedEpisodes, apiKey)
     }
 
@@ -80,10 +82,9 @@ Respond in $language.
 """.trimIndent()
     }
 
-    private suspend fun inferWithLlm(prompt: String): String {
-        // TODO: route to AICore or MediaPipe based on LlmOrchestrator.selectConfig()
-        // Placeholder — real implementation connects to the active LLM backend
-        return buildFallbackHtml("Recap wird geladen…")
+    private suspend fun inferWithLlm(prompt: String, episodes: List<TmdbEpisode>): String {
+        Log.d(TAG, "Starting LLM inference with cascade fallback")
+        return llmProviderFactory.generateWithCascade(prompt, episodes)
     }
 
     private fun replaceTmdbPlaceholders(
@@ -101,10 +102,4 @@ Respond in $language.
             """src="$url""""
         }
     }
-
-    private fun buildFallbackHtml(message: String) = """
-        <div style="display:flex;align-items:center;justify-content:center;height:100%;color:white;font-family:sans-serif;">
-          <p>$message</p>
-        </div>
-    """.trimIndent()
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/RemoteOllamaProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/RemoteOllamaProvider.kt
@@ -1,0 +1,67 @@
+package com.justb81.watchbuddy.phone.llm
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * LLM provider that sends prompts to a remote Ollama server via HTTP POST.
+ *
+ * Expected Ollama endpoint: POST /api/generate
+ * The server URL is user-configurable (e.g. http://192.168.1.100:11434).
+ */
+class RemoteOllamaProvider(
+    private val serverUrl: String,
+    private val model: String = "gemma3:4b"
+) : LlmProvider {
+
+    override val displayName: String = "Ollama ($model @ $serverUrl)"
+
+    @Serializable
+    private data class OllamaRequest(
+        val model: String,
+        val prompt: String,
+        val stream: Boolean = false
+    )
+
+    @Serializable
+    private data class OllamaResponse(
+        val response: String = ""
+    )
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override suspend fun generate(prompt: String): String = withContext(Dispatchers.IO) {
+        val url = URL("${serverUrl.trimEnd('/')}/api/generate")
+        val connection = url.openConnection() as HttpURLConnection
+        try {
+            connection.requestMethod = "POST"
+            connection.setRequestProperty("Content-Type", "application/json")
+            connection.doOutput = true
+            connection.connectTimeout = 10_000
+            connection.readTimeout = 120_000 // LLM generation can be slow
+
+            val body = json.encodeToString(OllamaRequest(model, prompt))
+            connection.outputStream.bufferedWriter().use { it.write(body) }
+
+            val code = connection.responseCode
+            if (code != 200) {
+                val error = connection.errorStream?.bufferedReader()?.readText() ?: "unknown error"
+                throw IllegalStateException("Ollama returned HTTP $code: $error")
+            }
+
+            val responseBody = connection.inputStream.bufferedReader().readText()
+            val parsed = json.decodeFromString<OllamaResponse>(responseBody)
+            if (parsed.response.isBlank()) {
+                throw IllegalStateException("Ollama returned empty response")
+            }
+            parsed.response
+        } finally {
+            connection.disconnect()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #9

- **LlmProvider interface** — common abstraction for all LLM backends (`generate(prompt)` + `displayName`)
- **4 concrete providers** with cascade fallback order:
  1. `AiCoreLlmProvider` — Gemini Nano via Android AICore (stub with TODO; `play-services-aicore` not yet in dependencies)
  2. `MediaPipeLlmProvider` — on-device Gemma inference via `tasks-genai` 0.10.14 (already in build deps)
  3. `RemoteOllamaProvider` — HTTP POST to user's Ollama server (`/api/generate`)
  4. `FallbackProvider` — TMDB episode synopsis rendered as animated HTML slideshow (no LLM needed)
- **LlmProviderFactory** — Hilt singleton that builds the provider cascade from `LlmOrchestrator.selectConfig()` and tries each in order until one succeeds
- **RecapGenerator.inferWithLlm()** now delegates to `LlmProviderFactory.generateWithCascade()` instead of returning static fallback HTML

### Cascade logic

| Device capability | Provider tried first | Fallback chain |
|---|---|---|
| AICore available (Pixel 8+, Android 14+) | AiCoreLlmProvider | → MediaPipe → Ollama → TMDB |
| MediaPipe viable (≥3 GB free RAM) | MediaPipeLlmProvider | → Ollama → TMDB |
| No on-device LLM | RemoteOllamaProvider | → TMDB |

### Notes

- **AICore** is a stub — the `play-services-aicore` dependency is not yet available in the project. The provider throws `UnsupportedOperationException` and the cascade falls through cleanly.
- **MediaPipe** uses the existing `mediapipe-tasks-genai:0.10.14` dependency. Model file must be downloaded first (handled by `SettingsViewModel.downloadModel()`).
- **RemoteOllama** defaults to `localhost:11434`. URL will be user-configurable via DataStore in a follow-up.

## Test plan

- [ ] CI build passes (Kotlin compilation of all new files)
- [ ] Verify on device with no LLM: FallbackProvider produces valid HTML slideshow from TMDB synopses
- [ ] Verify with downloaded Gemma model: MediaPipeLlmProvider generates HTML recap
- [ ] Verify cascade: if MediaPipe fails (no model file), falls through to Ollama, then to TMDB fallback
- [ ] Verify AICore stub throws and cascade continues to next provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)