### PR TITLE
feat(phone): implement CompanionService as Android Foreground Service

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/WatchBuddyPhoneApp.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/WatchBuddyPhoneApp.kt
@@ -1,8 +1,11 @@
 package com.justb81.watchbuddy
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import com.justb81.watchbuddy.service.CompanionService
 import dagger.hilt.android.HiltAndroidApp
 import javax.inject.Inject
 
@@ -16,4 +19,23 @@ class WatchBuddyPhoneApp : Application(), Configuration.Provider {
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
             .build()
+
+    override fun onCreate() {
+        super.onCreate()
+        createNotificationChannels()
+    }
+
+    private fun createNotificationChannels() {
+        val manager = getSystemService(NotificationManager::class.java)
+        if (manager.getNotificationChannel(CompanionService.CHANNEL_ID) == null) {
+            val channel = NotificationChannel(
+                CompanionService.CHANNEL_ID,
+                getString(R.string.companion_channel_name),
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = getString(R.string.companion_channel_description)
+            }
+            manager.createNotificationChannel(channel)
+        }
+    }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
@@ -7,6 +7,9 @@ import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import com.justb81.watchbuddy.service.CompanionService
+import kotlinx.coroutines.flow.first
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -26,13 +29,26 @@ data class HomeUiState(
 class HomeViewModel @Inject constructor(
     application: Application,
     private val traktApi: TraktApiService,
-    private val tokenRepository: TokenRepository
+    private val tokenRepository: TokenRepository,
+    private val settingsRepository: SettingsRepository
 ) : AndroidViewModel(application) {
 
     private val _uiState = MutableStateFlow(HomeUiState(isLoading = true))
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
-    init { loadShows() }
+    init {
+        loadShows()
+        startCompanionIfEnabled()
+    }
+
+    private fun startCompanionIfEnabled() {
+        viewModelScope.launch {
+            val settings = settingsRepository.settings.first()
+            if (settings.companionEnabled) {
+                CompanionService.start(getApplication<Application>())
+            }
+        }
+    }
 
     fun loadShows() {
         viewModelScope.launch {

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import androidx.work.WorkManager
 import androidx.work.workDataOf
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.service.CompanionService
 import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
 import com.justb81.watchbuddy.phone.llm.ModelDownloadWorker
 import com.justb81.watchbuddy.phone.server.DeviceCapabilityProvider
@@ -142,7 +143,12 @@ class SettingsViewModel @Inject constructor(
             val current = settingsRepository.settings.first()
             settingsRepository.saveSettings(current.copy(companionEnabled = newState))
         }
-        // TODO: start/stop CompanionService
+        val context = getApplication<Application>()
+        if (newState) {
+            CompanionService.start(context)
+        } else {
+            CompanionService.stop(context)
+        }
     }
 
     fun disconnectTrakt() {

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
@@ -1,0 +1,110 @@
+package com.justb81.watchbuddy.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.net.nsd.NsdManager
+import android.net.nsd.NsdServiceInfo
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.phone.server.CompanionHttpServer
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class CompanionService : Service() {
+
+    companion object {
+        const val CHANNEL_ID = "companion_service"
+        private const val NOTIFICATION_ID = 1
+        private const val NSD_SERVICE_TYPE = "_http._tcp."
+        private const val NSD_SERVICE_NAME = "watchbuddy-companion"
+
+        fun start(context: Context) {
+            val intent = Intent(context, CompanionService::class.java)
+            context.startForegroundService(intent)
+        }
+
+        fun stop(context: Context) {
+            context.stopService(Intent(context, CompanionService::class.java))
+        }
+    }
+
+    @Inject lateinit var companionHttpServer: CompanionHttpServer
+
+    private var nsdManager: NsdManager? = null
+    private var nsdRegistrationListener: NsdManager.RegistrationListener? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        ensureNotificationChannel()
+        startForeground(NOTIFICATION_ID, buildNotification())
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        companionHttpServer.start()
+        registerNsd()
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        unregisterNsd()
+        companionHttpServer.stop()
+        super.onDestroy()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun ensureNotificationChannel() {
+        val manager = getSystemService(NotificationManager::class.java)
+        if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.companion_channel_name),
+                NotificationManager.IMPORTANCE_LOW
+            )
+            channel.description = getString(R.string.companion_channel_description)
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun buildNotification(): Notification =
+        NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle(getString(R.string.companion_notification_title))
+            .setContentText(getString(R.string.companion_notification_text))
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setOngoing(true)
+            .build()
+
+    private fun registerNsd() {
+        val serviceInfo = NsdServiceInfo().apply {
+            serviceName = NSD_SERVICE_NAME
+            serviceType = NSD_SERVICE_TYPE
+            port = CompanionHttpServer.PORT
+        }
+
+        val listener = object : NsdManager.RegistrationListener {
+            override fun onServiceRegistered(info: NsdServiceInfo) {}
+            override fun onRegistrationFailed(info: NsdServiceInfo, errorCode: Int) {}
+            override fun onServiceUnregistered(info: NsdServiceInfo) {}
+            override fun onUnregistrationFailed(info: NsdServiceInfo, errorCode: Int) {}
+        }
+
+        nsdRegistrationListener = listener
+        nsdManager = (getSystemService(Context.NSD_SERVICE) as NsdManager).also {
+            it.registerService(serviceInfo, NsdManager.PROTOCOL_DNS_SD, listener)
+        }
+    }
+
+    private fun unregisterNsd() {
+        nsdRegistrationListener?.let { listener ->
+            nsdManager?.unregisterService(listener)
+        }
+        nsdRegistrationListener = null
+        nsdManager = null
+    }
+}

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -67,6 +67,12 @@
     <string name="settings_not_connected">Not connected</string>
     <string name="settings_llm_detecting">Detecting…</string>
 
+    <!-- Companion Service -->
+    <string name="companion_channel_name">Companion Service</string>
+    <string name="companion_channel_description">Shows when the companion server is active for TV connections</string>
+    <string name="companion_notification_title">WatchBuddy Companion</string>
+    <string name="companion_notification_text">Bereit für TV-Verbindung</string>
+
     <!-- Common -->
     <string name="no_description">No description available.</string>
     <string name="loading">Loading…</string>


### PR DESCRIPTION
## Summary

Implements #12 — CompanionService as a proper Android Foreground Service that manages the CompanionHttpServer lifecycle.

- **CompanionService.kt**: New `@AndroidEntryPoint` service with `startForeground()` notification (channel `companion_service`, low importance), NSD/mDNS registration (`watchbuddy-companion._http._tcp.`), and `CompanionHttpServer.start()/stop()` bound to service lifecycle
- **WatchBuddyPhoneApp**: Registers the `companion_service` NotificationChannel in `Application.onCreate()` for early availability
- **SettingsViewModel**: `toggleCompanionService()` now calls `CompanionService.start()/stop()` via static helpers using `startForegroundService`/`stopService`
- **HomeViewModel**: Auto-starts the service on app launch when `companionEnabled == true` (read from DataStore via SettingsRepository)
- **strings.xml**: Added notification channel name/description and foreground notification title/text

### Manifest (already declared, no changes needed)
- `<service android:name=".service.CompanionService" android:foregroundServiceType="dataSync" />`
- Permissions: `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`, `POST_NOTIFICATIONS`

Closes #12

## Test plan

- [ ] Toggle companion service ON in Settings → verify foreground notification appears ("WatchBuddy Companion — Bereit für TV-Verbindung")
- [ ] Toggle companion service OFF → verify notification disappears and HTTP server stops (port 8765 unreachable)
- [ ] Kill and relaunch app with companion enabled → verify service auto-starts from HomeViewModel
- [ ] Verify NSD service is discoverable from TV app on same network
- [ ] Test on API 34+ device to confirm FOREGROUND_SERVICE_DATA_SYNC permission works
- [ ] Test on API 26 (minSdk) to confirm backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)