### PR TITLE
Add automatic stable branch updates on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,3 +153,21 @@ jobs:
         with:
           name: watchbuddy-release-${{ needs.release-please.outputs.version }}
           path: release-assets/*.apk
+
+  update-stable:
+    name: Update stable branch
+    needs: [release-please, build-release]
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fast-forward stable branch to release tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          TAG="${{ needs.release-please.outputs.tag_name }}"
+          git checkout -B stable "$TAG"
+          git push origin stable --force


### PR DESCRIPTION
## Summary
This change adds a new CI/CD workflow job that automatically updates the `stable` branch to point to the latest release tag whenever a new release is created.

## Key Changes
- Added `update-stable` job to the release workflow that runs after successful release creation and build
- The job checks out the repository with full history and fast-forwards the `stable` branch to the release tag
- Uses force push to ensure the stable branch always points to the latest release
- Configured with appropriate git user credentials for the automated commit

## Implementation Details
- The job only runs when `release_created` output from the `release-please` job is true, ensuring it only executes on actual releases
- Uses `fetch-depth: 0` to ensure full git history is available for the fast-forward operation
- Configures git with `github-actions[bot]` credentials for proper attribution of the branch update
- The `--force` flag on the push ensures the stable branch is always synchronized with the latest release tag

https://claude.ai/code/session_014wE5WVhrVohpFUF7ux89uy