### PR TITLE
feat: make Ollama server URL configurable via Settings UI

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
@@ -4,7 +4,10 @@ import android.content.Context
 import android.util.Log
 import com.justb81.watchbuddy.core.model.LlmBackend
 import com.justb81.watchbuddy.core.model.TmdbEpisode
+import com.justb81.watchbuddy.phone.settings.AppSettings
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -17,12 +20,11 @@ import javax.inject.Singleton
 @Singleton
 class LlmProviderFactory @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val llmOrchestrator: LlmOrchestrator
+    private val llmOrchestrator: LlmOrchestrator,
+    private val settingsRepository: SettingsRepository
 ) {
     companion object {
         private const val TAG = "LlmProviderFactory"
-        // TODO: make configurable via DataStore / Settings UI
-        private const val DEFAULT_OLLAMA_URL = "http://localhost:11434"
     }
 
     /**
@@ -39,7 +41,9 @@ class LlmProviderFactory @Inject constructor(
         ollamaUrl: String? = null
     ): String {
         val config = llmOrchestrator.selectConfig()
-        val providers = buildProviderCascade(config, episodes, ollamaUrl)
+        val savedSettings = settingsRepository.settings.first()
+        val resolvedOllamaUrl = ollamaUrl ?: savedSettings.ollamaUrl
+        val providers = buildProviderCascade(config, episodes, resolvedOllamaUrl)
 
         for (provider in providers) {
             try {
@@ -81,8 +85,7 @@ class LlmProviderFactory @Inject constructor(
         }
 
         // Remote Ollama as next-to-last resort
-        val url = ollamaUrl ?: DEFAULT_OLLAMA_URL
-        providers += RemoteOllamaProvider(url)
+        providers += RemoteOllamaProvider(ollamaUrl ?: AppSettings.DEFAULT_OLLAMA_URL)
 
         // TMDB synopsis fallback is always last
         providers += FallbackProvider(episodes)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/AppSettings.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/AppSettings.kt
@@ -6,5 +6,10 @@ data class AppSettings(
     val authMode: AuthMode = AuthMode.MANAGED,
     val backendUrl: String = "",
     val directClientId: String = "",
-    val companionEnabled: Boolean = false
-)
+    val companionEnabled: Boolean = false,
+    val ollamaUrl: String = DEFAULT_OLLAMA_URL
+) {
+    companion object {
+        const val DEFAULT_OLLAMA_URL = "http://localhost:11434"
+    }
+}

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
@@ -35,6 +35,7 @@ class SettingsRepository @Inject constructor(
         val BACKEND_URL = stringPreferencesKey("backend_url")
         val DIRECT_CLIENT_ID = stringPreferencesKey("direct_client_id")
         val COMPANION_ENABLED = booleanPreferencesKey("companion_enabled")
+        val OLLAMA_URL = stringPreferencesKey("ollama_url")
         val MODEL_READY = booleanPreferencesKey("model_ready")
     }
 
@@ -58,7 +59,8 @@ class SettingsRepository @Inject constructor(
                 ?: AuthMode.MANAGED,
             backendUrl = prefs[Keys.BACKEND_URL] ?: "",
             directClientId = prefs[Keys.DIRECT_CLIENT_ID] ?: "",
-            companionEnabled = prefs[Keys.COMPANION_ENABLED] ?: false
+            companionEnabled = prefs[Keys.COMPANION_ENABLED] ?: false,
+            ollamaUrl = prefs[Keys.OLLAMA_URL] ?: AppSettings.DEFAULT_OLLAMA_URL
         )
     }
 
@@ -68,6 +70,7 @@ class SettingsRepository @Inject constructor(
             prefs[Keys.BACKEND_URL] = settings.backendUrl
             prefs[Keys.DIRECT_CLIENT_ID] = settings.directClientId
             prefs[Keys.COMPANION_ENABLED] = settings.companionEnabled
+            prefs[Keys.OLLAMA_URL] = settings.ollamaUrl
         }
     }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -296,6 +296,23 @@ private fun AdvancedAuthSettings(uiState: SettingsUiState, viewModel: SettingsVi
             else -> {}
         }
 
+        Spacer(Modifier.height(16.dp))
+
+        // Ollama server URL
+        Text(
+            text  = stringResource(R.string.settings_ollama_section),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Spacer(Modifier.height(4.dp))
+        OutlinedTextField(
+            value         = uiState.ollamaUrl,
+            onValueChange = viewModel::setOllamaUrl,
+            label         = { Text(stringResource(R.string.settings_ollama_url)) },
+            modifier      = Modifier.fillMaxWidth(),
+            singleLine    = true
+        )
+
         Spacer(Modifier.height(12.dp))
         Button(
             onClick  = { viewModel.saveAdvancedSettings() },

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -17,6 +17,7 @@ import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
 import com.justb81.watchbuddy.phone.llm.ModelDownloadWorker
 import com.justb81.watchbuddy.phone.server.DeviceCapabilityProvider
 import com.justb81.watchbuddy.phone.settings.AppSettings
+import com.justb81.watchbuddy.phone.settings.AppSettings.Companion.DEFAULT_OLLAMA_URL
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,6 +41,7 @@ data class SettingsUiState(
     val llmModelName: String?      = null,
     val llmDownloadProgress: Int?  = null,   // null = not downloading, 0-100 = progress
     val llmReady: Boolean          = false,
+    val ollamaUrl: String           = DEFAULT_OLLAMA_URL,
     val freeRamMb: Int             = 0,
     val saveSuccess: Boolean       = false
 )
@@ -76,7 +78,8 @@ class SettingsViewModel @Inject constructor(
                 customBackendUrl = saved.backendUrl,
                 directClientId = saved.directClientId,
                 directClientSecret = clientSecret,
-                companionRunning = saved.companionEnabled
+                companionRunning = saved.companionEnabled,
+                ollamaUrl = saved.ollamaUrl
             )
         }
     }
@@ -116,6 +119,10 @@ class SettingsViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(directClientSecret = secret)
     }
 
+    fun setOllamaUrl(url: String) {
+        _uiState.value = _uiState.value.copy(ollamaUrl = url)
+    }
+
     fun saveAdvancedSettings() {
         viewModelScope.launch {
             val state = _uiState.value
@@ -124,7 +131,8 @@ class SettingsViewModel @Inject constructor(
                     authMode = state.authMode,
                     backendUrl = state.customBackendUrl,
                     directClientId = state.directClientId,
-                    companionEnabled = state.companionRunning
+                    companionEnabled = state.companionRunning,
+                    ollamaUrl = state.ollamaUrl
                 )
             )
             settingsRepository.saveClientSecret(state.directClientSecret)

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -56,6 +56,8 @@
     <string name="settings_auth_backend_url">Backend-URL</string>
     <string name="settings_auth_client_id">Client ID</string>
     <string name="settings_auth_client_secret">Client Secret</string>
+    <string name="settings_ollama_section">Remote-LLM</string>
+    <string name="settings_ollama_url">Ollama-Server-URL</string>
     <string name="settings_save">Speichern</string>
     <string name="settings_saved">Einstellungen gespeichert</string>
     <string name="settings_cancel">Abbrechen</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -56,6 +56,8 @@
     <string name="settings_auth_backend_url">URL del backend</string>
     <string name="settings_auth_client_id">Client ID</string>
     <string name="settings_auth_client_secret">Client Secret</string>
+    <string name="settings_ollama_section">LLM remoto</string>
+    <string name="settings_ollama_url">URL del servidor Ollama</string>
     <string name="settings_save">Guardar</string>
     <string name="settings_saved">Ajustes guardados</string>
     <string name="settings_cancel">Cancelar</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -56,6 +56,8 @@
     <string name="settings_auth_backend_url">URL du backend</string>
     <string name="settings_auth_client_id">Client ID</string>
     <string name="settings_auth_client_secret">Client Secret</string>
+    <string name="settings_ollama_section">LLM distant</string>
+    <string name="settings_ollama_url">URL du serveur Ollama</string>
     <string name="settings_save">Enregistrer</string>
     <string name="settings_saved">Paramètres enregistrés</string>
     <string name="settings_cancel">Annuler</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -56,6 +56,8 @@
     <string name="settings_auth_backend_url">Backend URL</string>
     <string name="settings_auth_client_id">Client ID</string>
     <string name="settings_auth_client_secret">Client Secret</string>
+    <string name="settings_ollama_section">Remote LLM</string>
+    <string name="settings_ollama_url">Ollama server URL</string>
     <string name="settings_save">Save</string>
     <string name="settings_saved">Settings saved</string>
     <string name="settings_cancel">Cancel</string>


### PR DESCRIPTION
The Ollama URL was hardcoded as a constant in LlmProviderFactory.
Users running Ollama on a different host/port had no way to change it.

Add the Ollama URL to AppSettings/DataStore, wire it through
SettingsRepository -> SettingsViewModel -> SettingsScreen, and read
the persisted value in LlmProviderFactory's cascade fallback. The
field appears in Advanced Settings under a "Remote LLM" label.

Includes localized strings for EN, DE, FR, and ES.

https://claude.ai/code/session_01DWG27qM4CSKyBzmgRRC8F3