### PR TITLE
fix(backend): harden token proxy with timeouts, validation, and security headers

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -3,28 +3,37 @@ name: Build Android APKs
 on:
   push:
     branches: [main, develop]
-    paths:
-      - 'app-phone/**'
-      - 'app-tv/**'
-      - 'core/**'
-      - '*.gradle.kts'
-      - 'gradle/**'
-      - 'gradle.properties'
   pull_request:
     branches: [main]
-    paths:
-      - 'app-phone/**'
-      - 'app-tv/**'
-      - 'core/**'
-      - '*.gradle.kts'
-      - 'gradle/**'
-      - 'gradle.properties'
   workflow_dispatch:
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'release-please--')"
+    permissions:
+      pull-requests: read
+    outputs:
+      android: ${{ steps.filter.outputs.android }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            android:
+              - 'app-phone/**'
+              - 'app-tv/**'
+              - 'core/**'
+              - '*.gradle.kts'
+              - 'gradle/**'
+              - 'gradle.properties'
+
   test:
     name: Unit Tests
-    if: "!startsWith(github.head_ref, 'release-please--')"
+    needs: changes
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -43,8 +52,8 @@ jobs:
 
   build-phone:
     name: Build Phone APK
-    needs: test
-    if: "!startsWith(github.head_ref, 'release-please--')"
+    needs: [changes, test]
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -71,8 +80,8 @@ jobs:
 
   build-tv:
     name: Build TV APK
-    needs: test
-    if: "!startsWith(github.head_ref, 'release-please--')"
+    needs: [changes, test]
+    if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -3,18 +3,32 @@ name: Backend Tests
 on:
   push:
     branches: [main, develop]
-    paths:
-      - 'backend/**'
   pull_request:
     branches: [main]
-    paths:
-      - 'backend/**'
   workflow_dispatch:
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.head_ref, 'release-please--')"
+    permissions:
+      pull-requests: read
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'backend/**'
+
   test:
     name: Backend Tests
-    if: "!startsWith(github.head_ref, 'release-please--')"
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -25,7 +39,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: backend/package-lock.json
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,5 +3,5 @@ TRAKT_CLIENT_ID=your_trakt_client_id_here
 TRAKT_CLIENT_SECRET=your_trakt_client_secret_here
 PORT=3000
 
-# Optional: restrict which origins can call this proxy
+# CORS is not enabled — this proxy is called server-to-server from Android apps.
 # ALLOWED_ORIGINS=com.justb81.watchbuddy

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,14 @@
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 
-COPY package.json ./
-RUN npm install --production
+COPY package.json package-lock.json ./
+RUN npm ci --production
 
 COPY src/ ./src/
+
+# Run as non-root
+USER node
 
 EXPOSE 3000
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,6 +11,7 @@
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
+        "helmet": "^8.0.0",
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
@@ -1840,6 +1841,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/http-errors": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,10 +11,11 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "express": "^4.18.2",
-    "node-fetch": "^3.3.2",
     "dotenv": "^16.3.1",
-    "express-rate-limit": "^7.1.5"
+    "express": "^4.18.2",
+    "express-rate-limit": "^7.1.5",
+    "helmet": "^8.0.0",
+    "node-fetch": "^3.3.2"
   },
   "devDependencies": {
     "nodemon": "^3.0.2",

--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -12,12 +12,13 @@ function mockFetch(status, body) {
 }
 
 /** Default config with fake credentials and a mock fetch. */
-function buildApp(fetchFn) {
+function buildApp(fetchFn, overrides = {}) {
   return createApp({
     clientId: 'test-client-id',
     clientSecret: 'test-client-secret',
     traktApi: 'https://api.trakt.tv',
     fetchFn,
+    ...overrides,
   });
 }
 
@@ -29,6 +30,16 @@ describe('GET /health', () => {
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ status: 'ok' });
+  });
+});
+
+// ── Security headers ───────────────────────────────────────────────────────
+
+describe('Security headers (helmet)', () => {
+  it('sets security headers via helmet', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    const res = await request(app).get('/health');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
   });
 });
 
