### PR TITLE
Add logging and improve thread safety in services

### DIFF
--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -21,7 +21,7 @@ android {
         versionCode = 1000 + ciVersionCode
 
         // versionName: release-please setzt VERSION_NAME, Fallback auf x-generic-string
-        versionName = System.getenv("VERSION_NAME") ?: "0.1.0" // x]release-please-version
+        versionName = System.getenv("VERSION_NAME") ?: "0.1.0" // x-release-please-version
 
         // ── Trakt-Konfiguration ───────────────────────────────────────────────
         // Leer lassen → App nutzt keinen Token-Proxy / zeigt keinen Trakt-Login.

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
@@ -9,6 +9,7 @@ import android.content.Intent
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.os.IBinder
+import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.phone.server.CompanionHttpServer
@@ -19,6 +20,7 @@ import javax.inject.Inject
 class CompanionService : Service() {
 
     companion object {
+        private const val TAG = "CompanionService"
         const val CHANNEL_ID = "companion_service"
         private const val NOTIFICATION_ID = 1
         private const val NSD_SERVICE_TYPE = "_http._tcp."
@@ -88,10 +90,18 @@ class CompanionService : Service() {
         }
 
         val listener = object : NsdManager.RegistrationListener {
-            override fun onServiceRegistered(info: NsdServiceInfo) {}
-            override fun onRegistrationFailed(info: NsdServiceInfo, errorCode: Int) {}
-            override fun onServiceUnregistered(info: NsdServiceInfo) {}
-            override fun onUnregistrationFailed(info: NsdServiceInfo, errorCode: Int) {}
+            override fun onServiceRegistered(info: NsdServiceInfo) {
+                Log.i(TAG, "NSD service registered: ${info.serviceName}")
+            }
+            override fun onRegistrationFailed(info: NsdServiceInfo, errorCode: Int) {
+                Log.e(TAG, "NSD registration failed: error=$errorCode, service=${info.serviceName}")
+            }
+            override fun onServiceUnregistered(info: NsdServiceInfo) {
+                Log.i(TAG, "NSD service unregistered: ${info.serviceName}")
+            }
+            override fun onUnregistrationFailed(info: NsdServiceInfo, errorCode: Int) {
+                Log.e(TAG, "NSD unregistration failed: error=$errorCode, service=${info.serviceName}")
+            }
         }
 
         nsdRegistrationListener = listener

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -21,7 +21,7 @@ android {
         versionCode = 2000 + ciVersionCode
 
         // versionName: release-please setzt VERSION_NAME, Fallback auf x-generic-string
-        versionName = System.getenv("VERSION_NAME") ?: "0.1.0" // x]release-please-version
+        versionName = System.getenv("VERSION_NAME") ?: "0.1.0" // x-release-please-version
     }
 
     // CI-Signing: Keystore-Pfad + Credentials über Umgebungsvariablen

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -79,14 +79,15 @@ class PhoneDiscoveryManager @Inject constructor(
             .maxByOrNull { it.score }
 
     private fun fetchCapabilityAndAdd(serviceInfo: NsdServiceInfo) {
-        val url = "http://${serviceInfo.host.hostAddress}:${serviceInfo.port}${CAPABILITY_PATH}"
+        val hostAddress = serviceInfo.host?.hostAddress ?: return
+        val url = "http://${hostAddress}:${serviceInfo.port}${CAPABILITY_PATH}"
         try {
             val response = httpClient.newCall(Request.Builder().url(url).build()).execute()
             val capability = response.body?.string()?.let {
                 Json.decodeFromString<DeviceCapability>(it)
             }
             val score = calculateScore(capability)
-            val baseUrl = "http://${serviceInfo.host.hostAddress}:${serviceInfo.port}/"
+            val baseUrl = "http://${hostAddress}:${serviceInfo.port}/"
             val phone = DiscoveredPhone(serviceInfo, capability, score, baseUrl)
             _discoveredPhones.value = (_discoveredPhones.value
                 .filter { it.serviceInfo.serviceName != serviceInfo.serviceName } + phone)

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
@@ -43,13 +43,14 @@ class MediaSessionScrobbler @Inject constructor(
     private val _pendingConfirmation = MutableSharedFlow<ScrobbleCandidate>()
     val pendingConfirmation: SharedFlow<ScrobbleCandidate> = _pendingConfirmation
 
-    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var pollingJob: Job? = null
 
     /** Track which media title is currently being scrobbled to avoid duplicate starts. */
     private var currentlyScrobbling: String? = null
 
     fun startListening(notificationListenerComponent: ComponentName) {
+        scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
         val sessionManager = context.getSystemService(Context.MEDIA_SESSION_SERVICE)
                 as MediaSessionManager
 
@@ -83,6 +84,7 @@ class MediaSessionScrobbler @Inject constructor(
 
     fun stopListening() {
         pollingJob?.cancel()
+        scope.cancel()
     }
 
     private suspend fun processPlayingMedia(packageName: String, rawTitle: String) {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvTokenCache.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvTokenCache.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.tv.scrobbler
 import android.util.Log
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import java.util.concurrent.atomic.AtomicReference
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -23,22 +24,21 @@ class TvTokenCache @Inject constructor(
         private const val CACHE_TTL = 30 * 60 * 1000L // 30 minutes
     }
 
-    @Volatile
-    private var cachedToken: String? = null
-    private var tokenTimestamp: Long = 0L
+    private data class CachedEntry(val token: String, val timestamp: Long)
+
+    private val cached = AtomicReference<CachedEntry?>(null)
 
     suspend fun getToken(): String? {
         val now = System.currentTimeMillis()
-        cachedToken?.let { token ->
-            if (now - tokenTimestamp < CACHE_TTL) return token
+        cached.get()?.let { entry ->
+            if (now - entry.timestamp < CACHE_TTL) return entry.token
         }
 
         val phone = phoneDiscovery.getBestPhone() ?: return null
         return try {
             val client = phoneApiClientFactory.createClient(phone.baseUrl)
             val response = client.getAccessToken()
-            cachedToken = response.accessToken
-            tokenTimestamp = System.currentTimeMillis()
+            cached.set(CachedEntry(response.accessToken, System.currentTimeMillis()))
             response.accessToken
         } catch (e: Exception) {
             Log.w(TAG, "Failed to fetch access token from phone", e)
@@ -47,7 +47,6 @@ class TvTokenCache @Inject constructor(
     }
 
     fun invalidate() {
-        cachedToken = null
-        tokenTimestamp = 0L
+        cached.set(null)
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModel.kt
@@ -8,11 +8,18 @@ import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import javax.inject.Inject
+
+@Serializable
+private data class RecapResponse(val html: String)
+
+private val lenientJson = Json { ignoreUnknownKeys = true }
 
 sealed class RecapUiState {
     object Idle : RecapUiState()
@@ -51,7 +58,7 @@ class RecapViewModel @Inject constructor(
                 val deviceName = phone.capability?.deviceName ?: getApplication<Application>().getString(R.string.tv_default_device_name)
                 _state.value = RecapUiState.Generating(deviceName)
                 try {
-                    val host = phone.serviceInfo.host.hostAddress
+                    val host = phone.serviceInfo.host?.hostAddress ?: continue
                     val port = phone.serviceInfo.port
                     val url  = "http://$host:$port/recap/$traktShowId"
 
@@ -64,10 +71,8 @@ class RecapViewModel @Inject constructor(
 
                     if (response.isSuccessful) {
                         val body = response.body?.string() ?: ""
-                        // Parse {"html": "..."} from response
-                        val html = Regex(""""html"\s*:\s*"(.*?)"""", RegexOption.DOT_MATCHES_ALL)
-                            .find(body)?.groupValues?.get(1) ?: body
-                        _state.value = RecapUiState.Ready(html)
+                        val recap = lenientJson.decodeFromString<RecapResponse>(body)
+                        _state.value = RecapUiState.Ready(recap.html)
                         return@launch
                     }
                 } catch (e: Exception) {


### PR DESCRIPTION
## Summary
This PR adds comprehensive logging to NSD service lifecycle events, improves thread safety in token caching, enhances JSON parsing robustness, and fixes resource management issues across the companion and TV app services.

## Key Changes

### Logging Improvements
- **CompanionService**: Added detailed logging for NSD (Network Service Discovery) registration lifecycle events (registration, unregistration, and their failures) to aid in debugging service discovery issues

### Thread Safety & Concurrency
- **TvTokenCache**: Replaced `@Volatile` fields with `AtomicReference<CachedEntry>` for safer concurrent access to cached tokens and timestamps, encapsulating both values in a data class
- **MediaSessionScrobbler**: Fixed scope lifecycle management by reinitializing the `CoroutineScope` in `startListening()` and properly canceling it in `stopListening()` to prevent resource leaks

### JSON Parsing & Null Safety
- **RecapViewModel**: 
  - Replaced regex-based JSON parsing with proper `kotlinx.serialization` deserialization for more robust and maintainable code
  - Added null-safe handling for `serviceInfo.host?.hostAddress` to prevent potential NPEs
- **PhoneDiscoveryManager**: Added null-safe handling for `serviceInfo.host?.hostAddress` with early return on null

### Build Configuration
- Fixed release-please version comment syntax in both `app-phone` and `app-tv` build.gradle.kts files (changed `x]release-please-version` to `x-release-please-version`)

## Notable Implementation Details
- The `CachedEntry` data class in `TvTokenCache` provides a clean way to atomically manage both token and timestamp together
- Proper coroutine scope lifecycle management in `MediaSessionScrobbler` ensures resources are cleaned up when listening stops
- Lenient JSON deserialization configuration allows graceful handling of unexpected response fields

Closes #60 - Replaced fragile regex JSON extraction with kotlinx.serialization RecapResponse data class in RecapViewModel.kt
Closes #59 - Fixed race condition between cachedToken and tokenTimestamp by using AtomicReference<CachedEntry> for atomic reads/writes in TvTokenCache.kt
Closes #58 - Cancel full CoroutineScope in stopListening() and recreate in startListening() to prevent memory leaks in MediaSessionScrobbler.kt
Closes #56 - Added null-safe access (host?.hostAddress) with early return/continue to prevent NPE on partial NSD resolution in PhoneDiscoveryManager.kt, RecapViewModel.kt
Closes #44 - Added Log.i/Log.e to all 4 NSD RegistrationListener callbacks instead of empty no-ops in CompanionService.kt


https://claude.ai/code/session_01CTABrdg5mpQqC7SBuiQECz