### PR TITLE
feat(tv): load shows from Phone companion via HTTP API

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiClientFactory.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiClientFactory.kt
@@ -1,0 +1,32 @@
+package com.justb81.watchbuddy.tv.discovery
+
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class PhoneApiClientFactory @Inject constructor(
+    private val httpClient: OkHttpClient
+) {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        coerceInputValues = true
+    }
+
+    private val cache = mutableMapOf<String, PhoneApiService>()
+
+    fun createClient(baseUrl: String): PhoneApiService =
+        cache.getOrPut(baseUrl) {
+            Retrofit.Builder()
+                .baseUrl(baseUrl)
+                .client(httpClient)
+                .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+                .build()
+                .create(PhoneApiService::class.java)
+        }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiService.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiService.kt
@@ -1,0 +1,25 @@
+package com.justb81.watchbuddy.tv.discovery
+
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import kotlinx.serialization.Serializable
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface PhoneApiService {
+
+    @GET("/shows")
+    suspend fun getShows(): List<TraktWatchedEntry>
+
+    @POST("/recap/{traktShowId}")
+    suspend fun getRecap(@Path("traktShowId") showId: Int): RecapResponse
+
+    @GET("/auth/token")
+    suspend fun getAccessToken(): TokenResponse
+}
+
+@Serializable
+data class TokenResponse(val accessToken: String)
+
+@Serializable
+data class RecapResponse(val html: String)

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -39,7 +39,8 @@ class PhoneDiscoveryManager @Inject constructor(
     data class DiscoveredPhone(
         val serviceInfo: NsdServiceInfo,
         val capability: DeviceCapability?,
-        val score: Int
+        val score: Int,
+        val baseUrl: String
     )
 
     private val discoveryListener = object : NsdManager.DiscoveryListener {
@@ -85,7 +86,8 @@ class PhoneDiscoveryManager @Inject constructor(
                 Json.decodeFromString<DeviceCapability>(it)
             }
             val score = calculateScore(capability)
-            val phone = DiscoveredPhone(serviceInfo, capability, score)
+            val baseUrl = "http://${serviceInfo.host.hostAddress}:${serviceInfo.port}/"
+            val phone = DiscoveredPhone(serviceInfo, capability, score, baseUrl)
             _discoveredPhones.value = (_discoveredPhones.value
                 .filter { it.serviceInfo.serviceName != serviceInfo.serviceName } + phone)
                 .sortedByDescending { it.score }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -97,6 +97,10 @@ fun TvHomeScreen(
                     }
                 }
 
+                uiState.noPhoneConnected && uiState.shows.isEmpty() -> {
+                    NoPhoneConnectedState(onRetry = { viewModel.loadShows() })
+                }
+
                 uiState.shows.isEmpty() -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Text(
@@ -123,6 +127,27 @@ fun TvHomeScreen(
                         }
                     }
                 }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun NoPhoneConnectedState(onRetry: () -> Unit) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text     = stringResource(R.string.tv_no_phone),
+                fontSize = 18.sp,
+                color    = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                modifier = Modifier.padding(bottom = 24.dp)
+            )
+            Button(
+                onClick = onRetry,
+                scale   = ButtonDefaults.scale(scale = 1f)
+            ) {
+                Text(stringResource(R.string.tv_retry))
             }
         }
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -3,7 +3,7 @@ package com.justb81.watchbuddy.tv.ui.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
-import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
@@ -16,17 +16,21 @@ data class TvHomeUiState(
     val connectedPhones: Int = 0,
     val bestPhoneName: String? = null,
     val bestPhoneBackend: String? = null,
+    val noPhoneConnected: Boolean = false,
     val error: String? = null
 )
 
 @HiltViewModel
 class TvHomeViewModel @Inject constructor(
-    private val traktApi: TraktApiService,
-    private val phoneDiscovery: PhoneDiscoveryManager
+    private val phoneDiscovery: PhoneDiscoveryManager,
+    private val phoneApiClientFactory: PhoneApiClientFactory
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TvHomeUiState())
     val uiState: StateFlow<TvHomeUiState> = _uiState.asStateFlow()
+
+    private var cachedShows: List<TraktWatchedEntry>? = null
+    private var cacheTimestamp: Long = 0L
 
     init {
         phoneDiscovery.startDiscovery()
@@ -49,24 +53,42 @@ class TvHomeViewModel @Inject constructor(
         }
     }
 
