### PR TITLE
feat(phone): navigate to Onboarding on Trakt disconnect

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
@@ -42,7 +42,12 @@ fun PhoneNavGraph(
 
         composable(PhoneRoute.Settings.route) {
             SettingsScreen(
-                onBack = { navController.popBackStack() }
+                onBack = { navController.popBackStack() },
+                onDisconnected = {
+                    navController.navigate(PhoneRoute.Onboarding.route) {
+                        popUpTo(navController.graph.id) { inclusive = true }
+                    }
+                }
             )
         }
     }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -20,6 +20,7 @@ import com.justb81.watchbuddy.R
 @Composable
 fun SettingsScreen(
     onBack: () -> Unit,
+    onDisconnected: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -212,6 +213,7 @@ fun SettingsScreen(
                 TextButton(onClick = {
                     viewModel.disconnectTrakt()
                     showDisconnectDialog = false
+                    onDisconnected()
                 }) {
                     Text(stringResource(R.string.settings_disconnect), color = MaterialTheme.colorScheme.error)
                 }


### PR DESCRIPTION
## Summary

- Adds `onDisconnected` callback to `SettingsScreen` that triggers after the user confirms disconnecting their Trakt account
- Wires the callback in `PhoneNavGraph` to navigate to `Onboarding` with the entire backstack cleared (`popUpTo(graph.id, inclusive = true)`)
- Complements the startup navigation logic already merged in PR #24, which routes directly to Home when a valid token exists

**Note:** The startup-navigation part of Issue #10 (skip Onboarding when token is valid) was already implemented by PR #24. This PR adds the remaining piece: navigating back to Onboarding on logout/disconnect.

## Changes

| File | Change |
|------|--------|
| `SettingsScreen.kt` | Added `onDisconnected` parameter; called after `disconnectTrakt()` in the confirmation dialog |
| `PhoneNavGraph.kt` | Passes `onDisconnected` lambda that navigates to `PhoneRoute.Onboarding` and clears the backstack |

## Test plan

- [ ] Launch app with a valid Trakt token → should start on Home screen (PR #24)
- [ ] Launch app without a token → should start on Onboarding screen (PR #24)
- [ ] Navigate to Settings → Disconnect Trakt → confirm → should navigate to Onboarding
- [ ] After disconnect, pressing back should NOT return to Home or Settings (backstack cleared)
- [ ] Re-authenticate via Onboarding → should navigate to Home

Closes #10

---
🤖 *Generated by Computer*