### PR TITLE
fix: resolve 7 high-priority bugs across Android apps and backend

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
@@ -8,6 +8,7 @@ import com.justb81.watchbuddy.phone.settings.AppSettings
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
+import okhttp3.OkHttpClient
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -21,7 +22,8 @@ import javax.inject.Singleton
 class LlmProviderFactory @Inject constructor(
     @ApplicationContext private val context: Context,
     private val llmOrchestrator: LlmOrchestrator,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val httpClient: OkHttpClient
 ) {
     companion object {
         private const val TAG = "LlmProviderFactory"
@@ -85,7 +87,7 @@ class LlmProviderFactory @Inject constructor(
         }
 
         // Remote Ollama as next-to-last resort
-        providers += RemoteOllamaProvider(ollamaUrl ?: AppSettings.DEFAULT_OLLAMA_URL)
+        providers += RemoteOllamaProvider(ollamaUrl ?: AppSettings.DEFAULT_OLLAMA_URL, httpClient = httpClient)
 
         // TMDB synopsis fallback is always last
         providers += FallbackProvider(episodes)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorker.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorker.kt
@@ -19,7 +19,8 @@ import java.util.concurrent.TimeUnit
 class ModelDownloadWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val httpClient: OkHttpClient
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
@@ -48,13 +49,13 @@ class ModelDownloadWorker @AssistedInject constructor(
     }
 
     private suspend fun downloadFile(url: String, target: File) {
-        val client = OkHttpClient.Builder()
+        val downloadClient = httpClient.newBuilder()
             .connectTimeout(30, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .build()
 
         val request = Request.Builder().url(url).build()
-        val response = client.newCall(request).execute()
+        val response = downloadClient.newCall(request).execute()
 
         if (!response.isSuccessful) {
             throw RuntimeException("HTTP ${response.code}: ${response.message}")

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/RemoteOllamaProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/RemoteOllamaProvider.kt
@@ -5,8 +5,10 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import java.net.HttpURLConnection
-import java.net.URL
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 
 /**
  * LLM provider that sends prompts to a remote Ollama server via HTTP POST.
@@ -16,7 +18,8 @@ import java.net.URL
  */
 class RemoteOllamaProvider(
     private val serverUrl: String,
-    private val model: String = "gemma3:4b"
+    private val model: String = "gemma3:4b",
+    private val httpClient: OkHttpClient
 ) : LlmProvider {
 
     override val displayName: String = "Ollama ($model @ $serverUrl)"
@@ -36,32 +39,32 @@ class RemoteOllamaProvider(
     private val json = Json { ignoreUnknownKeys = true }
 
     override suspend fun generate(prompt: String): String = withContext(Dispatchers.IO) {
-        val url = URL("${serverUrl.trimEnd('/')}/api/generate")
-        val connection = url.openConnection() as HttpURLConnection
-        try {
-            connection.requestMethod = "POST"
-            connection.setRequestProperty("Content-Type", "application/json")
-            connection.doOutput = true
-            connection.connectTimeout = 10_000
-            connection.readTimeout = 120_000 // LLM generation can be slow
+        val url = "${serverUrl.trimEnd('/')}/api/generate"
+        val body = json.encodeToString(OllamaRequest(model, prompt))
 
-            val body = json.encodeToString(OllamaRequest(model, prompt))
-            connection.outputStream.bufferedWriter().use { it.write(body) }
+        val request = Request.Builder()
+            .url(url)
+            .post(body.toRequestBody("application/json".toMediaType()))
+            .build()
 
-            val code = connection.responseCode
-            if (code != 200) {
-                val error = connection.errorStream?.bufferedReader()?.readText() ?: "unknown error"
-                throw IllegalStateException("Ollama returned HTTP $code: $error")
+        val ollamaClient = httpClient.newBuilder()
+            .connectTimeout(10, java.util.concurrent.TimeUnit.SECONDS)
+            .readTimeout(120, java.util.concurrent.TimeUnit.SECONDS)
+            .build()
+
+        val response = ollamaClient.newCall(request).execute()
+        response.use { res ->
+            if (!res.isSuccessful) {
+                val error = res.body?.string() ?: "unknown error"
+                throw IllegalStateException("Ollama returned HTTP ${res.code}: $error")
             }
 
-            val responseBody = connection.inputStream.bufferedReader().readText()
+            val responseBody = res.body?.string() ?: throw IllegalStateException("Empty response body")
             val parsed = json.decodeFromString<OllamaResponse>(responseBody)
             if (parsed.response.isBlank()) {
                 throw IllegalStateException("Ollama returned empty response")
             }
             parsed.response
-        } finally {
-            connection.disconnect()
         }
     }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.phone.server.CompanionHttpServer
@@ -19,6 +20,7 @@ import javax.inject.Inject
 class CompanionService : Service() {
 
     companion object {
+        private const val TAG = "CompanionService"
         const val CHANNEL_ID = "companion_service"
         private const val NOTIFICATION_ID = 1
         private const val NSD_SERVICE_TYPE = "_http._tcp."
@@ -88,10 +90,18 @@ class CompanionService : Service() {
         }
 
         val listener = object : NsdManager.RegistrationListener {
-            override fun onServiceRegistered(info: NsdServiceInfo) {}
-            override fun onRegistrationFailed(info: NsdServiceInfo, errorCode: Int) {}
-            override fun onServiceUnregistered(info: NsdServiceInfo) {}
-            override fun onUnregistrationFailed(info: NsdServiceInfo, errorCode: Int) {}
+            override fun onServiceRegistered(info: NsdServiceInfo) {
+                Log.i(TAG, "NSD service registered: ${info.serviceName}")
+            }
+            override fun onRegistrationFailed(info: NsdServiceInfo, errorCode: Int) {
+                Log.e(TAG, "NSD registration failed: error=$errorCode, service=${info.serviceName}")
+            }
+            override fun onServiceUnregistered(info: NsdServiceInfo) {
+                Log.i(TAG, "NSD service unregistered: ${info.serviceName}")
+            }
+            override fun onUnregistrationFailed(info: NsdServiceInfo, errorCode: Int) {
+                Log.e(TAG, "NSD unregistration failed: error=$errorCode, service=${info.serviceName}")
+            }
         }
 
         nsdRegistrationListener = listener

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -79,14 +79,15 @@ class PhoneDiscoveryManager @Inject constructor(
             .maxByOrNull { it.score }
 
     private fun fetchCapabilityAndAdd(serviceInfo: NsdServiceInfo) {
-        val url = "http://${serviceInfo.host.hostAddress}:${serviceInfo.port}${CAPABILITY_PATH}"
+        val host = serviceInfo.host?.hostAddress ?: return
+        val url = "http://${host}:${serviceInfo.port}${CAPABILITY_PATH}"
         try {
             val response = httpClient.newCall(Request.Builder().url(url).build()).execute()
             val capability = response.body?.string()?.let {
                 Json.decodeFromString<DeviceCapability>(it)
             }
             val score = calculateScore(capability)
-            val baseUrl = "http://${serviceInfo.host.hostAddress}:${serviceInfo.port}/"
+            val baseUrl = "http://${host}:${serviceInfo.port}/"
             val phone = DiscoveredPhone(serviceInfo, capability, score, baseUrl)
             _discoveredPhones.value = (_discoveredPhones.value
                 .filter { it.serviceInfo.serviceName != serviceInfo.serviceName } + phone)

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
@@ -43,7 +43,7 @@ class MediaSessionScrobbler @Inject constructor(
     private val _pendingConfirmation = MutableSharedFlow<ScrobbleCandidate>()
     val pendingConfirmation: SharedFlow<ScrobbleCandidate> = _pendingConfirmation
 
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var pollingJob: Job? = null
 
     /** Track which media title is currently being scrobbled to avoid duplicate starts. */
@@ -53,6 +53,7 @@ class MediaSessionScrobbler @Inject constructor(
         val sessionManager = context.getSystemService(Context.MEDIA_SESSION_SERVICE)
                 as MediaSessionManager
 
+        scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
         pollingJob = scope.launch {
             while (isActive) {
                 try {
@@ -83,6 +84,8 @@ class MediaSessionScrobbler @Inject constructor(
 
     fun stopListening() {
         pollingJob?.cancel()
+        scope.cancel()
+        currentlyScrobbling = null
     }
 
     private suspend fun processPlayingMedia(packageName: String, rawTitle: String) {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvTokenCache.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvTokenCache.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.tv.scrobbler
 import android.util.Log
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -23,22 +24,21 @@ class TvTokenCache @Inject constructor(
         private const val CACHE_TTL = 30 * 60 * 1000L // 30 minutes
     }
 
-    @Volatile
-    private var cachedToken: String? = null
-    private var tokenTimestamp: Long = 0L
+    private data class CachedToken(val token: String, val timestamp: Long)
+
+    private val cached = AtomicReference<CachedToken?>(null)
 
     suspend fun getToken(): String? {
         val now = System.currentTimeMillis()
-        cachedToken?.let { token ->
-            if (now - tokenTimestamp < CACHE_TTL) return token
+        cached.get()?.let { entry ->
+            if (now - entry.timestamp < CACHE_TTL) return entry.token
         }
 
         val phone = phoneDiscovery.getBestPhone() ?: return null
         return try {
             val client = phoneApiClientFactory.createClient(phone.baseUrl)
             val response = client.getAccessToken()
-            cachedToken = response.accessToken
-            tokenTimestamp = System.currentTimeMillis()
+            cached.set(CachedToken(response.accessToken, System.currentTimeMillis()))
             response.accessToken
         } catch (e: Exception) {
             Log.w(TAG, "Failed to fetch access token from phone", e)
@@ -47,7 +47,6 @@ class TvTokenCache @Inject constructor(
     }
 
     fun invalidate() {
-        cachedToken = null
-        tokenTimestamp = 0L
+        cached.set(null)
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModel.kt
@@ -8,11 +8,18 @@ import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import javax.inject.Inject
+
+@Serializable
+private data class RecapResponse(val html: String)
+
+private val recapJson = Json { ignoreUnknownKeys = true }
 
 sealed class RecapUiState {
     object Idle : RecapUiState()
@@ -51,7 +58,7 @@ class RecapViewModel @Inject constructor(
                 val deviceName = phone.capability?.deviceName ?: getApplication<Application>().getString(R.string.tv_default_device_name)
                 _state.value = RecapUiState.Generating(deviceName)
                 try {
-                    val host = phone.serviceInfo.host.hostAddress
+                    val host = phone.serviceInfo.host?.hostAddress ?: continue
                     val port = phone.serviceInfo.port
                     val url  = "http://$host:$port/recap/$traktShowId"
 
@@ -64,9 +71,7 @@ class RecapViewModel @Inject constructor(
 
                     if (response.isSuccessful) {
                         val body = response.body?.string() ?: ""
-                        // Parse {"html": "..."} from response
-                        val html = Regex(""""html"\s*:\s*"(.*?)"""", RegexOption.DOT_MATCHES_ALL)
-                            .find(body)?.groupValues?.get(1) ?: body
+                        val html = recapJson.decodeFromString<RecapResponse>(body).html
                         _state.value = RecapUiState.Ready(html)
                         return@launch
                     }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,6 +7,9 @@ RUN npm install --production
 
 COPY src/ ./src/
 
+RUN addgroup -S app && adduser -S app -G app
+USER app
+
 EXPOSE 3000
 
 CMD ["node", "src/index.js"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
     "dev": "nodemon src/index.js"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.18.2",
     "node-fetch": "^3.3.2",
     "dotenv": "^16.3.1",

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -18,9 +18,14 @@ import 'dotenv/config';
 import express from 'express';
 import fetch from 'node-fetch';
 import rateLimit from 'express-rate-limit';
+import cors from 'cors';
 
 const app = express();
 app.use(express.json());
+
+// CORS — restrict to configured origins or disable entirely
+const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',').map(o => o.trim()).filter(Boolean);
+app.use(cors(allowedOrigins?.length ? { origin: allowedOrigins } : { origin: false }));
 
 // Rate limiting — Trakt allows 1000 calls/5min per app
 const limiter = rateLimit({
@@ -31,11 +36,28 @@ const limiter = rateLimit({
 app.use('/trakt', limiter);
 
 const TRAKT_API = 'https://api.trakt.tv';
+const FETCH_TIMEOUT_MS = 15_000;
 const { TRAKT_CLIENT_ID, TRAKT_CLIENT_SECRET, PORT = 3000 } = process.env;
 
 if (!TRAKT_CLIENT_ID || !TRAKT_CLIENT_SECRET) {
   console.error('ERROR: TRAKT_CLIENT_ID and TRAKT_CLIENT_SECRET must be set in .env');
   process.exit(1);
+}
+
+/** Input validation: alphanumeric string with limited length. */
+function isValidToken(value) {
+  return typeof value === 'string' && value.length > 0 && value.length <= 256 && /^[a-zA-Z0-9_\-]+$/.test(value);
+}
+
+/** Fetch with timeout via AbortController. */
+async function fetchWithTimeout(url, options) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    return await fetch(url, { ...options, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 // ── POST /trakt/token ─────────────────────────────────────────────────────────
@@ -44,9 +66,10 @@ if (!TRAKT_CLIENT_ID || !TRAKT_CLIENT_SECRET) {
 app.post('/trakt/token', async (req, res) => {
   const { code } = req.body;
   if (!code) return res.status(400).json({ error: 'Missing code' });
+  if (!isValidToken(code)) return res.status(400).json({ error: 'Invalid code format' });
 
   try {
-    const traktRes = await fetch(`${TRAKT_API}/oauth/device/token`, {
+    const traktRes = await fetchWithTimeout(`${TRAKT_API}/oauth/device/token`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -71,6 +94,10 @@ app.post('/trakt/token', async (req, res) => {
       scope: data.scope
     });
   } catch (err) {
+    if (err.name === 'AbortError') {
+      console.error('Token exchange timed out');
+      return res.status(504).json({ error: 'Upstream timeout' });
+    }
     console.error('Token exchange error:', err);
     return res.status(502).json({ error: 'Upstream error' });
   }
@@ -81,9 +108,10 @@ app.post('/trakt/token', async (req, res) => {
 app.post('/trakt/token/refresh', async (req, res) => {
   const { refresh_token } = req.body;
   if (!refresh_token) return res.status(400).json({ error: 'Missing refresh_token' });
+  if (!isValidToken(refresh_token)) return res.status(400).json({ error: 'Invalid refresh_token format' });
 
   try {
-    const traktRes = await fetch(`${TRAKT_API}/oauth/token`, {
+    const traktRes = await fetchWithTimeout(`${TRAKT_API}/oauth/token`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -103,6 +131,10 @@ app.post('/trakt/token/refresh', async (req, res) => {
       expires_in: data.expires_in
     });
   } catch (err) {
+    if (err.name === 'AbortError') {
+      console.error('Token refresh timed out');
+      return res.status(504).json({ error: 'Upstream timeout' });
+    }
     console.error('Token refresh error:', err);
     return res.status(502).json({ error: 'Upstream error' });
   }


### PR DESCRIPTION
- #56: Null-check serviceInfo.host before accessing hostAddress in NSD
  callbacks (PhoneDiscoveryManager, RecapViewModel) to prevent NPE
- #59: Replace separate @Volatile token + timestamp fields with
  AtomicReference<CachedToken> in TvTokenCache to fix race condition
- #58: Cancel full CoroutineScope in MediaSessionScrobbler.stopListening()
  and recreate in startListening() to prevent memory leaks
- #60: Replace fragile regex JSON extraction with kotlinx.serialization
  RecapResponse model in RecapViewModel
- #57: Replace ad-hoc HttpURLConnection and per-call OkHttpClient with
  injected shared OkHttpClient in RemoteOllamaProvider and
  ModelDownloadWorker
- #44: Add logging to all NSD RegistrationListener callbacks in
  CompanionService instead of silent no-ops
- #45: Harden backend token proxy — add CORS middleware, fetch timeouts
  via AbortController, input validation for code/refresh_token, and
  non-root Docker user

https://claude.ai/code/session_01DRjHXK8r8CLKgmsPGvYN59