### PR TITLE
docs: enforce English-only content requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,21 @@ watchbuddy/
 
 ## Key Conventions
 
+### Language — MANDATORY
+
+**All content in this repository must be written in English.** This applies to everything, without exception:
+
+- Code: variable names, function names, class names, constants
+- Comments and documentation strings
+- Commit messages (Conventional Commits, in English)
+- Pull request titles and descriptions
+- GitHub issue titles, descriptions, and comments
+- Markdown files (README, CLAUDE.md, architecture docs, CHANGELOG, etc.)
+- CI/CD configuration and log messages
+- Code review comments
+
+The only exceptions are **localization string resources** (`values-de/`, `values-fr/`, `values-es/`) which contain translated user-facing strings by design. The default `values/strings.xml` must remain in English.
+
 ### Code Style
 - Kotlin official code style (`kotlin.code.style=official`)
 - Compose UI follows single-Activity, screen-level composables


### PR DESCRIPTION
## Summary

- Adds a mandatory "Language — MANDATORY" section to `CLAUDE.md` under Key Conventions
- Requires all repository content (code, comments, commits, PRs, issues, docs, reviews) to be written in English
- Only exception: localization string resources (`values-de/`, `values-fr/`, `values-es/`) which contain translated user-facing strings by design

## Test plan

- [x] Verify `CLAUDE.md` renders correctly
- [x] Confirm the new section is placed logically under Key Conventions

https://claude.ai/code/session_01CDiaasYx8CRG2WmhQsqQ8C