### PR TITLE
feat(tv): implement real fuzzy matching in MediaSessionScrobbler

### DIFF
--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -96,4 +96,7 @@ dependencies {
 
     // WorkManager (background Trakt sync)
     implementation(libs.work.runtime)
+
+    // Testing
+    testImplementation("junit:junit:4.13.2")
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/FuzzyMatcher.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/FuzzyMatcher.kt
@@ -1,0 +1,80 @@
+package com.justb81.watchbuddy.tv.scrobbler
+
+/**
+ * String-matching utilities for fuzzy title comparison.
+ * Pure Kotlin — no external dependencies.
+ */
+object FuzzyMatcher {
+
+    /**
+     * Normalize a title for comparison:
+     * - lowercase
+     * - remove special characters (keep alphanumeric and spaces)
+     * - strip leading "the "
+     * - collapse whitespace and trim
+     */
+    fun normalize(title: String): String {
+        return title
+            .lowercase()
+            .replace(Regex("[^a-z0-9\\s]"), "")
+            .replace(Regex("\\s+"), " ")
+            .trim()
+            .removePrefix("the ")
+            .trim()
+    }
+
+    /**
+     * Classic Levenshtein edit distance between two strings.
+     * Uses O(min(m,n)) space via single-row DP.
+     */
+    fun levenshteinDistance(a: String, b: String): Int {
+        if (a == b) return 0
+        if (a.isEmpty()) return b.length
+        if (b.isEmpty()) return a.length
+
+        // Ensure a is the shorter string for space efficiency
+        val (short, long) = if (a.length <= b.length) a to b else b to a
+
+        var prev = IntArray(short.length + 1) { it }
+        var curr = IntArray(short.length + 1)
+
+        for (i in 1..long.length) {
+            curr[0] = i
+            for (j in 1..short.length) {
+                val cost = if (long[i - 1] == short[j - 1]) 0 else 1
+                curr[j] = minOf(
+                    curr[j - 1] + 1,       // insertion
+                    prev[j] + 1,            // deletion
+                    prev[j - 1] + cost      // substitution
+                )
+            }
+            val tmp = prev
+            prev = curr
+            curr = tmp
+        }
+        return prev[short.length]
+    }
+
+    /**
+     * Compute a similarity score between two strings.
+     *
+     * @return Float in [0.0, 1.0] where 1.0 = exact match
+     */
+    fun fuzzyScore(a: String, b: String): Float {
+        val na = normalize(a)
+        val nb = normalize(b)
+
+        if (na.isEmpty() || nb.isEmpty()) return 0.0f
+
+        // Exact match after normalization
+        if (na == nb) return 1.0f
+
+        // Prefix match (one starts with the other)
+        if (na.startsWith(nb) || nb.startsWith(na)) return 0.95f
+
+        // Levenshtein-based score
+        val distance = levenshteinDistance(na, nb)
+        val maxLen = maxOf(na.length, nb.length)
+        return (1.0f - distance.toFloat() / maxLen).coerceAtLeast(0.0f)
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
@@ -21,17 +21,21 @@ import javax.inject.Singleton
  * How it works:
  *   1. MediaSessionManager.getActiveSessions() returns all active sessions
  *   2. Extract package name + media title from session metadata
- *   3. Fuzzy-match title against user's Trakt watchlist
- *   4. Confidence ≥ 0.9 → auto-scrobble; < 0.9 → emit ScrobbleCandidate for UI confirmation
+ *   3. Fuzzy-match title against user's Trakt watchlist (local cache first, then API)
+ *   4. Confidence ≥ 0.95 → auto-scrobble; 0.70–0.95 → emit for UI confirmation; < 0.70 → ignore
  *   5. On playback stop/pause → call Trakt scrobble/stop
  */
 @Singleton
 class MediaSessionScrobbler @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val traktApi: TraktApiService
+    private val traktApi: TraktApiService,
+    private val showCacheProvider: ShowCacheProvider
 ) {
     companion object {
-        const val AUTO_SCROBBLE_THRESHOLD = 0.90f
+        const val AUTO_SCROBBLE_THRESHOLD = 0.95f
+        const val OVERLAY_THRESHOLD = 0.70f
+        const val CACHE_CONFIDENCE_THRESHOLD = 0.85f
+        const val MIN_MATCH_THRESHOLD = 0.50f
     }
 
     private val _pendingConfirmation = MutableSharedFlow<ScrobbleCandidate>()
@@ -75,10 +79,10 @@ class MediaSessionScrobbler @Inject constructor(
     private suspend fun processPlayingMedia(packageName: String, rawTitle: String) {
         val candidate = matchTitleToTrakt(packageName, rawTitle)
         if (candidate != null) {
-            if (candidate.confidence >= AUTO_SCROBBLE_THRESHOLD) {
-                autoScrobble(candidate)
-            } else {
-                _pendingConfirmation.emit(candidate)
+            when {
+                candidate.confidence >= AUTO_SCROBBLE_THRESHOLD -> autoScrobble(candidate)
+                candidate.confidence >= OVERLAY_THRESHOLD -> _pendingConfirmation.emit(candidate)
+                // < OVERLAY_THRESHOLD → ignore
             }
         }
     }
@@ -86,9 +90,44 @@ class MediaSessionScrobbler @Inject constructor(
     /**
      * Fuzzy-match the media title to a show+episode in the user's Trakt history.
      * Parses common patterns like "Show Title S02E04", "Show Title · Season 2", etc.
+     *
+     * Strategy:
+     *   1. Extract episode info (SxxExx pattern) from raw title
+     *   2. Search local cache (ShowCacheProvider) with fuzzy score
+     *   3. If cache score < 0.85 → fall back to Trakt API searchShow()
+     *   4. Return null if best score < 0.50
      */
-    private suspend fun matchTitleToTrakt(packageName: String, rawTitle: String): ScrobbleCandidate? {
-        // Common patterns: "Breaking Bad S03E07", "The Boys Season 2 Episode 4"
+    internal suspend fun matchTitleToTrakt(packageName: String, rawTitle: String): ScrobbleCandidate? {
+        val parsed = parseEpisodeInfo(rawTitle)
+        if (parsed.showTitle.isBlank()) return null
+
+        // 1. Search local cache
+        val cacheResult = searchCache(parsed.showTitle)
+
+        // 2. If cache hit is strong enough, use it
+        if (cacheResult != null && cacheResult.second >= CACHE_CONFIDENCE_THRESHOLD) {
+            return buildCandidate(packageName, rawTitle, cacheResult.first, cacheResult.second, parsed)
+        }
+
+        // 3. Trakt API fallback
+        val apiResult = searchTraktApi(parsed.showTitle)
+
+        // 4. Pick the best result between cache and API
+        val best = listOfNotNull(cacheResult, apiResult).maxByOrNull { it.second }
+            ?: return null
+
+        if (best.second < MIN_MATCH_THRESHOLD) return null
+
+        return buildCandidate(packageName, rawTitle, best.first, best.second, parsed)
+    }
+
+    private data class ParsedEpisodeInfo(
+        val showTitle: String,
+        val season: Int?,
+        val episode: Int?
+    )
+
+    private fun parseEpisodeInfo(rawTitle: String): ParsedEpisodeInfo {
         val episodePattern = Regex("""(?i)S(\d{1,2})E(\d{1,2})""")
         val match = episodePattern.find(rawTitle)
 
@@ -96,18 +135,48 @@ class MediaSessionScrobbler @Inject constructor(
         val season = match?.groupValues?.get(1)?.toIntOrNull()
         val episode = match?.groupValues?.get(2)?.toIntOrNull()
 
-        if (showTitle.isBlank()) return null
+        return ParsedEpisodeInfo(showTitle, season, episode)
+    }
 
-        // TODO: search user's local Trakt cache first, then API fallback
-        val confidence = if (match != null) 0.85f else 0.50f  // TODO: real fuzzy score
+    private fun searchCache(showTitle: String): Pair<TraktShow, Float>? {
+        val cachedShows = showCacheProvider.getCachedShows()
+        if (cachedShows.isEmpty()) return null
 
+        return cachedShows
+            .map { entry -> entry.show to FuzzyMatcher.fuzzyScore(showTitle, entry.show.title) }
+            .maxByOrNull { it.second }
+            ?.takeIf { it.second >= MIN_MATCH_THRESHOLD }
+    }
+
+    private suspend fun searchTraktApi(showTitle: String): Pair<TraktShow, Float>? {
+        return try {
+            val results = traktApi.searchShow(bearer = "", query = showTitle, limit = 5)
+            results
+                .mapNotNull { result ->
+                    val show = result.show ?: return@mapNotNull null
+                    show to FuzzyMatcher.fuzzyScore(showTitle, show.title)
+                }
+                .maxByOrNull { it.second }
+                ?.takeIf { it.second >= MIN_MATCH_THRESHOLD }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    private fun buildCandidate(
+        packageName: String,
+        rawTitle: String,
+        show: TraktShow,
+        score: Float,
+        parsed: ParsedEpisodeInfo
+    ): ScrobbleCandidate {
         return ScrobbleCandidate(
             packageName = packageName,
             mediaTitle = rawTitle,
-            confidence = confidence,
-            matchedShow = TraktShow(title = showTitle, ids = com.justb81.watchbuddy.core.model.TraktIds()),
-            matchedEpisode = if (season != null && episode != null)
-                TraktEpisode(season = season, number = episode)
+            confidence = score,
+            matchedShow = show,
+            matchedEpisode = if (parsed.season != null && parsed.episode != null)
+                TraktEpisode(season = parsed.season, number = parsed.episode)
             else null
         )
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/ShowCacheProvider.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/ShowCacheProvider.kt
@@ -1,0 +1,23 @@
+package com.justb81.watchbuddy.tv.scrobbler
+
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * In-memory cache of the user's watched shows.
+ * Fed by TvHomeViewModel when shows are loaded; read by MediaSessionScrobbler
+ * to avoid unnecessary Trakt API calls during fuzzy matching.
+ */
+@Singleton
+class ShowCacheProvider @Inject constructor() {
+
+    @Volatile
+    private var cachedShows: List<TraktWatchedEntry> = emptyList()
+
+    fun updateShows(shows: List<TraktWatchedEntry>) {
+        cachedShows = shows
+    }
+
+    fun getCachedShows(): List<TraktWatchedEntry> = cachedShows
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import com.justb81.watchbuddy.tv.scrobbler.ShowCacheProvider
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
@@ -23,7 +24,8 @@ data class TvHomeUiState(
 @HiltViewModel
 class TvHomeViewModel @Inject constructor(
     private val phoneDiscovery: PhoneDiscoveryManager,
-    private val phoneApiClientFactory: PhoneApiClientFactory
+    private val phoneApiClientFactory: PhoneApiClientFactory,
+    private val showCacheProvider: ShowCacheProvider
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TvHomeUiState())
@@ -63,6 +65,7 @@ class TvHomeViewModel @Inject constructor(
                     val shows = api.getShows()
                     cachedShows = shows
                     cacheTimestamp = System.currentTimeMillis()
+                    showCacheProvider.updateShows(shows)
                     _uiState.update { it.copy(isLoading = false, shows = shows) }
                 } else {
                     // No phone — try cache fallback

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/FuzzyMatcherTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/FuzzyMatcherTest.kt
@@ -1,0 +1,127 @@
+package com.justb81.watchbuddy.tv.scrobbler
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FuzzyMatcherTest {
+
+    // ── normalize() ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `normalize lowercases input`() {
+        assertEquals("breaking bad", FuzzyMatcher.normalize("Breaking Bad"))
+    }
+
+    @Test
+    fun `normalize removes special characters`() {
+        assertEquals("marvels agentsofshield", FuzzyMatcher.normalize("Marvel's Agents.of" + "S.H.I.E.L.D."))
+        // Note: dots and apostrophes removed, spaces collapsed
+    }
+
+    @Test
+    fun `normalize strips leading the`() {
+        assertEquals("boys", FuzzyMatcher.normalize("The Boys"))
+        assertEquals("mandalorian", FuzzyMatcher.normalize("the mandalorian"))
+    }
+
+    @Test
+    fun `normalize does not strip the in the middle`() {
+        assertEquals("over the garden wall", FuzzyMatcher.normalize("Over the Garden Wall"))
+    }
+
+    @Test
+    fun `normalize collapses whitespace`() {
+        assertEquals("stranger things", FuzzyMatcher.normalize("  Stranger   Things  "))
+    }
+
+    @Test
+    fun `normalize handles empty string`() {
+        assertEquals("", FuzzyMatcher.normalize(""))
+    }
+
+    @Test
+    fun `normalize handles only special characters`() {
+        assertEquals("", FuzzyMatcher.normalize("!@#\$%"))
+    }
+
+    // ── levenshteinDistance() ─────────────────────────────────────────────────
+
+    @Test
+    fun `levenshtein identical strings`() {
+        assertEquals(0, FuzzyMatcher.levenshteinDistance("kitten", "kitten"))
+    }
+
+    @Test
+    fun `levenshtein empty strings`() {
+        assertEquals(0, FuzzyMatcher.levenshteinDistance("", ""))
+        assertEquals(5, FuzzyMatcher.levenshteinDistance("hello", ""))
+        assertEquals(5, FuzzyMatcher.levenshteinDistance("", "hello"))
+    }
+
+    @Test
+    fun `levenshtein classic example`() {
+        assertEquals(3, FuzzyMatcher.levenshteinDistance("kitten", "sitting"))
+    }
+
+    @Test
+    fun `levenshtein single character difference`() {
+        assertEquals(1, FuzzyMatcher.levenshteinDistance("cat", "bat"))
+    }
+
+    @Test
+    fun `levenshtein completely different strings`() {
+        assertEquals(3, FuzzyMatcher.levenshteinDistance("abc", "xyz"))
+    }
+
+    // ── fuzzyScore() ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `fuzzyScore exact match returns 1_0`() {
+        assertEquals(1.0f, FuzzyMatcher.fuzzyScore("Breaking Bad", "Breaking Bad"), 0.001f)
+    }
+
+    @Test
+    fun `fuzzyScore exact match ignoring case returns 1_0`() {
+        assertEquals(1.0f, FuzzyMatcher.fuzzyScore("breaking bad", "BREAKING BAD"), 0.001f)
+    }
+
+    @Test
+    fun `fuzzyScore exact match ignoring the returns 1_0`() {
+        assertEquals(1.0f, FuzzyMatcher.fuzzyScore("The Boys", "boys"), 0.001f)
+    }
+
+    @Test
+    fun `fuzzyScore prefix match returns 0_95`() {
+        assertEquals(0.95f, FuzzyMatcher.fuzzyScore("Stranger Things", "Stranger Things Season 3"), 0.001f)
+    }
+
+    @Test
+    fun `fuzzyScore similar titles returns high score`() {
+        val score = FuzzyMatcher.fuzzyScore("Breaking Bad", "Braking Bad")
+        assertTrue("Expected score > 0.8 but was $score", score > 0.8f)
+    }
+
+    @Test
+    fun `fuzzyScore completely different titles returns low score`() {
+        val score = FuzzyMatcher.fuzzyScore("Breaking Bad", "Game of Thrones")
+        assertTrue("Expected score < 0.5 but was $score", score < 0.5f)
+    }
+
+    @Test
+    fun `fuzzyScore empty string returns 0`() {
+        assertEquals(0.0f, FuzzyMatcher.fuzzyScore("", "anything"), 0.001f)
+        assertEquals(0.0f, FuzzyMatcher.fuzzyScore("anything", ""), 0.001f)
+    }
+
+    @Test
+    fun `fuzzyScore special characters are ignored`() {
+        assertEquals(1.0f, FuzzyMatcher.fuzzyScore("Marvel's Agents of S.H.I.E.L.D.", "marvels agents of shield"), 0.001f)
+    }
+
+    @Test
+    fun `fuzzyScore handles minor typos gracefully`() {
+        val score = FuzzyMatcher.fuzzyScore("Stranger Things", "Stranjer Things")
+        assertTrue("Expected score > 0.85 but was $score", score > 0.85f)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #15

Replaces placeholder confidence scores in `MediaSessionScrobbler` with real fuzzy string matching against both the local show cache and Trakt API.

- **`FuzzyMatcher`** — pure Kotlin utility with `normalize()` (lowercase, strip special chars, remove leading "the"), `levenshteinDistance()` (O(min(m,n)) space DP), and `fuzzyScore()` (exact → 1.0, prefix → 0.95, Levenshtein-based otherwise)
- **`ShowCacheProvider`** — `@Singleton` in-memory cache fed by `TvHomeViewModel.loadShows()`, consumed by the scrobbler to avoid unnecessary API calls
- **`matchTitleToTrakt()` rewrite** — searches local cache first; falls back to `TraktApiService.searchShow()` if cache score < 0.85; picks best result across both sources
- **Updated confidence thresholds**: `>=0.95` auto-scrobble, `0.70–0.95` overlay prompt, `<0.70` ignore, `<0.50` no match
- **Unit tests** for `normalize()`, `levenshteinDistance()`, and `fuzzyScore()` (JUnit 4, 17 test cases)

### Files changed

| File | Change |
|------|--------|
| `app-tv/.../scrobbler/FuzzyMatcher.kt` | **New** — string normalization + Levenshtein + fuzzy scoring |
| `app-tv/.../scrobbler/ShowCacheProvider.kt` | **New** — injectable in-memory show cache |
| `app-tv/.../scrobbler/MediaSessionScrobbler.kt` | Rewritten `matchTitleToTrakt()` with cache-first + API fallback |
| `app-tv/.../home/TvHomeViewModel.kt` | Feeds `ShowCacheProvider` when shows are loaded |
| `app-tv/build.gradle.kts` | Added `testImplementation("junit:junit:4.13.2")` |
| `app-tv/src/test/.../FuzzyMatcherTest.kt` | **New** — 17 unit tests |

## Test plan

- [ ] CI build passes (`build-android.yml`)
- [ ] Unit tests pass: `./gradlew :app-tv:testDebugUnitTest --tests "*.FuzzyMatcherTest"`
- [ ] Manual verification: title "Breaking Bad S03E07" extracts show "Breaking Bad" + S03E07, matches cache/API
- [ ] Verify auto-scrobble triggers at >=0.95 confidence
- [ ] Verify overlay prompt triggers at 0.70-0.95 confidence
- [ ] Verify titles below 0.70 confidence are silently ignored
- [ ] Verify Trakt API fallback fires when cache score < 0.85

🤖 Generated with [Claude Code](https://claude.com/claude-code)