### PR TITLE
feat(phone): implement /shows, /recap and /auth/token endpoints

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -1,15 +1,19 @@
 package com.justb81.watchbuddy.phone.server
 
-import com.justb81.watchbuddy.core.model.DeviceCapability
-import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
+import android.util.Log
+import com.justb81.watchbuddy.core.tmdb.TmdbApiService
+import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.llm.RecapGenerator
+import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
 import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -22,15 +26,19 @@ import javax.inject.Singleton
  *   GET  /capability           → DeviceCapability (device score, RAM, LLM backend)
  *   GET  /shows                → List of watched shows for this user (from Trakt cache)
  *   POST /recap/{traktShowId}  → Generate + return HTML recap for a show
+ *   GET  /auth/token           → Current access token for TV app usage
  */
 @Singleton
 class CompanionHttpServer @Inject constructor(
-    private val llmOrchestrator: LlmOrchestrator,
     private val recapGenerator: RecapGenerator,
-    private val capabilityProvider: DeviceCapabilityProvider
+    private val capabilityProvider: DeviceCapabilityProvider,
+    private val showRepository: ShowRepository,
+    private val tokenRepository: TokenRepository,
+    private val tmdbApiService: TmdbApiService
 ) {
     companion object {
         const val PORT = 8765
+        private const val TAG = "CompanionHttpServer"
     }
 
     private var server: ApplicationEngine? = null
@@ -46,15 +54,78 @@ class CompanionHttpServer @Inject constructor(
                 }
 
                 get("/shows") {
-                    // TODO: return cached Trakt watched shows for this user
-                    call.respond(emptyList<String>())
+                    tokenRepository.getAccessToken()
+                        ?: return@get call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
+                    try {
+                        val shows = showRepository.getShows()
+                        call.respond(shows)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Failed to fetch shows", e)
+                        call.respond(HttpStatusCode.InternalServerError, ErrorResponse(e.message ?: "Unknown error"))
+                    }
                 }
 
                 post("/recap/{traktShowId}") {
                     val showId = call.parameters["traktShowId"]?.toIntOrNull()
-                        ?: return@post call.respond(io.ktor.http.HttpStatusCode.BadRequest)
-                    // TODO: fetch show + watched episodes, call recapGenerator.generateRecap()
-                    call.respond(mapOf("html" to "<div>Recap für Show $showId wird generiert…</div>"))
+                        ?: return@post call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid show ID"))
+
+                    tokenRepository.getAccessToken()
+                        ?: return@post call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
+
+                    try {
+                        val body = try { call.receive<RecapRequest>() } catch (_: Exception) { RecapRequest() }
+
+                        val shows = showRepository.getShows()
+                        val watchedEntry = shows.find { it.show.ids.trakt == showId }
+                            ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("Show not found"))
+
+                        val tmdbId = watchedEntry.show.ids.tmdb
+                            ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("No TMDB ID for show"))
+
+                        val tmdbShow = tmdbApiService.getShow(tmdbId, body.tmdbApiKey)
+
+                        // Collect watched episode numbers from Trakt data
+                        val watchedEpisodeRefs = watchedEntry.seasons.flatMap { season ->
+                            season.episodes.map { ep -> season.number to ep.number }
+                        }
+
+                        // Load episode details from TMDB for the last 8 watched episodes
+                        val tmdbEpisodes = watchedEpisodeRefs
+                            .takeLast(8)
+                            .mapNotNull { (season, episode) ->
+                                try {
+                                    tmdbApiService.getEpisode(tmdbId, season, episode, body.tmdbApiKey)
+                                } catch (e: Exception) {
+                                    Log.w(TAG, "Failed to load TMDB episode S${season}E${episode}", e)
+                                    null
+                                }
+                            }
+
+                        if (tmdbEpisodes.isEmpty()) {
+                            return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("No episode data available"))
+                        }
+
+                        // Use last episode as the "target" (next to watch)
+                        val targetEpisode = tmdbEpisodes.last()
+                        val watchedEpisodes = tmdbEpisodes.dropLast(1).ifEmpty { tmdbEpisodes }
+
+                        val html = recapGenerator.generateRecap(
+                            show = tmdbShow,
+                            watchedEpisodes = watchedEpisodes,
+                            targetEpisode = targetEpisode,
+                            apiKey = body.tmdbApiKey
+                        )
+                        call.respond(mapOf("html" to html))
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Recap generation failed for show $showId", e)
+                        call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Recap generation failed: ${e.message}"))
+                    }
+                }
+
+                get("/auth/token") {
+                    val token = tokenRepository.getAccessToken()
+                        ?: return@get call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
+                    call.respond(TokenResponse(accessToken = token))
                 }
             }
         }.start(wait = false)
@@ -65,3 +136,18 @@ class CompanionHttpServer @Inject constructor(
         server = null
     }
 }
+
+@Serializable
+private data class RecapRequest(
+    val tmdbApiKey: String = ""
+)
+
+@Serializable
+private data class TokenResponse(
+    val accessToken: String
+)
+
+@Serializable
+private data class ErrorResponse(
+    val error: String
+)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
@@ -1,0 +1,31 @@
+package com.justb81.watchbuddy.phone.server
+
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.phone.auth.TokenRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ShowRepository @Inject constructor(
+    private val traktApi: TraktApiService,
+    private val tokenRepository: TokenRepository
+) {
+    private var cachedShows: List<TraktWatchedEntry> = emptyList()
+    private var lastFetch: Long = 0L
+
+    suspend fun getShows(): List<TraktWatchedEntry> {
+        val now = System.currentTimeMillis()
+        if (now - lastFetch > CACHE_TTL || cachedShows.isEmpty()) {
+            val token = tokenRepository.getAccessToken()
+                ?: return emptyList()
+            cachedShows = traktApi.getWatchedShows("Bearer $token")
+            lastFetch = now
+        }
+        return cachedShows
+    }
+
+    private companion object {
+        const val CACHE_TTL = 5 * 60 * 1000L // 5 minutes
+    }
+}


### PR DESCRIPTION
## Summary

- **GET /shows**: Returns cached Trakt watched shows (5-min TTL via new `ShowRepository`). Returns 401 if no access token, 500 on API errors.
- **POST /recap/{traktShowId}**: Loads show from Trakt cache, fetches TMDB episode details for last 8 watched episodes, generates HTML recap via `RecapGenerator` with LLM cascade fallback. Returns 404 if show not found, 503 if generation fails.
- **GET /auth/token**: Returns current access token as `{"accessToken": "..."}` for TV app usage. Returns 401 if no token stored.
- **ShowRepository**: New `@Singleton` cache layer between `TraktApiService` and HTTP server with 5-minute cache TTL to avoid overloading the Trakt API.

Closes #8

## Test plan

- [ ] Verify `/shows` returns real Trakt watched shows when token is available
- [ ] Verify `/shows` returns 401 when no token is stored
- [ ] Verify `/recap/{id}` generates HTML recap for a valid show ID
- [ ] Verify `/recap/{id}` returns 404 for unknown show IDs
- [ ] Verify `/recap/{id}` returns 503 when LLM generation fails
- [ ] Verify `/auth/token` returns access token JSON
- [ ] Verify `/auth/token` returns 401 when no token stored
- [ ] Verify show cache expires after 5 minutes and re-fetches
- [ ] Verify TV app can successfully consume all endpoints

---
🤖 *Generated by Computer*