### PR TITLE
feat(phone): load username from Trakt profile in DeviceCapabilityProvider

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
@@ -4,7 +4,9 @@ import android.app.ActivityManager
 import android.content.Context
 import android.os.Build
 import com.justb81.watchbuddy.core.model.DeviceCapability
-import com.justb81.watchbuddy.core.model.LlmBackend
+import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.core.trakt.TraktUserProfile
+import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -13,23 +15,44 @@ import javax.inject.Singleton
 @Singleton
 class DeviceCapabilityProvider @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val llmOrchestrator: LlmOrchestrator
+    private val llmOrchestrator: LlmOrchestrator,
+    private val traktApiService: TraktApiService,
+    private val tokenRepository: TokenRepository
 ) {
-    fun getCapability(): DeviceCapability {
+    private var cachedProfile: TraktUserProfile? = null
+
+    private suspend fun getCachedProfile(): TraktUserProfile? {
+        cachedProfile?.let { return it }
+        val token = tokenRepository.getAccessToken() ?: return null
+        return try {
+            traktApiService.getProfile("Bearer $token").also { cachedProfile = it }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    suspend fun getCapability(): DeviceCapability {
         val config = llmOrchestrator.selectConfig()
         val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
         val memInfo = ActivityManager.MemoryInfo()
         activityManager.getMemoryInfo(memInfo)
         val freeRamMb = (memInfo.availMem / 1_048_576).toInt()
 
+        val profile = getCachedProfile()
+
         return DeviceCapability(
             deviceId = Build.ID,
-            userName = "user",          // TODO: pull from user preferences / Trakt profile
+            userName = profile?.username ?: "user",
+            userAvatarUrl = profile?.images?.avatar?.full,
             deviceName = Build.MODEL,
             llmBackend = config.backend,
             modelQuality = config.qualityScore,
             freeRamMb = freeRamMb,
             isAvailable = true
         )
+    }
+
+    fun invalidateCache() {
+        cachedProfile = null
     }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -14,6 +14,7 @@ import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
 import com.justb81.watchbuddy.phone.llm.ModelDownloadWorker
+import com.justb81.watchbuddy.phone.server.DeviceCapabilityProvider
 import com.justb81.watchbuddy.phone.settings.AppSettings
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -47,6 +48,7 @@ class SettingsViewModel @Inject constructor(
     application: Application,
     private val llmOrchestrator: LlmOrchestrator,
     private val tokenRepository: TokenRepository,
+    private val deviceCapabilityProvider: DeviceCapabilityProvider,
     private val settingsRepository: SettingsRepository
 ) : AndroidViewModel(application) {
 
@@ -145,6 +147,7 @@ class SettingsViewModel @Inject constructor(
 
     fun disconnectTrakt() {
         tokenRepository.clearTokens()
+        deviceCapabilityProvider.invalidateCache()
         _uiState.value = _uiState.value.copy(traktUsername = null)
     }
 

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -76,6 +76,7 @@ data class TmdbEpisode(
 data class DeviceCapability(
     val deviceId: String,
     val userName: String,
+    val userAvatarUrl: String? = null,
     val deviceName: String,
     val llmBackend: LlmBackend,         // AICORE, MEDIAPIPE_GPU, MEDIAPIPE_CPU, NONE
     val modelQuality: Int,              // 0–150 (see scoring docs)

--- a/core/src/main/java/com/justb81/watchbuddy/core/trakt/TraktApiService.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/trakt/TraktApiService.kt
@@ -101,7 +101,16 @@ interface TraktApiService {
 @Serializable data class TraktUserProfile(
     val username: String,
     val name: String? = null,
-    val vip: Boolean = false
+    val vip: Boolean = false,
+    val images: TraktUserImages? = null
+)
+
+@Serializable data class TraktUserImages(
+    val avatar: TraktAvatar? = null
+)
+
+@Serializable data class TraktAvatar(
+    val full: String? = null
 )
 
 @Serializable data class ScrobbleBody(


### PR DESCRIPTION
## Summary

- Replace the hardcoded `"user"` string in `DeviceCapabilityProvider.getCapability()` with the actual Trakt username from the `users/me` API endpoint
- Cache the `TraktUserProfile` after first fetch; subsequent calls return the cached profile without a network request
- Add `userAvatarUrl` field to `DeviceCapability` model, populated from `profile.images.avatar.full`
- Extend `TraktUserProfile` with `images` → `avatar` → `full` fields for avatar URL support
- Invalidate the cached profile on Trakt disconnect via `SettingsViewModel.disconnectTrakt()`

## Changed Files

| File | Change |
|------|--------|
| `core/.../model/Models.kt` | Add `userAvatarUrl: String? = null` to `DeviceCapability` |
| `core/.../trakt/TraktApiService.kt` | Add `images` field to `TraktUserProfile`, add `TraktUserImages` and `TraktAvatar` data classes |
| `app-phone/.../server/DeviceCapabilityProvider.kt` | Inject `TraktApiService` + `TokenRepository`, add cached profile loading, make `getCapability()` suspend, add `invalidateCache()` |
| `app-phone/.../ui/settings/SettingsViewModel.kt` | Inject `DeviceCapabilityProvider`, call `invalidateCache()` in `disconnectTrakt()` |

## Test plan

- [ ] Verify `GET /capability` returns the Trakt username when authenticated
- [ ] Verify `GET /capability` falls back to `"user"` when no token is stored
- [ ] Verify profile is fetched only once (cached on subsequent calls)
- [ ] Verify disconnecting Trakt in Settings clears the cached profile
- [ ] Verify `userAvatarUrl` is populated when the Trakt profile has an avatar
- [ ] Verify the TV app still correctly deserializes the `DeviceCapability` JSON (backward compatible due to default `null`)

Closes #21

---
🤖 *Generated by Computer*