### PR TITLE
feat(tv): resolve streaming availability via user preference mapping

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepository.kt
@@ -4,8 +4,8 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringSetKey
-import androidx.datastore.preferences.core.stringKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
@@ -21,8 +21,8 @@ private val Context.streamingDataStore: DataStore<Preferences> by preferencesDat
 class StreamingPreferencesRepository @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
-    private val subscribedKey = stringSetKey("subscribed_service_ids")
-    private val orderKey = stringKey("service_order")
+    private val subscribedKey = stringSetPreferencesKey("subscribed_service_ids")
+    private val orderKey = stringPreferencesKey("service_order")
 
     /**
      * Emits the ordered list of subscribed service IDs.

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepository.kt
@@ -1,0 +1,48 @@
+package com.justb81.watchbuddy.tv.data
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetKey
+import androidx.datastore.preferences.core.stringKey
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.streamingDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "streaming_preferences"
+)
+
+@Singleton
+class StreamingPreferencesRepository @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val subscribedKey = stringSetKey("subscribed_service_ids")
+    private val orderKey = stringKey("service_order")
+
+    /**
+     * Emits the ordered list of subscribed service IDs.
+     * Empty list means no preference has been set (show all as fallback).
+     */
+    val subscribedServiceIds: Flow<List<String>> = context.streamingDataStore.data.map { prefs ->
+        val ids = prefs[subscribedKey] ?: emptySet()
+        val order = prefs[orderKey]?.split(",") ?: emptyList()
+        // Return IDs sorted by the stored priority order
+        if (order.isNotEmpty()) {
+            ids.sortedBy { id -> order.indexOf(id).let { if (it == -1) Int.MAX_VALUE else it } }
+        } else {
+            ids.toList()
+        }
+    }
+
+    suspend fun setSubscribedServices(orderedIds: List<String>) {
+        context.streamingDataStore.edit { prefs ->
+            prefs[subscribedKey] = orderedIds.toSet()
+            prefs[orderKey] = orderedIds.joinToString(",")
+        }
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -26,6 +26,7 @@ import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 fun TvHomeScreen(
     onShowClick: (TraktWatchedEntry) -> Unit,
     onUserSelectClick: () -> Unit,
+    onStreamingSettingsClick: () -> Unit = {},
     viewModel: TvHomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -68,6 +69,14 @@ fun TvHomeScreen(
                             fontSize = 12.sp,
                             color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f)
                         )
+                    }
+
+                    // Streaming settings button
+                    OutlinedButton(
+                        onClick = onStreamingSettingsClick,
+                        scale   = ButtonDefaults.scale(scale = 1f)
+                    ) {
+                        Text(stringResource(R.string.tv_streaming_settings_button))
                     }
 
                     // User select button

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
@@ -10,6 +10,7 @@ import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.tv.ui.home.TvHomeScreen
 import com.justb81.watchbuddy.tv.ui.recap.RecapScreen
 import com.justb81.watchbuddy.tv.ui.scrobble.ScrobbleOverlay
+import com.justb81.watchbuddy.tv.ui.settings.StreamingSettingsScreen
 import com.justb81.watchbuddy.tv.ui.showdetail.ShowDetailScreen
 import com.justb81.watchbuddy.tv.ui.userselect.UserSelectScreen
 import com.justb81.watchbuddy.core.model.ScrobbleCandidate
@@ -18,7 +19,8 @@ sealed class TvRoute(val route: String) {
     object Home       : TvRoute("tv_home")
     object UserSelect : TvRoute("tv_user_select")
     object ShowDetail : TvRoute("tv_show_detail")
-    object Recap      : TvRoute("tv_recap")
+    object Recap              : TvRoute("tv_recap")
+    object StreamingSettings  : TvRoute("tv_streaming_settings")
 }
 
 @Composable
@@ -43,6 +45,9 @@ fun TvNavGraph() {
                 },
                 onUserSelectClick = {
                     navController.navigate(TvRoute.UserSelect.route)
+                },
+                onStreamingSettingsClick = {
+                    navController.navigate(TvRoute.StreamingSettings.route)
                 }
             )
         }
