### PR TITLE
Disable patch version bumps for minor pre-major releases

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
   "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": false,
   "include-component-in-tag": false,
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary
This change modifies the release configuration to disable automatic patch version bumps when releasing minor versions before a major release.

## Changes
- Set `bump-patch-for-minor-pre-major` to `false` in `release-please-config.json`

## Details
Previously, the configuration was set to bump patch versions for minor pre-major releases. This change disables that behavior, meaning that minor version releases before a major version will no longer automatically trigger patch version increments. This provides more control over version numbering strategy during pre-major release cycles.

https://claude.ai/code/session_01C58UsXfDia8kw9NVbkuZXd