-    private fun loadShows() {
+    fun loadShows() {
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, error = null) }
+            _uiState.update { it.copy(isLoading = true, error = null, noPhoneConnected = false) }
             try {
-                // TV fetches shows from the best connected phone's /shows endpoint
                 val bestPhone = phoneDiscovery.getBestPhone()
-                val shows: List<TraktWatchedEntry> = if (bestPhone != null) {
-                    // TODO: fetch via phone HTTP API
-                    emptyList()
+                if (bestPhone != null) {
+                    val api = phoneApiClientFactory.createClient(bestPhone.baseUrl)
+                    val shows = api.getShows()
+                    cachedShows = shows
+                    cacheTimestamp = System.currentTimeMillis()
+                    _uiState.update { it.copy(isLoading = false, shows = shows) }
                 } else {
-                    // Fallback: direct Trakt API (needs token on TV — not ideal)
-                    emptyList()
+                    // No phone — try cache fallback
+                    val cached = getCachedShows()
+                    if (cached != null) {
+                        _uiState.update { it.copy(isLoading = false, shows = cached, noPhoneConnected = true) }
+                    } else {
+                        _uiState.update { it.copy(isLoading = false, noPhoneConnected = true) }
+                    }
                 }
-                _uiState.update { it.copy(isLoading = false, shows = shows) }
             } catch (e: Exception) {
-                _uiState.update { it.copy(isLoading = false, error = e.message) }
+                // Network error — try cache fallback
+                val cached = getCachedShows()
+                if (cached != null) {
+                    _uiState.update { it.copy(isLoading = false, shows = cached, error = e.message) }
+                } else {
+                    _uiState.update { it.copy(isLoading = false, error = e.message, noPhoneConnected = true) }
+                }
             }
         }
+    }
+
+    private fun getCachedShows(): List<TraktWatchedEntry>? {
+        val ttl = 5 * 60 * 1000L // 5 minutes
+        val cached = cachedShows
+        return if (cached != null && System.currentTimeMillis() - cacheTimestamp < ttl) cached else null
     }
 
     override fun onCleared() {

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -8,6 +8,7 @@
     <string name="tv_all_shows">Alle Serien</string>
     <string name="tv_no_shows">Keine Serien gefunden.\nVerbinde die WatchBuddy-App auf deinem Handy mit Trakt.</string>
     <string name="tv_no_phone">Kein Handy verbunden.\nStarte die WatchBuddy-App auf deinem Smartphone.</string>
+    <string name="tv_retry">Erneut versuchen</string>
     <string name="tv_devices_count">%1$d Gerät(e)</string>
 
     <!-- User select -->

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -8,6 +8,7 @@
     <string name="tv_all_shows">Todas las series</string>
     <string name="tv_no_shows">No se encontraron series.\nConecta la aplicación WatchBuddy en tu teléfono con Trakt.</string>
     <string name="tv_no_phone">Ningún teléfono conectado.\nInicia la aplicación WatchBuddy en tu smartphone.</string>
+    <string name="tv_retry">Reintentar</string>
     <string name="tv_devices_count">%1$d dispositivo(s)</string>
 
     <!-- User select -->

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -8,6 +8,7 @@
     <string name="tv_all_shows">Toutes les séries</string>
     <string name="tv_no_shows">Aucune série trouvée.\nConnectez l\'application WatchBuddy sur votre téléphone avec Trakt.</string>
     <string name="tv_no_phone">Aucun téléphone connecté.\nDémarrez l\'application WatchBuddy sur votre smartphone.</string>
+    <string name="tv_retry">Réessayer</string>
     <string name="tv_devices_count">%1$d appareil(s)</string>
 
     <!-- User select -->

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="tv_all_shows">All Shows</string>
     <string name="tv_no_shows">No shows found.\nConnect the WatchBuddy app on your phone with Trakt.</string>
     <string name="tv_no_phone">No phone connected.\nStart the WatchBuddy app on your smartphone.</string>
+    <string name="tv_retry">Retry</string>
     <string name="tv_devices_count">%1$d device(s)</string>
 
     <!-- User select -->


### PR DESCRIPTION
## Summary

- **PhoneApiService**: New Retrofit interface for the phone's HTTP API (`/shows`, `/recap/{id}`, `/auth/token`)
- **PhoneApiClientFactory**: `@Singleton` factory that creates Retrofit clients with dynamic base URLs from NSD discovery
- **PhoneDiscoveryManager**: Added `baseUrl` field to `DiscoveredPhone` data class (computed from NSD host/port)
- **TvHomeViewModel.loadShows()**: Fetches shows from best phone via `PhoneApiService`, with in-memory cache (5-min TTL) for offline fallback
- **TvHomeScreen**: New `noPhoneConnected` UI state with "No phone connected" message and retry button
- **Strings**: Added `tv_retry` in all 4 locales (EN, DE, FR, ES)

Closes #14

## Test plan

- [ ] Launch TV app with no phone on the network — verify "Kein Handy verbunden" state with retry button
- [ ] Launch phone app, then TV app — verify shows load from phone's `/shows` endpoint
- [ ] Disconnect phone after shows loaded — verify cached shows still display for 5 minutes
- [ ] After cache expires with no phone — verify `noPhoneConnected` state reappears
- [ ] Tap retry button — verify it triggers a new `loadShows()` attempt
- [ ] Verify all 4 locales render the retry button text correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)