@@ -135,6 +146,52 @@ describe('POST /trakt/token', () => {
     expect(res.status).toBe(429);
     expect(res.body).toEqual({ error: 'rate_limit_exceeded' });
   });
+
+  it('returns 400 when code is not a string', async () => {
+    const res = await request(app)
+      .post('/trakt/token')
+      .send({ code: 12345 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('code must be a string');
+  });
+
+  it('returns 400 when code exceeds max length', async () => {
+    const res = await request(app)
+      .post('/trakt/token')
+      .send({ code: 'a'.repeat(257) });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('code exceeds max length');
+  });
+
+  it('returns 400 when code contains invalid characters', async () => {
+    const res = await request(app)
+      .post('/trakt/token')
+      .send({ code: 'bad code!@#' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('code contains invalid characters');
+  });
+
+  it('returns 504 when upstream fetch times out', async () => {
+    const hangingFetch = vi.fn().mockImplementation((_url, options) => {
+      return new Promise((_resolve, reject) => {
+        if (options?.signal) {
+          options.signal.addEventListener('abort', () => {
+            const err = new Error('The operation was aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }
+      });
+    });
+    const timeoutApp = buildApp(hangingFetch, { fetchTimeoutMs: 50 });
+
+    const res = await request(timeoutApp)
+      .post('/trakt/token')
+      .send({ code: 'device-code-abc' });
+
+    expect(res.status).toBe(504);
+    expect(res.body).toEqual({ error: 'Upstream timeout' });
+  });
 });
 
 // ── Token refresh endpoint ──────────────────────────────────────────────────
@@ -224,6 +281,52 @@ describe('POST /trakt/token/refresh', () => {
 
     expect(res.status).toBe(502);
     expect(res.body).toEqual({ error: 'Upstream error' });
+  });
+
+  it('returns 400 when refresh_token is not a string', async () => {
+    const res = await request(app)
+      .post('/trakt/token/refresh')
+      .send({ refresh_token: ['array'] });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('refresh_token must be a string');
+  });
+
+  it('returns 400 when refresh_token exceeds max length', async () => {
+    const res = await request(app)
+      .post('/trakt/token/refresh')
+      .send({ refresh_token: 'x'.repeat(257) });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('refresh_token exceeds max length');
+  });
+
+  it('returns 400 when refresh_token contains invalid characters', async () => {
+    const res = await request(app)
+      .post('/trakt/token/refresh')
+      .send({ refresh_token: 'has spaces and $pecial' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('refresh_token contains invalid characters');
+  });
+
+  it('returns 504 when upstream fetch times out', async () => {
+    const hangingFetch = vi.fn().mockImplementation((_url, options) => {
+      return new Promise((_resolve, reject) => {
+        if (options?.signal) {
+          options.signal.addEventListener('abort', () => {
+            const err = new Error('The operation was aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }
+      });
+    });
+    const timeoutApp = buildApp(hangingFetch, { fetchTimeoutMs: 50 });
+
+    const res = await request(timeoutApp)
+      .post('/trakt/token/refresh')
+      .send({ refresh_token: 'old-ref-token' });
+
+    expect(res.status).toBe(504);
+    expect(res.body).toEqual({ error: 'Upstream timeout' });
   });
 });
 

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -7,7 +7,25 @@
 
 import express from 'express';
 import fetch from 'node-fetch';
+import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
+
+const TOKEN_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const MAX_TOKEN_LENGTH = 256;
+
+/**
+ * Validates a token-like string field.
+ * @param {*} value - The value to validate
+ * @param {string} fieldName - Human-readable field name for error messages
+ * @returns {string|null} Error message, or null if valid
+ */
+function validateField(value, fieldName) {
+  if (!value) return `Missing ${fieldName}`;
+  if (typeof value !== 'string') return `${fieldName} must be a string`;
+  if (value.length > MAX_TOKEN_LENGTH) return `${fieldName} exceeds max length`;
+  if (!TOKEN_PATTERN.test(value)) return `${fieldName} contains invalid characters`;
+  return null;
+}
 
 /**
  * Creates a configured Express app for the Trakt token proxy.
@@ -17,6 +35,7 @@ import rateLimit from 'express-rate-limit';
  * @param {string} config.clientSecret - Trakt client secret
  * @param {string} [config.traktApi]   - Trakt API base URL (default: https://api.trakt.tv)
  * @param {Function} [config.fetchFn]  - fetch implementation (default: node-fetch)
+ * @param {number} [config.fetchTimeoutMs] - Upstream fetch timeout in ms (default: 15000)
  * @returns {import('express').Express}
  */
 export function createApp(config) {
@@ -25,9 +44,21 @@ export function createApp(config) {
     clientSecret,
     traktApi = 'https://api.trakt.tv',
     fetchFn = fetch,
+    fetchTimeoutMs = 15_000,
   } = config;
 
+  async function fetchWithTimeout(url, options) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), fetchTimeoutMs);
+    try {
+      return await fetchFn(url, { ...options, signal: controller.signal });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   const app = express();
+  app.use(helmet());
   app.use(express.json());
 
   // Rate limiting — Trakt allows 1000 calls/5min per app
@@ -43,10 +74,11 @@ export function createApp(config) {
   // Calls Trakt /oauth/device/token with server-side secret injected
   app.post('/trakt/token', async (req, res) => {
     const { code } = req.body;
-    if (!code) return res.status(400).json({ error: 'Missing code' });
+    const codeError = validateField(code, 'code');
+    if (codeError) return res.status(400).json({ error: codeError });
 
     try {
-      const traktRes = await fetchFn(`${traktApi}/oauth/device/token`, {
+      const traktRes = await fetchWithTimeout(`${traktApi}/oauth/device/token`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -71,6 +103,10 @@ export function createApp(config) {
         scope: data.scope,
       });
     } catch (err) {
+      if (err.name === 'AbortError') {
+        console.error('Token exchange timeout');
+        return res.status(504).json({ error: 'Upstream timeout' });
+      }
       console.error('Token exchange error:', err);
       return res.status(502).json({ error: 'Upstream error' });
     }
@@ -80,10 +116,11 @@ export function createApp(config) {
   // Body: { "refresh_token": "<token>" }
   app.post('/trakt/token/refresh', async (req, res) => {
     const { refresh_token } = req.body;
-    if (!refresh_token) return res.status(400).json({ error: 'Missing refresh_token' });
+    const rtError = validateField(refresh_token, 'refresh_token');
+    if (rtError) return res.status(400).json({ error: rtError });
 
     try {
-      const traktRes = await fetchFn(`${traktApi}/oauth/token`, {
+      const traktRes = await fetchWithTimeout(`${traktApi}/oauth/token`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -103,6 +140,10 @@ export function createApp(config) {
         expires_in: data.expires_in,
       });
     } catch (err) {
+      if (err.name === 'AbortError') {
+        console.error('Token refresh timeout');
+        return res.status(504).json({ error: 'Upstream timeout' });
+      }
       console.error('Token refresh error:', err);
       return res.status(502).json({ error: 'Upstream error' });
     }


### PR DESCRIPTION
- Add 15s fetch timeout via AbortController (504 on timeout)
- Validate code/refresh_token: type, length (256), and character allowlist
- Add helmet for security headers (X-Content-Type-Options, etc.)
- Run container as non-root user (USER node in Dockerfile)
- Upgrade Docker base image from node:20 to node:22 (current LTS)
- Use npm ci for reproducible Docker builds

Closes #45

https://claude.ai/code/session_01XH93sDabfyXVu95gZEeG72