### PR TITLE
fix: resolve all P0-critical issues (#3, #4, #5)

### DIFF
--- a/app-phone/proguard-rules.pro
+++ b/app-phone/proguard-rules.pro
@@ -1,0 +1,82 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# WatchBuddy Phone — ProGuard / R8 Rules
+# ──────────────────────────────────────────────────────────────────────────────
+
+# ── Kotlin Serialization ─────────────────────────────────────────────────────
+# Keep @Serializable classes and their generated serializers
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.**
+-keepclassmembers class kotlinx.serialization.json.** { *** Companion; }
+-keepclasseswithmembers class kotlinx.serialization.json.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keep,includedescriptorclasses class com.justb81.watchbuddy.**$$serializer { *; }
+-keepclassmembers class com.justb81.watchbuddy.** {
+    *** Companion;
+}
+-keepclasseswithmembers class com.justb81.watchbuddy.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# ── Retrofit ─────────────────────────────────────────────────────────────────
+-keepattributes Signature, Exceptions
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+-dontwarn javax.annotation.**
+-dontwarn kotlin.Unit
+-dontwarn retrofit2.KotlinExtensions
+-dontwarn retrofit2.KotlinExtensions$*
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# ── OkHttp ───────────────────────────────────────────────────────────────────
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**
+
+# ── Hilt / Dagger ────────────────────────────────────────────────────────────
+-dontwarn dagger.hilt.android.internal.**
+
+# ── Room ─────────────────────────────────────────────────────────────────────
+-keep class * extends androidx.room.RoomDatabase
+-keep @androidx.room.Entity class *
+-dontwarn androidx.room.paging.**
+
+# ── Ktor (phone HTTP server) ────────────────────────────────────────────────
+-keep class io.ktor.** { *; }
+-dontwarn io.ktor.**
+-keep class io.netty.** { *; }
+-dontwarn io.netty.**
+
+# ── MediaPipe GenAI ──────────────────────────────────────────────────────────
+-keep class com.google.mediapipe.** { *; }
+-dontwarn com.google.mediapipe.**
+
+# ── Coil ─────────────────────────────────────────────────────────────────────
+-dontwarn coil.**
+
+# ── Security Crypto ──────────────────────────────────────────────────────────
+-keep class androidx.security.crypto.** { *; }
+
+# ── Coroutines ───────────────────────────────────────────────────────────────
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+-keepclassmembers class kotlinx.coroutines.** {
+    volatile <fields>;
+}
+
+# ── General ──────────────────────────────────────────────────────────────────
+-keep class * extends android.app.Application
+-keep class * extends android.app.Service
+-keep class * extends android.content.BroadcastReceiver
+-keepclassmembers class * implements android.os.Parcelable {
+    static ** CREATOR;
+}
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}