@@ -82,6 +87,12 @@ fun TvNavGraph() {
                     }
                 )
             }
+        }
+
+        composable(TvRoute.StreamingSettings.route) {
+            StreamingSettingsScreen(
+                onBack = { navController.popBackStack() }
+            )
         }
     }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsScreen.kt
@@ -1,0 +1,186 @@
+package com.justb81.watchbuddy.tv.ui.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.tv.material3.*
+import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.model.StreamingService
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun StreamingSettingsScreen(
+    onBack: () -> Unit,
+    viewModel: StreamingSettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFF0A0A0A))
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 48.dp, vertical = 32.dp)
+        ) {
+            // Header
+            Text(
+                text       = stringResource(R.string.tv_streaming_settings_title),
+                fontSize   = 32.sp,
+                fontWeight = FontWeight.Bold,
+                color      = Color.White
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text     = stringResource(R.string.tv_streaming_settings_subtitle),
+                fontSize = 14.sp,
+                color    = Color.White.copy(alpha = 0.5f)
+            )
+
+            Spacer(Modifier.height(24.dp))
+
+            // Service list
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.weight(1f)
+            ) {
+                itemsIndexed(
+                    uiState.services,
+                    key = { _, service -> service.id }
+                ) { _, service ->
+                    val isSubscribed = service.id in uiState.subscribedIds
+                    val priority = uiState.orderedIds.indexOf(service.id)
+
+                    ServiceRow(
+                        service      = service,
+                        isSubscribed = isSubscribed,
+                        priority     = if (isSubscribed) priority + 1 else null,
+                        canMoveUp    = isSubscribed && priority > 0,
+                        canMoveDown  = isSubscribed && priority < uiState.orderedIds.lastIndex,
+                        onToggle     = { viewModel.toggleService(service.id) },
+                        onMoveUp     = { viewModel.moveServiceUp(service.id) },
+                        onMoveDown   = { viewModel.moveServiceDown(service.id) }
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+
+            // Back button
+            OutlinedButton(onClick = onBack) {
+                Text(stringResource(R.string.tv_back))
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun ServiceRow(
+    service: StreamingService,
+    isSubscribed: Boolean,
+    priority: Int?,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
+    onToggle: () -> Unit,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit
+) {
+    val borderColor = if (isSubscribed) Color(0xFFE53935) else Color.Transparent
+
+    Card(
+        onClick  = onToggle,
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(2.dp, borderColor, RoundedCornerShape(12.dp)),
+        shape    = CardDefaults.shape(RoundedCornerShape(12.dp)),
+        colors   = CardDefaults.colors(
+            containerColor        = if (isSubscribed) Color(0xFF1C1C1E) else Color(0xFF121214),
+            focusedContainerColor = Color(0xFF2C2C2E)
+        ),
+        scale    = CardDefaults.scale(focusedScale = 1.02f)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 14.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                // Priority number or checkbox indicator
+                Box(
+                    modifier = Modifier
+                        .size(32.dp)
+                        .background(
+                            if (isSubscribed) Color(0xFFE53935) else Color(0xFF3A3A3C),
+                            RoundedCornerShape(8.dp)
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text       = if (priority != null) priority.toString() else "",
+                        fontSize   = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                        color      = Color.White
+                    )
+                }
+
+                Column {
+                    Text(
+                        text       = service.name,
+                        fontSize   = 18.sp,
+                        fontWeight = FontWeight.Medium,
+                        color      = Color.White
+                    )
+                    Text(
+                        text     = service.packageName,
+                        fontSize = 11.sp,
+                        color    = Color.White.copy(alpha = 0.3f)
+                    )
+                }
+            }
+
+            // Priority reorder buttons (only for subscribed services)
+            if (isSubscribed) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedButton(
+                        onClick = onMoveUp,
+                        enabled = canMoveUp,
+                        modifier = Modifier.size(40.dp),
+                        contentPadding = PaddingValues(0.dp)
+                    ) {
+                        Text("\u25B2", fontSize = 14.sp)
+                    }
+                    OutlinedButton(
+                        onClick = onMoveDown,
+                        enabled = canMoveDown,
+                        modifier = Modifier.size(40.dp),
+                        contentPadding = PaddingValues(0.dp)
+                    ) {
+                        Text("\u25BC", fontSize = 14.sp)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsViewModel.kt
@@ -1,0 +1,75 @@
+package com.justb81.watchbuddy.tv.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.justb81.watchbuddy.core.model.KNOWN_STREAMING_SERVICES
+import com.justb81.watchbuddy.core.model.StreamingService
+import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class StreamingSettingsUiState(
+    val services: List<StreamingService> = KNOWN_STREAMING_SERVICES,
+    val subscribedIds: Set<String> = emptySet(),
+    val orderedIds: List<String> = emptyList()
+)
+
+@HiltViewModel
+class StreamingSettingsViewModel @Inject constructor(
+    private val repository: StreamingPreferencesRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(StreamingSettingsUiState())
+    val uiState: StateFlow<StreamingSettingsUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.subscribedServiceIds.collect { ids ->
+                _uiState.update {
+                    it.copy(subscribedIds = ids.toSet(), orderedIds = ids)
+                }
+            }
+        }
+    }
+
+    fun toggleService(serviceId: String) {
+        val current = _uiState.value.orderedIds.toMutableList()
+        if (serviceId in current) {
+            current.remove(serviceId)
+        } else {
+            current.add(serviceId)
+        }
+        _uiState.update { it.copy(subscribedIds = current.toSet(), orderedIds = current) }
+        viewModelScope.launch {
+            repository.setSubscribedServices(current)
+        }
+    }
+
+    fun moveServiceUp(serviceId: String) {
+        val current = _uiState.value.orderedIds.toMutableList()
+        val index = current.indexOf(serviceId)
+        if (index > 0) {
+            current.removeAt(index)
+            current.add(index - 1, serviceId)
+            _uiState.update { it.copy(orderedIds = current) }
+            viewModelScope.launch {
+                repository.setSubscribedServices(current)
+            }
+        }
+    }
+
+    fun moveServiceDown(serviceId: String) {
+        val current = _uiState.value.orderedIds.toMutableList()
+        val index = current.indexOf(serviceId)
+        if (index in 0 until current.lastIndex) {
+            current.removeAt(index)
+            current.add(index + 1, serviceId)
+            _uiState.update { it.copy(orderedIds = current) }
+            viewModelScope.launch {
+                repository.setSubscribedServices(current)
+            }
+        }
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -15,9 +15,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.tv.material3.*
 import com.justb81.watchbuddy.R
-import com.justb81.watchbuddy.core.model.KNOWN_STREAMING_SERVICES
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 
 @OptIn(ExperimentalTvMaterial3Api::class)
@@ -25,14 +25,16 @@ import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 fun ShowDetailScreen(
     entry: TraktWatchedEntry,
     onRecapClick: () -> Unit,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    viewModel: ShowDetailViewModel = hiltViewModel()
 ) {
     val context      = LocalContext.current
     val lastSeason   = entry.seasons.maxByOrNull { it.number }
     val lastEpisode  = lastSeason?.episodes?.maxByOrNull { it.number }
     val nextSeason   = lastSeason?.number ?: 1
     val nextEpisode  = (lastEpisode?.number ?: 0) + 1
-    val tmdbId       = entry.show.ids.tmdb
+
+    val services by viewModel.availableServices.collectAsState(initial = emptyList())
 
     Box(
         modifier = Modifier
@@ -115,10 +117,10 @@ fun ShowDetailScreen(
             // Action buttons
             Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
 
-                // Watch Now — deep link
+                // Watch Now — deep link using preferred service
                 Button(
                     onClick = {
-                        val deepLink = resolveDeepLink(entry, nextSeason, nextEpisode)
+                        val deepLink = viewModel.resolveDeepLink(entry, services)
                         if (deepLink != null) {
                             context.startActivity(
                                 Intent(Intent.ACTION_VIEW, Uri.parse(deepLink))
@@ -147,16 +149,15 @@ fun ShowDetailScreen(
                 }
             }
 
-            // Streaming service list
-            if (KNOWN_STREAMING_SERVICES.isNotEmpty()) {
+            // Streaming service list — only subscribed services (fallback: all)
+            if (services.isNotEmpty()) {
                 Text(
                     text     = stringResource(R.string.tv_available_at),
                     fontSize = 12.sp,
                     color    = Color.White.copy(alpha = 0.4f)
                 )
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    // TODO: resolve actual availability via JustWatch / user mapping
-                    KNOWN_STREAMING_SERVICES.take(4).forEach { service ->
+                    services.take(4).forEach { service ->
                         MetaChip(service.name, color = Color(0xFF1C1C1E))
                     }
                 }
@@ -189,18 +190,4 @@ private fun MetaChip(text: String, color: Color = Color(0xFF2C2C2E)) {
             modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
         )
     }
-}
-
-/**
- * Resolves the best available deep link for a show.
- * TODO: replace with user-configured streaming service mapping.
- */
-private fun resolveDeepLink(
-    entry: TraktWatchedEntry,
-    season: Int,
-    episode: Int
-): String? {
-    val tmdbId = entry.show.ids.tmdb ?: return null
-    // Default to Netflix — real implementation checks user's subscriptions
-    return "https://www.netflix.com/title/$tmdbId"
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModel.kt
@@ -1,0 +1,51 @@
+package com.justb81.watchbuddy.tv.ui.showdetail
+
+import androidx.lifecycle.ViewModel
+import com.justb81.watchbuddy.core.model.KNOWN_STREAMING_SERVICES
+import com.justb81.watchbuddy.core.model.StreamingService
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@HiltViewModel
+class ShowDetailViewModel @Inject constructor(
+    private val streamingPrefs: StreamingPreferencesRepository
+) : ViewModel() {
+
+    /**
+     * Returns the streaming services to display, filtered and ordered by user preferences.
+     * Falls back to all known services if no preference is set.
+     */
+    val availableServices: Flow<List<StreamingService>> = streamingPrefs.subscribedServiceIds.map { ids ->
+        if (ids.isEmpty()) {
+            KNOWN_STREAMING_SERVICES
+        } else {
+            ids.mapNotNull { id -> KNOWN_STREAMING_SERVICES.find { it.id == id } }
+        }
+    }
+
+    /**
+     * Resolves the best deep link for a show based on user's preferred streaming services.
+     * Returns the first available service's deep link, respecting priority order.
+     */
+    fun resolveDeepLink(
+        entry: TraktWatchedEntry,
+        subscribedServices: List<StreamingService>
+    ): String? {
+        val tmdbId = entry.show.ids.tmdb ?: return null
+        val slug = entry.show.ids.slug ?: entry.show.title.lowercase().replace(" ", "-")
+
+        val service = subscribedServices.firstOrNull()
+            ?: KNOWN_STREAMING_SERVICES.firstOrNull()
+            ?: return null
+
+        return service.deepLinkTemplate
+            .replace("{tmdb_id}", tmdbId.toString())
+            .replace("{slug}", slug)
+            .replace("{asin}", tmdbId.toString())
+            .replace("{id}", tmdbId.toString())
+    }
+}

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -39,6 +39,11 @@
     <string name="tv_recap_close">Schließen</string>
     <string name="tv_recap_watch_now">Jetzt ansehen</string>
 
+    <!-- Streaming settings -->
+    <string name="tv_streaming_settings_button">Dienste</string>
+    <string name="tv_streaming_settings_title">Streamingdienste</string>
+    <string name="tv_streaming_settings_subtitle">Wähle deine abonnierten Dienste aus. Die Reihenfolge bestimmt die Priorität für Jetzt ansehen.</string>
+
     <!-- Scrobble overlay -->
     <string name="tv_scrobble_question">Schaust du gerade %1$s?</string>
     <string name="tv_scrobble_episode">S%1$02dE%2$02d</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -39,6 +39,11 @@
     <string name="tv_recap_close">Cerrar</string>
     <string name="tv_recap_watch_now">Ver ahora</string>
 
+    <!-- Streaming settings -->
+    <string name="tv_streaming_settings_button">Servicios</string>
+    <string name="tv_streaming_settings_title">Servicios de streaming</string>
+    <string name="tv_streaming_settings_subtitle">Selecciona tus servicios suscritos. El orden determina la prioridad para Ver ahora.</string>
+
     <!-- Scrobble overlay -->
     <string name="tv_scrobble_question">¿Estás viendo %1$s?</string>
     <string name="tv_scrobble_episode">S%1$02dE%2$02d</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -39,6 +39,11 @@
     <string name="tv_recap_close">Fermer</string>
     <string name="tv_recap_watch_now">Regarder maintenant</string>
 
+    <!-- Streaming settings -->
+    <string name="tv_streaming_settings_button">Services</string>
+    <string name="tv_streaming_settings_title">Services de streaming</string>
+    <string name="tv_streaming_settings_subtitle">Sélectionnez vos services abonnés. L\'ordre détermine la priorité pour Regarder maintenant.</string>
+
     <!-- Scrobble overlay -->
     <string name="tv_scrobble_question">Regardez-vous %1$s ?</string>
     <string name="tv_scrobble_episode">S%1$02dE%2$02d</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -39,6 +39,11 @@
     <string name="tv_recap_close">Close</string>
     <string name="tv_recap_watch_now">Watch now</string>
 
+    <!-- Streaming settings -->
+    <string name="tv_streaming_settings_button">Services</string>
+    <string name="tv_streaming_settings_title">Streaming Services</string>
+    <string name="tv_streaming_settings_subtitle">Select your subscribed services. Order determines priority for Watch Now.</string>
+
     <!-- Scrobble overlay -->
     <string name="tv_scrobble_question">Are you watching %1$s?</string>
     <string name="tv_scrobble_episode">S%1$02dE%2$02d</string>


### PR DESCRIPTION
## Summary

Implements Issue #19: User-configurable streaming service preferences for the TV app.

- **StreamingPreferencesRepository** — DataStore-backed persistence for subscribed service IDs with priority ordering
- **StreamingSettingsScreen** — D-Pad navigable settings screen (accessible via "Services" button on home screen) where users select their subscribed streaming services and reorder priority
- **ShowDetailViewModel** — filters displayed services by user preferences with fallback to all known services when no preference is set
- **resolveDeepLink()** — now picks the highest-priority subscribed service's deep link template instead of always defaulting to Netflix
- Localized strings for EN, DE, FR, ES

### Changes by file

| File | Change |
|------|--------|
| `StreamingPreferencesRepository.kt` | **New** — DataStore persistence for ordered service subscriptions |
| `StreamingSettingsViewModel.kt` | **New** — ViewModel with toggle/reorder logic |
| `StreamingSettingsScreen.kt` | **New** — TV-optimized settings UI with D-Pad navigation |
| `ShowDetailViewModel.kt` | **New** — Injects preferences, exposes filtered service list |
| `ShowDetailScreen.kt` | **Modified** — Uses ViewModel for services + deep links |
| `TvNavGraph.kt` | **Modified** — Added `StreamingSettings` route |
| `TvHomeScreen.kt` | **Modified** — Added "Services" button in header |
| `strings.xml` (en/de/fr/es) | **Modified** — Added streaming settings strings |

Closes #19

## Test plan

- [ ] Open TV app → verify "Services" button appears in home header
- [ ] Navigate to Services screen → verify all 7 known services listed
- [ ] Select/deselect services → verify checkboxes toggle and persist across app restart
- [ ] Reorder subscribed services with up/down arrows → verify priority numbers update
- [ ] Navigate to ShowDetailScreen → verify only subscribed services shown (or all if none selected)
- [ ] Press "Watch Now" → verify deep link opens highest-priority service (not always Netflix)
- [ ] Verify German, French, Spanish localizations display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)