### PR TITLE
Remove boot completion receiver and add token backend URL provider

### DIFF
--- a/app-phone/src/main/AndroidManifest.xml
+++ b/app-phone/src/main/AndroidManifest.xml
@@ -12,7 +12,6 @@
     <!-- No special permission needed for NsdManager, INTERNET covers it -->
 
     <!-- Background work (model updates, token refresh) -->
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
@@ -60,16 +59,6 @@
             android:enabled="true"
             android:exported="false"
             android:foregroundServiceType="dataSync" />
-
-        <!-- Background model updater -->
-        <receiver
-            android:name=".receiver.BootReceiver"
-            android:enabled="true"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
-            </intent-filter>
-        </receiver>
 
     </application>
 </manifest>

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
@@ -17,4 +17,13 @@ object AppModule {
     @Singleton
     @Named("isDebugBuild")
     fun provideIsDebugBuild(): Boolean = BuildConfig.DEBUG
+
+    /**
+     * URL des Token-Proxy-Backends — die TV-App nutzt keinen Token-Proxy,
+     * daher Leerstring. Wird von NetworkModule.provideTokenProxyRetrofit()
+     * benötigt; bei leerem String wird null zurückgegeben.
+     */
+    @Provides
+    @Singleton
+    fun provideTokenBackendUrl(): String = ""
 }


### PR DESCRIPTION
## Summary
This PR removes the boot completion receiver from the phone app and adds a token backend URL provider to the TV app's dependency injection module.

## Key Changes
- **Phone app**: Removed `RECEIVE_BOOT_COMPLETED` permission and the `BootReceiver` component that was triggered on device boot. This eliminates the background model updater that was previously initialized at boot time.
- **TV app**: Added `provideTokenBackendUrl()` provider function to the AppModule that returns an empty string, indicating the TV app does not use a token proxy backend. This provider is required by `NetworkModule.provideTokenProxyRetrofit()`.

## Implementation Details
- The removal of the boot receiver simplifies the phone app's startup flow and reduces unnecessary background initialization.
- The token backend URL provider in the TV app follows the existing dependency injection pattern and allows the network module to handle the empty string case by returning null for the token proxy Retrofit instance.

https://claude.ai/code/session_013RH5ouXRMHFhu6d6JaQCXZ