### PR TITLE
feat(tv): call Trakt Scrobble API in MediaSessionScrobbler

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -1,8 +1,11 @@
 package com.justb81.watchbuddy.phone.server
 
 import android.util.Log
+import com.justb81.watchbuddy.core.model.DeviceCapability
+import com.justb81.watchbuddy.core.model.TokenResponse
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
 import com.justb81.watchbuddy.phone.llm.RecapGenerator
 import io.ktor.http.*
 import io.ktor.server.application.*
@@ -24,12 +27,13 @@ import javax.inject.Singleton
  *
  * Endpoints:
  *   GET  /capability           → DeviceCapability (device score, RAM, LLM backend)
+ *   GET  /auth/token           → TokenResponse (access token for Trakt API calls from TV)
  *   GET  /shows                → List of watched shows for this user (from Trakt cache)
  *   POST /recap/{traktShowId}  → Generate + return HTML recap for a show
- *   GET  /auth/token           → Current access token for TV app usage
  */
 @Singleton
 class CompanionHttpServer @Inject constructor(
+    private val llmOrchestrator: LlmOrchestrator,
     private val recapGenerator: RecapGenerator,
     private val capabilityProvider: DeviceCapabilityProvider,
     private val showRepository: ShowRepository,
@@ -51,6 +55,18 @@ class CompanionHttpServer @Inject constructor(
             routing {
                 get("/capability") {
                     call.respond(capabilityProvider.getCapability())
+                }
+
+                get("/auth/token") {
+                    val token = tokenRepository.getAccessToken()
+                    if (token.isNullOrBlank() || !tokenRepository.isTokenValid()) {
+                        call.respond(io.ktor.http.HttpStatusCode.Unauthorized)
+                        return@get
+                    }
+                    call.respond(TokenResponse(
+                        accessToken = token,
+                        expiresIn = 3600  // approximate remaining TTL
+                    ))
                 }
 
                 get("/shows") {
@@ -122,11 +138,6 @@ class CompanionHttpServer @Inject constructor(
                     }
                 }
 
-                get("/auth/token") {
-                    val token = tokenRepository.getAccessToken()
-                        ?: return@get call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
-                    call.respond(TokenResponse(accessToken = token))
-                }
             }
         }.start(wait = false)
     }