--- a/app-phone/src/main/AndroidManifest.xml
+++ b/app-phone/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.WatchBuddy">

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/RecapGenerator.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/RecapGenerator.kt
@@ -28,6 +28,24 @@ class RecapGenerator @Inject constructor(
         private const val TAG = "RecapGenerator"
         // TMDB still placeholder pattern: data-tmdb-still="S{season}E{episode}"
         private val STILL_PLACEHOLDER_REGEX = Regex("""data-tmdb-still="S(\d+)E(\d+)"""")
+
+        // HTML sanitization: strip dangerous tags and event handlers to prevent XSS
+        private val DANGEROUS_TAGS_REGEX = Regex(
+            """<\s*/?\s*(script|iframe|object|embed|form|link|meta|base|applet)\b[^>]*>""",
+            setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)
+        )
+        private val DANGEROUS_TAG_CONTENT_REGEX = Regex(
+            """<\s*(script|style)\b[^>]*>.*?<\s*/\s*\1\s*>""",
+            setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)
+        )
+        private val EVENT_HANDLER_REGEX = Regex(
+            """\s+on\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]*)""",
+            RegexOption.IGNORE_CASE
+        )
+        private val JAVASCRIPT_URL_REGEX = Regex(
+            """(href|src|action)\s*=\s*["']?\s*javascript:""",
+            RegexOption.IGNORE_CASE
+        )
     }
 
     /**
@@ -44,7 +62,8 @@ class RecapGenerator @Inject constructor(
     ): String {
         val prompt = buildPrompt(show, watchedEpisodes, targetEpisode)
         val rawHtml = inferWithLlm(prompt, watchedEpisodes)
-        return replaceTmdbPlaceholders(rawHtml, watchedEpisodes, apiKey)
+        val sanitized = sanitizeHtml(rawHtml)
+        return replaceTmdbPlaceholders(sanitized, watchedEpisodes, apiKey)
     }
 
     private fun buildPrompt(
@@ -85,6 +104,18 @@ Respond in $language.
     private suspend fun inferWithLlm(prompt: String, episodes: List<TmdbEpisode>): String {
         Log.d(TAG, "Starting LLM inference with cascade fallback")
         return llmProviderFactory.generateWithCascade(prompt, episodes)
+    }
+
+    /**
+     * Strips dangerous HTML elements and attributes to prevent XSS when rendered in WebView.
+     * Removes: script/iframe/object/embed/form tags, on* event handlers, javascript: URLs.
+     */
+    private fun sanitizeHtml(html: String): String {
+        var sanitized = DANGEROUS_TAG_CONTENT_REGEX.replace(html, "")
+        sanitized = DANGEROUS_TAGS_REGEX.replace(sanitized, "")
+        sanitized = EVENT_HANDLER_REGEX.replace(sanitized, "")
+        sanitized = JAVASCRIPT_URL_REGEX.replace(sanitized, """$1="about:blank""")
+        return sanitized
     }
 
     private fun replaceTmdbPlaceholders(

--- a/app-phone/src/main/res/xml/network_security_config.xml
+++ b/app-phone/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Disallow cleartext (HTTP) traffic by default -->
+    <base-config cleartextTrafficPermitted="false" />
+
+    <!-- Allow cleartext only for localhost — the Ktor companion HTTP server
+         runs on port 8765 and is accessed locally / from TV on the LAN. -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>

--- a/app-tv/proguard-rules.pro
+++ b/app-tv/proguard-rules.pro
@@ -1,0 +1,72 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# WatchBuddy TV — ProGuard / R8 Rules
+# ──────────────────────────────────────────────────────────────────────────────
+
+# ── Kotlin Serialization ─────────────────────────────────────────────────────
+# Keep @Serializable classes and their generated serializers
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.**
+-keepclassmembers class kotlinx.serialization.json.** { *** Companion; }
+-keepclasseswithmembers class kotlinx.serialization.json.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-keep,includedescriptorclasses class com.justb81.watchbuddy.**$$serializer { *; }
+-keepclassmembers class com.justb81.watchbuddy.** {
+    *** Companion;
+}
+-keepclasseswithmembers class com.justb81.watchbuddy.** {
+    kotlinx.serialization.KSerializer serializer(...);
+}
+
+# ── Retrofit ─────────────────────────────────────────────────────────────────
+-keepattributes Signature, Exceptions
+-keepclassmembers,allowshrinking,allowobfuscation interface * {
+    @retrofit2.http.* <methods>;
+}
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+-dontwarn javax.annotation.**
+-dontwarn kotlin.Unit
+-dontwarn retrofit2.KotlinExtensions
+-dontwarn retrofit2.KotlinExtensions$*
+-if interface * { @retrofit2.http.* <methods>; }
+-keep,allowobfuscation interface <1>
+-keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
+# ── OkHttp ───────────────────────────────────────────────────────────────────
+-dontwarn okhttp3.internal.platform.**
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**
+
+# ── Hilt / Dagger ────────────────────────────────────────────────────────────
+-dontwarn dagger.hilt.android.internal.**
+
+# ── Room ─────────────────────────────────────────────────────────────────────
+-keep class * extends androidx.room.RoomDatabase
+-keep @androidx.room.Entity class *
+-dontwarn androidx.room.paging.**
+
+# ── Coil ─────────────────────────────────────────────────────────────────────
+-dontwarn coil.**
+
+# ── Security Crypto ──────────────────────────────────────────────────────────
+-keep class androidx.security.crypto.** { *; }
+
+# ── Coroutines ───────────────────────────────────────────────────────────────
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler {}
+-keepclassmembers class kotlinx.coroutines.** {
+    volatile <fields>;
+}
+
+# ── General ──────────────────────────────────────────────────────────────────
+-keep class * extends android.app.Application
+-keep class * extends android.app.Service
+-keep class * extends android.content.BroadcastReceiver
+-keepclassmembers class * implements android.os.Parcelable {
+    static ** CREATOR;
+}
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}

