### PR TITLE
ci: run unit tests before APK builds

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -15,8 +15,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  test:
+    name: Unit Tests
+    if: "!startsWith(github.head_ref, 'release-please--')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Run unit tests
+        run: ./gradlew test
+
   build-phone:
     name: Build Phone APK
+    needs: test
     if: "!startsWith(github.head_ref, 'release-please--')"
     runs-on: ubuntu-latest
     steps:
@@ -44,6 +64,7 @@ jobs:
 
   build-tv:
     name: Build TV APK
+    needs: test
     if: "!startsWith(github.head_ref, 'release-please--')"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Add a `test` job to `build-android.yml` that runs `./gradlew test` (all 261 unit tests)
- Both `build-phone` and `build-tv` now depend on the `test` job via `needs: test`
- If any unit test fails, APK builds are skipped and the CI run is red

## Test plan
- [ ] Verify the `test` job appears in the Actions workflow
- [ ] Confirm `build-phone` and `build-tv` only start after `test` succeeds
- [ ] Break a test intentionally on a branch and verify APKs are not built

https://claude.ai/code/session_014VWKjrhKLagAEL6dFb4TXb