### PR TITLE
feat(tv): wire ScrobbleOverlay confirmation to autoScrobble via ScrobbleViewModel

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
@@ -22,7 +22,7 @@ import javax.inject.Singleton
  *   1. MediaSessionManager.getActiveSessions() returns all active sessions
  *   2. Extract package name + media title from session metadata
  *   3. Fuzzy-match title against user's Trakt watchlist
- *   4. Confidence ≥ 0.9 → auto-scrobble; < 0.9 → emit ScrobbleCandidate for UI confirmation
+ *   4. Confidence ≥ 0.95 → auto-scrobble; 0.70–0.95 → emit ScrobbleCandidate for UI confirmation
  *   5. On playback stop/pause → call Trakt scrobble/stop
  */
 @Singleton
@@ -31,7 +31,8 @@ class MediaSessionScrobbler @Inject constructor(
     private val traktApi: TraktApiService
 ) {
     companion object {
-        const val AUTO_SCROBBLE_THRESHOLD = 0.90f
+        const val AUTO_SCROBBLE_THRESHOLD = 0.95f
+        const val CONFIRMATION_THRESHOLD = 0.70f
     }
 
     private val _pendingConfirmation = MutableSharedFlow<ScrobbleCandidate>()
@@ -75,10 +76,10 @@ class MediaSessionScrobbler @Inject constructor(
     private suspend fun processPlayingMedia(packageName: String, rawTitle: String) {
         val candidate = matchTitleToTrakt(packageName, rawTitle)
         if (candidate != null) {
-            if (candidate.confidence >= AUTO_SCROBBLE_THRESHOLD) {
-                autoScrobble(candidate)
-            } else {
-                _pendingConfirmation.emit(candidate)
+            when {
+                candidate.confidence >= AUTO_SCROBBLE_THRESHOLD -> autoScrobble(candidate)
+                candidate.confidence >= CONFIRMATION_THRESHOLD  -> _pendingConfirmation.emit(candidate)
+                // Below CONFIRMATION_THRESHOLD → ignore (too uncertain)
             }
         }
     }
@@ -112,7 +113,7 @@ class MediaSessionScrobbler @Inject constructor(
         )
     }
 
-    private suspend fun autoScrobble(candidate: ScrobbleCandidate) {
+    suspend fun autoScrobble(candidate: ScrobbleCandidate) {
         // TODO: retrieve stored access_token from secure storage and call traktApi.scrobbleStart()
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
@@ -2,6 +2,7 @@ package com.justb81.watchbuddy.tv.ui.navigation
 
 import androidx.compose.runtime.*
 import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -10,10 +11,10 @@ import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.tv.ui.home.TvHomeScreen
 import com.justb81.watchbuddy.tv.ui.recap.RecapScreen
 import com.justb81.watchbuddy.tv.ui.scrobble.ScrobbleOverlay
+import com.justb81.watchbuddy.tv.ui.scrobble.ScrobbleViewModel
 import com.justb81.watchbuddy.tv.ui.settings.StreamingSettingsScreen
 import com.justb81.watchbuddy.tv.ui.showdetail.ShowDetailScreen
 import com.justb81.watchbuddy.tv.ui.userselect.UserSelectScreen
-import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 
 sealed class TvRoute(val route: String) {
     object Home       : TvRoute("tv_home")
@@ -24,14 +25,16 @@ sealed class TvRoute(val route: String) {
 }
 
 @Composable
-fun TvNavGraph() {
+fun TvNavGraph(
+    scrobbleViewModel: ScrobbleViewModel = hiltViewModel()
+) {
     val navController = rememberNavController()
 
     // Shared state: currently selected show (passed between Home → Detail → Recap)
     var selectedEntry by remember { mutableStateOf<TraktWatchedEntry?>(null) }
 
-    // Scrobble overlay state — shown on top of any screen
-    var scrobbleCandidate by remember { mutableStateOf<ScrobbleCandidate?>(null) }
+    // Scrobble overlay state — driven by ScrobbleViewModel
+    val pendingCandidate by scrobbleViewModel.pendingCandidate.collectAsState()
 
     NavHost(
         navController    = navController,
@@ -97,14 +100,11 @@ fun TvNavGraph() {
     }
 
     // Scrobble overlay — renders on top of everything
-    scrobbleCandidate?.let { candidate ->
+    pendingCandidate?.let { candidate ->
         ScrobbleOverlay(
             candidate = candidate,
-            onConfirm = {
-                // TODO: call scrobbler.autoScrobble(candidate)
-                scrobbleCandidate = null
-            },
-            onDismiss = { scrobbleCandidate = null }
+            onConfirm = { scrobbleViewModel.confirmScrobble() },
+            onDismiss = { scrobbleViewModel.dismissScrobble() }
         )
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModel.kt
@@ -1,0 +1,54 @@
+package com.justb81.watchbuddy.tv.ui.scrobble
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.justb81.watchbuddy.core.model.ScrobbleCandidate
+import com.justb81.watchbuddy.tv.scrobbler.MediaSessionScrobbler
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class ScrobbleViewModel @Inject constructor(
+    private val scrobbler: MediaSessionScrobbler
+) : ViewModel() {
+
+    private val _pendingCandidate = MutableStateFlow<ScrobbleCandidate?>(null)
+    val pendingCandidate: StateFlow<ScrobbleCandidate?> = _pendingCandidate.asStateFlow()
+
+    /** Set of dismissed media titles to avoid re-prompting for the same episode. */
+    private val dismissedTitles = mutableSetOf<String>()
+
+    init {
+        viewModelScope.launch {
+            scrobbler.pendingConfirmation.collect { candidate ->
+                if (candidate.mediaTitle !in dismissedTitles) {
+                    _pendingCandidate.value = candidate
+                }
+            }
+        }
+    }
+
+    fun onCandidateDetected(candidate: ScrobbleCandidate) {
+        if (candidate.mediaTitle !in dismissedTitles) {
+            _pendingCandidate.value = candidate
+        }
+    }
+
+    fun confirmScrobble() {
+        val candidate = _pendingCandidate.value ?: return
+        _pendingCandidate.value = null
+        viewModelScope.launch {
+            scrobbler.autoScrobble(candidate)
+        }
+    }
+
+    fun dismissScrobble() {
+        val candidate = _pendingCandidate.value ?: return
+        dismissedTitles.add(candidate.mediaTitle)
+        _pendingCandidate.value = null
+    }
+}


### PR DESCRIPTION
## Summary

- **New `ScrobbleViewModel`** (`@HiltViewModel`) that manages the scrobble confirmation lifecycle:
  - Collects candidates from `MediaSessionScrobbler.pendingConfirmation` SharedFlow
  - `confirmScrobble()` calls `autoScrobble()` and clears the pending state
  - `dismissScrobble()` clears pending state and remembers the dismissed episode to prevent re-prompting
- **Adjusted confidence thresholds** in `MediaSessionScrobbler`:
  - `>= 0.95` → direct auto-scrobble (no overlay)
  - `0.70 – 0.95` → emit candidate for UI confirmation overlay
  - `< 0.70` → ignored (too uncertain)
- **Updated `TvNavGraph`** to use `ScrobbleViewModel` via `hiltViewModel()` instead of local `mutableStateOf<ScrobbleCandidate?>` — overlay callbacks now route through the ViewModel

## Test plan

- [ ] Verify ScrobbleOverlay appears when `MediaSessionScrobbler` emits a candidate with confidence 0.70–0.95
- [ ] Tap "Ja, tracken" → confirm `autoScrobble()` is called and overlay disappears
- [ ] Tap "Nein" → confirm overlay disappears and same episode is not shown again
- [ ] Verify candidates with confidence >= 0.95 are auto-scrobbled without overlay
- [ ] Verify candidates with confidence < 0.70 produce no overlay
- [ ] Verify overlay renders on top of all navigation destinations (Home, ShowDetail, Recap, etc.)
- [ ] Verify auto-dismiss after 15 seconds still works correctly

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)