--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
         android:banner="@drawable/tv_banner"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/Theme.WatchBuddy">
 
         <!-- TV Leanback launcher -->

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapScreen.kt
@@ -1,6 +1,5 @@
 package com.justb81.watchbuddy.tv.ui.recap
 
-import android.annotation.SuppressLint
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.compose.foundation.background
@@ -152,7 +151,6 @@ fun RecapScreen(
     }
 }
 
-@SuppressLint("SetJavaScriptEnabled")
 @Composable
 private fun RecapWebView(html: String) {
     // Wrap HTML in a full page with dark background and slide animation
@@ -219,7 +217,7 @@ private fun RecapWebView(html: String) {
         factory = { ctx ->
             WebView(ctx).apply {
                 webViewClient = WebViewClient()
-                settings.javaScriptEnabled = true
+                settings.javaScriptEnabled = false
                 settings.loadWithOverviewMode = true
                 settings.useWideViewPort = true
                 setBackgroundColor(android.graphics.Color.TRANSPARENT)

--- a/app-tv/src/main/res/xml/network_security_config.xml
+++ b/app-tv/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <!-- Allow cleartext by default because the TV discovers phone companions via
+         mDNS and connects to their dynamic LAN IPs over HTTP (port 8765).
+         Android's domain-config cannot express LAN IP ranges, so cleartext must
+         stay permitted at the base level. Certificate pinning in NetworkModule
+         protects the HTTPS API calls (Trakt, TMDB) independently. -->
+    <base-config cleartextTrafficPermitted="true" />
+
+    <!-- Enforce HTTPS-only for external API hosts -->
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="true">api.trakt.tv</domain>
+        <domain includeSubdomains="true">api.themoviedb.org</domain>
+    </domain-config>
+</network-security-config>

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
@@ -8,6 +8,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
+import okhttp3.CertificatePinner
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -26,11 +27,21 @@ object NetworkModule {
         coerceInputValues = true
     }
 
+    // Pin intermediate CA certificates for Trakt and TMDB APIs.
+    // Using wildcard pins on intermediate CAs for resilience during leaf cert rotation.
+    private val certificatePinner = CertificatePinner.Builder()
+        .add("api.trakt.tv", "sha256/jQJTbIh0grw0/1TkHSumWb+Fs0Ggogr621gT3PvPKG0=")         // Let's Encrypt R3
+        .add("api.trakt.tv", "sha256/C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=")         // ISRG Root X1
+        .add("api.themoviedb.org", "sha256/jQJTbIh0grw0/1TkHSumWb+Fs0Ggogr621gT3PvPKG0=")    // Let's Encrypt R3
+        .add("api.themoviedb.org", "sha256/C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=")    // ISRG Root X1
+        .build()
+
     @Provides
     @Singleton
     fun provideOkHttpClient(
         @Named("isDebugBuild") isDebug: Boolean
     ): OkHttpClient = OkHttpClient.Builder()
+        .certificatePinner(certificatePinner)
         .addInterceptor { chain ->
             // Trakt required headers
             val request = chain.request().newBuilder()


### PR DESCRIPTION
- #3 XSS prevention: disable JavaScript in RecapScreen WebView, add HTML sanitization in RecapGenerator (strips script/iframe/object tags, on* event handlers, javascript: URLs)
- #4 Missing ProGuard rules: create proguard-rules.pro for both app-phone and app-tv with keep rules for all dependencies (Retrofit, OkHttp, Hilt, Ktor, MediaPipe, Room, kotlinx.serialization, Coil, etc.)
- #5 Certificate pinning: add CertificatePinner to shared OkHttpClient for api.trakt.tv and api.themoviedb.org (Let's Encrypt R3 + ISRG Root X1), create network_security_config.xml for both apps restricting cleartext traffic, reference configs in AndroidManifest.xml


https://claude.ai/code/session_01Gd8wxjRjb6cgx3xiKnWFU8