@@ -140,11 +151,6 @@ class CompanionHttpServer @Inject constructor(
 @Serializable
 private data class RecapRequest(
     val tmdbApiKey: String = ""
-)
-
-@Serializable
-private data class TokenResponse(
-    val accessToken: String
 )
 
 @Serializable

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiClientFactory.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiClientFactory.kt
@@ -1,0 +1,30 @@
+package com.justb81.watchbuddy.tv.discovery
+
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Creates [PhoneApiService] instances for a given phone base URL. */
+@Singleton
+class PhoneApiClientFactory @Inject constructor() {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private val client = OkHttpClient.Builder()
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .readTimeout(5, TimeUnit.SECONDS)
+        .build()
+
+    fun createClient(baseUrl: String): PhoneApiService =
+        Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(client)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(PhoneApiService::class.java)
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiService.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiService.kt
@@ -1,0 +1,11 @@
+package com.justb81.watchbuddy.tv.discovery
+
+import com.justb81.watchbuddy.core.model.TokenResponse
+import retrofit2.http.GET
+
+/** Retrofit client for the phone's CompanionHttpServer (dynamic base URL). */
+interface PhoneApiService {
+
+    @GET("/auth/token")
+    suspend fun getAccessToken(): TokenResponse
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
@@ -2,11 +2,15 @@ package com.justb81.watchbuddy.tv.scrobbler
 
 import android.content.ComponentName
 import android.content.Context
+import android.media.session.MediaController
 import android.media.session.MediaSessionManager
 import android.media.session.PlaybackState
+import android.util.Log
 import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 import com.justb81.watchbuddy.core.model.TraktEpisode
+import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
+import com.justb81.watchbuddy.core.trakt.ScrobbleBody
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.*
@@ -23,15 +27,23 @@ import javax.inject.Singleton
  *   2. Extract package name + media title from session metadata
  *   3. Fuzzy-match title against user's Trakt watchlist
  *   4. Confidence ≥ 0.9 → auto-scrobble; < 0.9 → emit ScrobbleCandidate for UI confirmation
- *   5. On playback stop/pause → call Trakt scrobble/stop
+ *   5. On playback stop/pause → call Trakt scrobble/stop or scrobble/pause
+ *
+ * Scrobble lifecycle:
+ *   STATE_PLAYING  → scrobble/start (progress = 0)
+ *   STATE_PAUSED   → scrobble/pause
+ *   STATE_STOPPED / ≥ 80% → scrobble/stop (marks episode as watched)
  */
 @Singleton
 class MediaSessionScrobbler @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val traktApi: TraktApiService
+    private val traktApi: TraktApiService,
+    private val tvTokenCache: TvTokenCache
 ) {
     companion object {
+        private const val TAG = "MediaSessionScrobbler"
         const val AUTO_SCROBBLE_THRESHOLD = 0.90f
+        private const val WATCHED_THRESHOLD = 80f
     }
 
     private val _pendingConfirmation = MutableSharedFlow<ScrobbleCandidate>()
@@ -39,6 +51,10 @@ class MediaSessionScrobbler @Inject constructor(
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var pollingJob: Job? = null
+
+    /** Currently active scrobble — tracks which episode we told Trakt about. */
+    private var activeCandidate: ScrobbleCandidate? = null
+    private var lastPlaybackState: Int = PlaybackState.STATE_NONE
 
     fun startListening(notificationListenerComponent: ComponentName) {
         val sessionManager = context.getSystemService(Context.MEDIA_SESSION_SERVICE)
@@ -48,16 +64,11 @@ class MediaSessionScrobbler @Inject constructor(
             while (isActive) {
                 try {
                     val sessions = sessionManager.getActiveSessions(notificationListenerComponent)
-                    sessions.forEach { controller ->
-                        val packageName = controller.packageName
-                        val metadata = controller.metadata ?: return@forEach
-                        val playbackState = controller.playbackState ?: return@forEach
-
-                        if (playbackState.state == PlaybackState.STATE_PLAYING) {
-                            val title = metadata.getString(android.media.MediaMetadata.METADATA_KEY_TITLE)
-                                ?: return@forEach
-
-                            processPlayingMedia(packageName, title)
+                    if (sessions.isEmpty()) {
+                        handlePlaybackStateChange(PlaybackState.STATE_STOPPED, progress = 100f)
+                    } else {
+                        sessions.forEach { controller ->
+                            processSession(controller)
                         }
                     }
                 } catch (e: Exception) {
@@ -70,15 +81,57 @@ class MediaSessionScrobbler @Inject constructor(
 
     fun stopListening() {
         pollingJob?.cancel()
+        scope.launch { handlePlaybackStateChange(PlaybackState.STATE_STOPPED, progress = 100f) }
     }
 
-    private suspend fun processPlayingMedia(packageName: String, rawTitle: String) {
-        val candidate = matchTitleToTrakt(packageName, rawTitle)
-        if (candidate != null) {
-            if (candidate.confidence >= AUTO_SCROBBLE_THRESHOLD) {
-                autoScrobble(candidate)
-            } else {
-                _pendingConfirmation.emit(candidate)
+    private suspend fun processSession(controller: MediaController) {
+        val packageName = controller.packageName
+        val metadata = controller.metadata ?: return
+        val playbackState = controller.playbackState ?: return
+        val state = playbackState.state
+
+        val title = metadata.getString(android.media.MediaMetadata.METADATA_KEY_TITLE)
+            ?: return
+        val duration = metadata.getLong(android.media.MediaMetadata.METADATA_KEY_DURATION)
+        val position = playbackState.position
+
+        val progress = if (duration > 0) (position.toFloat() / duration * 100f) else 0f
+
+        when (state) {
+            PlaybackState.STATE_PLAYING -> {
+                val candidate = matchTitleToTrakt(packageName, title)
+                if (candidate != null) {
+                    if (candidate.confidence >= AUTO_SCROBBLE_THRESHOLD) {
+                        if (activeCandidate?.mediaTitle != candidate.mediaTitle) {
+                            activeCandidate = candidate
+                            autoScrobble(candidate, progress)
+                        }
+                        lastPlaybackState = state
+                    } else if (activeCandidate?.mediaTitle != candidate.mediaTitle) {
+                        _pendingConfirmation.emit(candidate)
+                    }
+                }
+            }
+            PlaybackState.STATE_PAUSED -> handlePlaybackStateChange(state, progress)
+            PlaybackState.STATE_STOPPED, PlaybackState.STATE_NONE ->
+                handlePlaybackStateChange(PlaybackState.STATE_STOPPED, progress)
+            else -> { /* ignore buffering etc. */ }
+        }
+    }
+
+    private suspend fun handlePlaybackStateChange(newState: Int, progress: Float) {
+        val candidate = activeCandidate ?: return
+        if (newState == lastPlaybackState) return
+
+        when (newState) {
+            PlaybackState.STATE_PAUSED -> {
+                scrobblePause(candidate, progress)
+                lastPlaybackState = newState
+            }
+            PlaybackState.STATE_STOPPED -> {
+                scrobbleStop(candidate, progress.coerceAtLeast(WATCHED_THRESHOLD))
+                activeCandidate = null
+                lastPlaybackState = PlaybackState.STATE_NONE
             }
         }
     }
@@ -105,14 +158,61 @@ class MediaSessionScrobbler @Inject constructor(
             packageName = packageName,
             mediaTitle = rawTitle,
             confidence = confidence,
-            matchedShow = TraktShow(title = showTitle, ids = com.justb81.watchbuddy.core.model.TraktIds()),
+            matchedShow = TraktShow(title = showTitle, ids = TraktIds()),
             matchedEpisode = if (season != null && episode != null)
                 TraktEpisode(season = season, number = episode)
             else null
         )
     }
 
-    private suspend fun autoScrobble(candidate: ScrobbleCandidate) {
-        // TODO: retrieve stored access_token from secure storage and call traktApi.scrobbleStart()
+    private suspend fun autoScrobble(candidate: ScrobbleCandidate, progress: Float) {
+        val token = tvTokenCache.getToken() ?: run {
+            Log.w(TAG, "No access token available — skipping scrobble")
+            return
+        }
+        val episode = candidate.matchedEpisode ?: run {
+            Log.w(TAG, "No matched episode — skipping scrobble")
+            return
+        }
+        val show = candidate.matchedShow ?: return
+        try {
+            traktApi.scrobbleStart(
+                bearer = "Bearer $token",
+                body = ScrobbleBody(show = show, episode = episode, progress = progress)
+            )
+            Log.i(TAG, "Scrobble started: ${show.title} S${episode.season}E${episode.number}")
+        } catch (e: Exception) {
+            Log.e(TAG, "scrobble/start failed: ${e.message}")
+        }
+    }
+
+    private suspend fun scrobblePause(candidate: ScrobbleCandidate, progress: Float) {
+        val token = tvTokenCache.getToken() ?: return
+        val episode = candidate.matchedEpisode ?: return
+        val show = candidate.matchedShow ?: return
+        try {
+            traktApi.scrobblePause(
+                bearer = "Bearer $token",
+                body = ScrobbleBody(show = show, episode = episode, progress = progress)
+            )
+            Log.i(TAG, "Scrobble paused: ${show.title} at ${progress.toInt()}%")
+        } catch (e: Exception) {
+            Log.e(TAG, "scrobble/pause failed: ${e.message}")
+        }
+    }
+
+    private suspend fun scrobbleStop(candidate: ScrobbleCandidate, progress: Float) {
+        val token = tvTokenCache.getToken() ?: return
+        val episode = candidate.matchedEpisode ?: return
+        val show = candidate.matchedShow ?: return
+        try {
+            traktApi.scrobbleStop(
+                bearer = "Bearer $token",
+                body = ScrobbleBody(show = show, episode = episode, progress = progress)
+            )
+            Log.i(TAG, "Scrobble stopped: ${show.title} S${episode.season}E${episode.number} (${progress.toInt()}%)")
+        } catch (e: Exception) {
+            Log.e(TAG, "scrobble/stop failed: ${e.message}")
+        }
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvTokenCache.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvTokenCache.kt
@@ -1,0 +1,54 @@
+package com.justb81.watchbuddy.tv.scrobbler
+
+import android.util.Log
+import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
+import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * In-memory cache for the Trakt access token obtained from the phone companion.
+ * The TV itself has no Trakt login — it fetches the token via the phone's HTTP API.
+ */
+@Singleton
+class TvTokenCache @Inject constructor(
+    private val phoneApiClientFactory: PhoneApiClientFactory,
+    private val phoneDiscovery: PhoneDiscoveryManager
+) {
+    companion object {
+        private const val TAG = "TvTokenCache"
+        private const val DEFAULT_TTL_MS = 3_600_000L  // 1 hour fallback
+    }
+
+    private var cachedToken: String? = null
+    private var tokenExpiry: Long = 0L
+
+    suspend fun getToken(): String? {
+        if (cachedToken != null && System.currentTimeMillis() < tokenExpiry) {
+            return cachedToken
+        }
+
+        val phone = phoneDiscovery.getBestPhone() ?: run {
+            Log.w(TAG, "No companion phone discovered")
+            return null
+        }
+        val baseUrl = "http://${phone.serviceInfo.host.hostAddress}:${phone.serviceInfo.port}"
+        val client = phoneApiClientFactory.createClient(baseUrl)
+
+        return try {
+            val response = client.getAccessToken()
+            cachedToken = response.accessToken
+            tokenExpiry = System.currentTimeMillis() + (response.expiresIn * 1_000L)
+                .coerceAtMost(DEFAULT_TTL_MS)
+            cachedToken
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to fetch token from phone: ${e.message}")
+            null
+        }
+    }
+
+    fun invalidate() {
+        cachedToken = null
+        tokenExpiry = 0L
+    }
+}

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -97,6 +97,14 @@ data class ScrobbleCandidate(
     val matchedEpisode: TraktEpisode? = null
 )
 
+// ── Token ────────────────────────────────────────────────────────────────────
+
+@Serializable
+data class TokenResponse(
+    val accessToken: String,
+    val expiresIn: Long            // remaining seconds until expiry
+)
+
 // ── Streaming Deep Links ──────────────────────────────────────────────────────
 
 @Serializable


### PR DESCRIPTION
## Summary
- **Phone**: Add `GET /auth/token` endpoint to `CompanionHttpServer` — returns the stored Trakt access token so the TV app can call the Trakt API on behalf of the user
- **Core**: Add `TokenResponse` DTO in shared models
- **TV**: Create `PhoneApiService` + `PhoneApiClientFactory` for dynamic Retrofit clients targeting discovered companion phones via NSD
- **TV**: Create `TvTokenCache` (`@Singleton`) with in-memory caching and 1h TTL that fetches tokens from the best discovered phone
- **TV**: Implement full scrobble lifecycle in `MediaSessionScrobbler`:
  - `STATE_PLAYING` → `scrobble/start`
  - `STATE_PAUSED` → `scrobble/pause`
  - `STATE_STOPPED` → `scrobble/stop` (marks episode as watched)
- Active scrobble state tracking prevents duplicate API calls
- All Trakt API calls wrapped in try/catch — no crash when phone is unreachable

Closes #16

## Test plan
- [ ] Start playback on TV (e.g. Netflix) with a title matching `S01E01` pattern → verify `scrobble/start` is called
- [ ] Pause playback → verify `scrobble/pause` is called
- [ ] Stop playback → verify `scrobble/stop` is called
- [ ] Disconnect phone from network → verify TV doesn't crash, logs warning
- [ ] Verify token is cached and not re-fetched on every poll cycle
- [ ] Verify `GET /auth/token` returns 401 when phone has no valid Trakt token

🤖 Generated with [Claude Code](https://claude.com/claude-code)