### PR TITLE
feat(tv): implement scrobble system (Issues #15, #16, #18)

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/TvShowCache.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/TvShowCache.kt
@@ -1,0 +1,23 @@
+package com.justb81.watchbuddy.tv.data
+
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * In-memory cache of the user's Trakt watched shows.
+ * Populated by [TvHomeViewModel] when shows are loaded from a phone.
+ * Used by [MediaSessionScrobbler] for local fuzzy-matching before hitting the Trakt API.
+ */
+@Singleton
+class TvShowCache @Inject constructor() {
+
+    @Volatile
+    private var cachedShows: List<TraktWatchedEntry> = emptyList()
+
+    fun updateShows(shows: List<TraktWatchedEntry>) {
+        cachedShows = shows
+    }
+
+    fun getCachedShows(): List<TraktWatchedEntry> = cachedShows
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
@@ -4,10 +4,12 @@ import android.content.ComponentName
 import android.content.Context
 import android.media.session.MediaSessionManager
 import android.media.session.PlaybackState
+import android.util.Log
 import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 import com.justb81.watchbuddy.core.model.TraktEpisode
-import com.justb81.watchbuddy.core.model.TraktShow
+import com.justb81.watchbuddy.core.trakt.ScrobbleBody
 import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.tv.data.TvShowCache
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -21,17 +23,21 @@ import javax.inject.Singleton
  * How it works:
  *   1. MediaSessionManager.getActiveSessions() returns all active sessions
  *   2. Extract package name + media title from session metadata
- *   3. Fuzzy-match title against user's Trakt watchlist
- *   4. Confidence ≥ 0.9 → auto-scrobble; < 0.9 → emit ScrobbleCandidate for UI confirmation
+ *   3. Fuzzy-match title against user's Trakt watchlist (local cache first, then API)
+ *   4. Confidence ≥ 0.95 → auto-scrobble; 0.70–0.95 → emit for UI confirmation; < 0.70 → ignore
  *   5. On playback stop/pause → call Trakt scrobble/stop
  */
 @Singleton
 class MediaSessionScrobbler @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val traktApi: TraktApiService
+    private val traktApi: TraktApiService,
+    private val tvShowCache: TvShowCache,
+    private val tvTokenCache: TvTokenCache
 ) {
     companion object {
-        const val AUTO_SCROBBLE_THRESHOLD = 0.90f
+        private const val TAG = "MediaSessionScrobbler"
+        private const val AUTO_SCROBBLE_THRESHOLD = 0.95f
+        private const val OVERLAY_THRESHOLD = 0.70f
     }
 
     private val _pendingConfirmation = MutableSharedFlow<ScrobbleCandidate>()
@@ -39,6 +45,9 @@ class MediaSessionScrobbler @Inject constructor(
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var pollingJob: Job? = null
+
+    /** Track which media title is currently being scrobbled to avoid duplicate starts. */
+    private var currentlyScrobbling: String? = null
 
     fun startListening(notificationListenerComponent: ComponentName) {
         val sessionManager = context.getSystemService(Context.MEDIA_SESSION_SERVICE)
@@ -53,15 +62,19 @@ class MediaSessionScrobbler @Inject constructor(
                         val metadata = controller.metadata ?: return@forEach
                         val playbackState = controller.playbackState ?: return@forEach
 
-                        if (playbackState.state == PlaybackState.STATE_PLAYING) {
-                            val title = metadata.getString(android.media.MediaMetadata.METADATA_KEY_TITLE)
-                                ?: return@forEach
+                        val title = metadata.getString(android.media.MediaMetadata.METADATA_KEY_TITLE)
+                            ?: return@forEach
 
-                            processPlayingMedia(packageName, title)
+                        when (playbackState.state) {
+                            PlaybackState.STATE_PLAYING -> processPlayingMedia(packageName, title)
+                            PlaybackState.STATE_PAUSED -> handleScrobblePause(title)
+                            PlaybackState.STATE_STOPPED,
+                            PlaybackState.STATE_NONE -> handleScrobbleStop(title)
+                            else -> { /* no-op */ }
                         }
                     }
                 } catch (e: Exception) {
-                    // Session access denied or device quirk — continue polling
+                    Log.w(TAG, "Session polling error", e)
                 }
                 delay(30_000) // Poll every 30 seconds
             }
@@ -73,22 +86,25 @@ class MediaSessionScrobbler @Inject constructor(
     }
 
     private suspend fun processPlayingMedia(packageName: String, rawTitle: String) {
-        val candidate = matchTitleToTrakt(packageName, rawTitle)
-        if (candidate != null) {
-            if (candidate.confidence >= AUTO_SCROBBLE_THRESHOLD) {
-                autoScrobble(candidate)
-            } else {
-                _pendingConfirmation.emit(candidate)
-            }
+        if (rawTitle == currentlyScrobbling) return // already handling this title
+
+        val candidate = matchTitleToTrakt(packageName, rawTitle) ?: return
+
+        if (candidate.confidence >= AUTO_SCROBBLE_THRESHOLD) {
+            autoScrobble(candidate)
+        } else if (candidate.confidence >= OVERLAY_THRESHOLD) {
+            _pendingConfirmation.emit(candidate)
         }
+        // confidence < 0.70 → too uncertain, don't scrobble
     }
+
+    // ── Fuzzy Matching (Issue #15) ───────────────────────────────────────────
 
     /**
      * Fuzzy-match the media title to a show+episode in the user's Trakt history.
-     * Parses common patterns like "Show Title S02E04", "Show Title · Season 2", etc.
+     * Searches the local show cache first, then falls back to the Trakt search API.
      */
     private suspend fun matchTitleToTrakt(packageName: String, rawTitle: String): ScrobbleCandidate? {
-        // Common patterns: "Breaking Bad S03E07", "The Boys Season 2 Episode 4"
         val episodePattern = Regex("""(?i)S(\d{1,2})E(\d{1,2})""")
         val match = episodePattern.find(rawTitle)
 
@@ -98,21 +114,160 @@ class MediaSessionScrobbler @Inject constructor(
 
         if (showTitle.isBlank()) return null
 
-        // TODO: search user's local Trakt cache first, then API fallback
-        val confidence = if (match != null) 0.85f else 0.50f  // TODO: real fuzzy score
+        // 1. Search local cache first
+        val cachedShows = tvShowCache.getCachedShows()
+        if (cachedShows.isNotEmpty()) {
+            val bestCacheMatch = cachedShows.maxByOrNull { fuzzyScore(it.show.title, showTitle) }
+            val cacheScore = bestCacheMatch?.let { fuzzyScore(it.show.title, showTitle) } ?: 0f
 
-        return ScrobbleCandidate(
-            packageName = packageName,
-            mediaTitle = rawTitle,
-            confidence = confidence,
-            matchedShow = TraktShow(title = showTitle, ids = com.justb81.watchbuddy.core.model.TraktIds()),
-            matchedEpisode = if (season != null && episode != null)
-                TraktEpisode(season = season, number = episode)
-            else null
-        )
+            if (cacheScore >= 0.70f && bestCacheMatch != null) {
+                return ScrobbleCandidate(
+                    packageName = packageName,
+                    mediaTitle = rawTitle,
+                    confidence = cacheScore,
+                    matchedShow = bestCacheMatch.show,
+                    matchedEpisode = if (season != null && episode != null)
+                        TraktEpisode(season = season, number = episode) else null
+                )
+            }
+        }
+
+        // 2. API fallback when cache has no good match
+        val token = tvTokenCache.getToken() ?: return null
+        return try {
+            val apiResults = traktApi.searchShow("Bearer $token", showTitle)
+            val apiMatch = apiResults
+                .filter { it.show != null }
+                .maxByOrNull { fuzzyScore(it.show!!.title, showTitle) }
+            val apiScore = apiMatch?.show?.let { fuzzyScore(it.title, showTitle) } ?: 0f
+
+            if (apiScore < 0.50f || apiMatch?.show == null) return null
+
+            ScrobbleCandidate(
+                packageName = packageName,
+                mediaTitle = rawTitle,
+                confidence = apiScore,
+                matchedShow = apiMatch.show,
+                matchedEpisode = if (season != null && episode != null)
+                    TraktEpisode(season = season, number = episode) else null
+            )
+        } catch (e: Exception) {
+            Log.w(TAG, "Trakt search API failed for '$showTitle'", e)
+            null
+        }
     }
 
-    private suspend fun autoScrobble(candidate: ScrobbleCandidate) {
-        // TODO: retrieve stored access_token from secure storage and call traktApi.scrobbleStart()
+    /**
+     * Normalizes a title for comparison: lowercases, strips special chars and
+     * leading articles ("the"), collapses whitespace.
+     */
+    internal fun normalize(title: String): String {
+        return title
+            .lowercase()
+            .replace(Regex("[^a-z0-9\\s]"), "")
+            .replace(Regex("\\bthe\\b"), "")
+            .trim()
+            .replace(Regex("\\s+"), " ")
+    }
+
+    /**
+     * Computes a fuzzy similarity score between two titles (0.0–1.0).
+     * Uses exact match → prefix match → Levenshtein distance.
+     */
+    internal fun fuzzyScore(a: String, b: String): Float {
+        val normA = normalize(a)
+        val normB = normalize(b)
+
+        if (normA.isEmpty() || normB.isEmpty()) return 0f
+        if (normA == normB) return 1.0f
+        if (normA.startsWith(normB) || normB.startsWith(normA)) return 0.95f
+
+        val distance = levenshteinDistance(normA, normB)
+        val maxLen = maxOf(normA.length, normB.length)
+        return (1.0f - (distance.toFloat() / maxLen)).coerceAtLeast(0f)
+    }
+
+    private fun levenshteinDistance(a: String, b: String): Int {
+        val dp = Array(a.length + 1) { IntArray(b.length + 1) }
+        for (i in 0..a.length) dp[i][0] = i
+        for (j in 0..b.length) dp[0][j] = j
+        for (i in 1..a.length) {
+            for (j in 1..b.length) {
+                dp[i][j] = if (a[i - 1] == b[j - 1]) dp[i - 1][j - 1]
+                else 1 + minOf(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+            }
+        }
+        return dp[a.length][b.length]
+    }
+
+    // ── Scrobble API (Issue #16) ─────────────────────────────────────────────
+
+    /**
+     * Sends a scrobble/start to Trakt for the given candidate.
+     * Called automatically for high-confidence matches or via [ScrobbleViewModel] after user confirmation.
+     */
+    suspend fun autoScrobble(candidate: ScrobbleCandidate) {
+        val token = tvTokenCache.getToken()
+        if (token == null) {
+            Log.w(TAG, "No access token available — scrobble skipped")
+            return
+        }
+
+        val show = candidate.matchedShow ?: return
+        val episode = candidate.matchedEpisode ?: return
+
+        try {
+            traktApi.scrobbleStart(
+                bearer = "Bearer $token",
+                body = ScrobbleBody(
+                    show = show,
+                    episode = episode,
+                    progress = 0f
+                )
+            )
+            currentlyScrobbling = candidate.mediaTitle
+            Log.i(TAG, "Scrobble started: ${show.title} S${episode.season}E${episode.number}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Scrobble start failed", e)
+        }
+    }
+
+    private suspend fun handleScrobblePause(rawTitle: String) {
+        if (rawTitle != currentlyScrobbling) return
+
+        val token = tvTokenCache.getToken() ?: return
+        val candidate = matchTitleToTrakt("", rawTitle) ?: return
+        val show = candidate.matchedShow ?: return
+        val episode = candidate.matchedEpisode ?: return
+
+        try {
+            traktApi.scrobblePause(
+                bearer = "Bearer $token",
+                body = ScrobbleBody(show = show, episode = episode, progress = 50f)
+            )
+            Log.i(TAG, "Scrobble paused: ${show.title}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Scrobble pause failed", e)
+        }
+    }
+
+    private suspend fun handleScrobbleStop(rawTitle: String) {
+        if (rawTitle != currentlyScrobbling) return
+
+        val token = tvTokenCache.getToken() ?: return
+        val candidate = matchTitleToTrakt("", rawTitle) ?: return
+        val show = candidate.matchedShow ?: return
+        val episode = candidate.matchedEpisode ?: return
+
+        try {
+            traktApi.scrobbleStop(
+                bearer = "Bearer $token",
+                body = ScrobbleBody(show = show, episode = episode, progress = 100f)
+            )
+            currentlyScrobbling = null
+            Log.i(TAG, "Scrobble stopped (watched): ${show.title} S${episode.season}E${episode.number}")
+        } catch (e: Exception) {
+            Log.e(TAG, "Scrobble stop failed", e)
+        }
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvTokenCache.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvTokenCache.kt
@@ -1,0 +1,53 @@
+package com.justb81.watchbuddy.tv.scrobbler
+
+import android.util.Log
+import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
+import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Caches the Trakt access token obtained from the phone companion app.
+ * The TV app itself has no Trakt login — it delegates auth to the phone via
+ * the companion HTTP API (GET /auth/token).
+ *
+ * Token is cached for [CACHE_TTL] to avoid excessive network calls.
+ */
+@Singleton
+class TvTokenCache @Inject constructor(
+    private val phoneApiClientFactory: PhoneApiClientFactory,
+    private val phoneDiscovery: PhoneDiscoveryManager
+) {
+    companion object {
+        private const val TAG = "TvTokenCache"
+        private const val CACHE_TTL = 30 * 60 * 1000L // 30 minutes
+    }
+
+    @Volatile
+    private var cachedToken: String? = null
+    private var tokenTimestamp: Long = 0L
+
+    suspend fun getToken(): String? {
+        val now = System.currentTimeMillis()
+        cachedToken?.let { token ->
+            if (now - tokenTimestamp < CACHE_TTL) return token
+        }
+
+        val phone = phoneDiscovery.getBestPhone() ?: return null
+        return try {
+            val client = phoneApiClientFactory.createClient(phone.baseUrl)
+            val response = client.getAccessToken()
+            cachedToken = response.accessToken
+            tokenTimestamp = System.currentTimeMillis()
+            response.accessToken
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to fetch access token from phone", e)
+            null
+        }
+    }
+
+    fun invalidate() {
+        cachedToken = null
+        tokenTimestamp = 0L
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.tv.ui.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.tv.data.TvShowCache
 import com.justb81.watchbuddy.tv.data.UserSessionRepository
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
@@ -26,7 +27,8 @@ data class TvHomeUiState(
 class TvHomeViewModel @Inject constructor(
     private val phoneDiscovery: PhoneDiscoveryManager,
     private val phoneApiClientFactory: PhoneApiClientFactory,
-    private val userSessionRepository: UserSessionRepository
+    private val userSessionRepository: UserSessionRepository,
+    private val tvShowCache: TvShowCache
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TvHomeUiState())
@@ -80,6 +82,7 @@ class TvHomeViewModel @Inject constructor(
                 val shows = api.getShows()
                 cachedShows = shows
                 cacheTimestamp = System.currentTimeMillis()
+                tvShowCache.updateShows(shows)
                 _uiState.update { it.copy(isLoading = false, shows = shows) }
             } else {
                 val cached = getCachedShows()

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
@@ -2,6 +2,7 @@ package com.justb81.watchbuddy.tv.ui.navigation
 
 import androidx.compose.runtime.*
 import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -10,10 +11,10 @@ import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.tv.ui.home.TvHomeScreen
 import com.justb81.watchbuddy.tv.ui.recap.RecapScreen
 import com.justb81.watchbuddy.tv.ui.scrobble.ScrobbleOverlay
+import com.justb81.watchbuddy.tv.ui.scrobble.ScrobbleViewModel
 import com.justb81.watchbuddy.tv.ui.settings.StreamingSettingsScreen
 import com.justb81.watchbuddy.tv.ui.showdetail.ShowDetailScreen
 import com.justb81.watchbuddy.tv.ui.userselect.UserSelectScreen
-import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 
 sealed class TvRoute(val route: String) {
     object Home       : TvRoute("tv_home")
@@ -30,8 +31,9 @@ fun TvNavGraph() {
     // Shared state: currently selected show (passed between Home → Detail → Recap)
     var selectedEntry by remember { mutableStateOf<TraktWatchedEntry?>(null) }
 
-    // Scrobble overlay state — shown on top of any screen
-    var scrobbleCandidate by remember { mutableStateOf<ScrobbleCandidate?>(null) }
+    // Scrobble overlay — driven by ScrobbleViewModel (Issue #18)
+    val scrobbleViewModel: ScrobbleViewModel = hiltViewModel()
+    val pendingCandidate by scrobbleViewModel.pendingCandidate.collectAsState()
 
     NavHost(
         navController    = navController,
@@ -94,14 +96,11 @@ fun TvNavGraph() {
     }
 
     // Scrobble overlay — renders on top of everything
-    scrobbleCandidate?.let { candidate ->
+    pendingCandidate?.let { candidate ->
         ScrobbleOverlay(
             candidate = candidate,
-            onConfirm = {
-                // TODO: call scrobbler.autoScrobble(candidate)
-                scrobbleCandidate = null
-            },
-            onDismiss = { scrobbleCandidate = null }
+            onConfirm = { scrobbleViewModel.confirmScrobble() },
+            onDismiss = { scrobbleViewModel.dismissScrobble() }
         )
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleOverlay.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleOverlay.kt
@@ -45,7 +45,7 @@ fun ScrobbleOverlay(
             delay(1_000)
             secondsLeft--
         }
-        onDismiss()
+        onConfirm() // Auto-confirm on countdown expiry
     }
 
     Box(

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModel.kt
@@ -1,0 +1,58 @@
+package com.justb81.watchbuddy.tv.ui.scrobble
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.justb81.watchbuddy.core.model.ScrobbleCandidate
+import com.justb81.watchbuddy.tv.scrobbler.MediaSessionScrobbler
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Bridges [MediaSessionScrobbler] with the [ScrobbleOverlay] UI.
+ *
+ * Candidates with confidence 0.70–0.95 land here for user confirmation.
+ * Dismissed episodes are remembered so the overlay is not shown again
+ * for the same episode during this session.
+ */
+@HiltViewModel
+class ScrobbleViewModel @Inject constructor(
+    private val scrobbler: MediaSessionScrobbler
+) : ViewModel() {
+
+    private val _pendingCandidate = MutableStateFlow<ScrobbleCandidate?>(null)
+    val pendingCandidate: StateFlow<ScrobbleCandidate?> = _pendingCandidate.asStateFlow()
+
+    private val dismissedEpisodes = mutableSetOf<String>()
+
+    init {
+        viewModelScope.launch {
+            scrobbler.pendingConfirmation.collect { candidate ->
+                val key = candidateKey(candidate)
+                if (key !in dismissedEpisodes) {
+                    _pendingCandidate.value = candidate
+                }
+            }
+        }
+    }
+
+    fun confirmScrobble() {
+        val candidate = _pendingCandidate.value ?: return
+        _pendingCandidate.value = null
+        viewModelScope.launch {
+            scrobbler.autoScrobble(candidate)
+        }
+    }
+
+    fun dismissScrobble() {
+        val candidate = _pendingCandidate.value ?: return
+        dismissedEpisodes.add(candidateKey(candidate))
+        _pendingCandidate.value = null
+    }
+
+    private fun candidateKey(candidate: ScrobbleCandidate): String =
+        "${candidate.matchedShow?.title}:S${candidate.matchedEpisode?.season}E${candidate.matchedEpisode?.number}"
+}


### PR DESCRIPTION
## Summary

Implements three interconnected issues for the TV app's scrobbling system:

- **Fixes #15 — Fuzzy Matching & Cache Search**: Replaces hardcoded confidence scores (0.85/0.50) with real Levenshtein-distance-based fuzzy matching. Introduces `TvShowCache` as a singleton in-memory cache populated by `TvHomeViewModel`. Shows are matched against the local cache first, then falling back to the Trakt search API — reducing unnecessary API calls.

- **Fixes #16 — Trakt Scrobble API**: Implements the previously empty `autoScrobble()` method with proper access token retrieval from the phone companion app via the new `TvTokenCache` (30-minute TTL). Adds full scrobble lifecycle handling (start/pause/stop) based on `MediaSession` playback state changes.

- **Fixes #18 — ScrobbleViewModel & Overlay Wiring**: Creates `ScrobbleViewModel` (Hilt-injected) to bridge `MediaSessionScrobbler` with the `ScrobbleOverlay` UI. `TvNavGraph` now uses the ViewModel-driven state instead of disconnected local state. Countdown expiry auto-confirms the scrobble (previously dismissed). Dismissed episodes are remembered to prevent re-showing the overlay for the same episode.

### New files
| File | Purpose |
|------|---------|
| `TvShowCache.kt` | Singleton in-memory cache for Trakt watched shows |
| `TvTokenCache.kt` | Caches access token from phone companion (30min TTL) |
| `ScrobbleViewModel.kt` | Hilt ViewModel bridging scrobbler ↔ overlay UI |

### Modified files
| File | Changes |
|------|---------|
| `MediaSessionScrobbler.kt` | Fuzzy matching, cache-first search, scrobble API calls, playback lifecycle |
| `TvNavGraph.kt` | ScrobbleViewModel integration, removed local state |
| `ScrobbleOverlay.kt` | Auto-confirm on countdown expiry |
| `TvHomeViewModel.kt` | Populates `TvShowCache` when shows are loaded |

### Confidence thresholds
| Range | Behavior |
|-------|----------|
| ≥ 0.95 | Auto-scrobble, no overlay |
| 0.70 – 0.95 | Show overlay with 15s auto-confirm countdown |
| < 0.70 | Ignore (too uncertain) |

## Test plan
- [ ] Verify fuzzy matching correctly identifies shows with minor title variations
- [ ] Verify cache-first search returns results without API calls when shows are cached
- [ ] Verify scrobble/start is called on Trakt API when a high-confidence match is found
- [ ] Verify scrobble/pause and scrobble/stop are called on playback state changes
- [ ] Verify ScrobbleOverlay appears for confidence 0.70–0.95 and triggers scrobble on confirm
- [ ] Verify countdown expiry auto-confirms the scrobble
- [ ] Verify dismissing an episode prevents re-showing the overlay for the same episode
- [ ] Verify no crash when phone is unreachable (token unavailable)