### PR TITLE
chore: upgrade Gradle 8.14.4, AGP 8.10.0, and enable build optimizations

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -30,8 +30,8 @@ jobs:
               - 'gradle/**'
               - 'gradle.properties'
 
-  test:
-    name: Unit Tests
+  test-and-build:
+    name: Test & Build
     needs: changes
     if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
@@ -47,25 +47,15 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
+      - name: Cache Configuration Cache
+        uses: actions/cache@v4
+        with:
+          path: .gradle/configuration-cache
+          key: config-cache-${{ hashFiles('**/*.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml') }}
+          restore-keys: config-cache-
+
       - name: Run unit tests
         run: ./gradlew test
-
-  build:
-    name: Build APKs
-    needs: [changes, test]
-    if: needs.changes.outputs.android == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
 
       - name: Build Phone and TV debug APKs
         env:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Run unit tests
         run: ./gradlew test
 
-  build-phone:
-    name: Build Phone APK
+  build:
+    name: Build APKs
     needs: [changes, test]
     if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
@@ -67,38 +67,16 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Build Phone debug APK
+      - name: Build Phone and TV debug APKs
         env:
           VERSION_CODE: ${{ github.run_number }}
-        run: ./gradlew :app-phone:assembleDebug
+        run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
 
       - name: Upload Phone APK
         uses: actions/upload-artifact@v7
         with:
           name: watchbuddy-phone-debug
           path: app-phone/build/outputs/apk/debug/*.apk
-
-  build-tv:
-    name: Build TV APK
-    needs: [changes, test]
-    if: needs.changes.outputs.android == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-
-      - name: Build TV debug APK
-        env:
-          VERSION_CODE: ${{ github.run_number }}
-        run: ./gradlew :app-tv:assembleDebug
 
       - name: Upload TV APK
         uses: actions/upload-artifact@v7

--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -16,36 +16,38 @@ android {
         minSdk = 26
         targetSdk = 35
 
-        // versionCode: CI setzt VERSION_CODE (run_number). Phone-Offset 1000.
-        val ciVersionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1
+        // versionCode: CI sets VERSION_CODE (run_number). Phone offset 1000.
+        val ciVersionCode = providers.environmentVariable("VERSION_CODE")
+            .orElse("1").get().toIntOrNull() ?: 1
         versionCode = 1000 + ciVersionCode
 
-        // versionName: release-please setzt VERSION_NAME, Fallback auf x-generic-string
-        versionName = System.getenv("VERSION_NAME") ?: "0.1.5" // x-release-please-version
+        // versionName: release-please sets VERSION_NAME, fallback to hardcoded value
+        versionName = providers.environmentVariable("VERSION_NAME")
+            .orElse("0.1.5").get() // x-release-please-version
 
-        // ── Trakt-Konfiguration ───────────────────────────────────────────────
-        // Leer lassen → App nutzt keinen Token-Proxy / zeigt keinen Trakt-Login.
-        // Werte können auch über CI-Umgebungsvariablen TRAKT_CLIENT_ID und
-        // TOKEN_BACKEND_URL gesetzt werden (empfohlen für Release-Builds).
+        // ── Trakt configuration ───────────────────────────────────────────────
+        // Leave empty → app does not use token proxy / does not show Trakt login.
+        // Values can also be set via CI environment variables TRAKT_CLIENT_ID and
+        // TOKEN_BACKEND_URL (recommended for release builds).
         buildConfigField(
             "String", "TRAKT_CLIENT_ID",
-            "\"${System.getenv("TRAKT_CLIENT_ID") ?: ""}\""
+            "\"${providers.environmentVariable("TRAKT_CLIENT_ID").orElse("").get()}\""
         )
         buildConfigField(
             "String", "TOKEN_BACKEND_URL",
-            "\"${System.getenv("TOKEN_BACKEND_URL") ?: ""}\""
+            "\"${providers.environmentVariable("TOKEN_BACKEND_URL").orElse("").get()}\""
         )
     }
 
-    // CI-Signing: Keystore-Pfad + Credentials über Umgebungsvariablen
-    val keystoreFile = System.getenv("KEYSTORE_FILE")
+    // CI signing: keystore path + credentials via environment variables
+    val keystoreFile = providers.environmentVariable("KEYSTORE_FILE").orNull
     if (keystoreFile != null) {
         signingConfigs {
             create("release") {
                 storeFile = file(keystoreFile)
-                storePassword = System.getenv("KEYSTORE_PASSWORD")
-                keyAlias = System.getenv("KEY_ALIAS")
-                keyPassword = System.getenv("KEY_PASSWORD")
+                storePassword = providers.environmentVariable("KEYSTORE_PASSWORD").orNull
+                keyAlias = providers.environmentVariable("KEY_ALIAS").orNull
+                keyPassword = providers.environmentVariable("KEY_PASSWORD").orNull
             }
         }
     }
@@ -79,7 +81,7 @@ android {
         buildConfig = true
     }
 
-    // Ktor + Netty bringen mehrere META-INF-Dateien mit — bei Konflikten einfach die erste nehmen
+    // Ktor + Netty bring multiple META-INF files — exclude duplicates
     packaging {
         resources {
             excludes += setOf(

--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -143,6 +143,7 @@ dependencies {
     testImplementation(libs.junit5.api)
     testImplementation(libs.junit5.params)
     testRuntimeOnly(libs.junit5.engine)
+    testRuntimeOnly(libs.junit5.platform.launcher)
     testImplementation(libs.mockk)
     testImplementation(libs.mockk.android)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt)
@@ -74,7 +73,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions { jvmTarget = "17" }
 
     buildFeatures {
         compose = true
@@ -153,6 +151,12 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.androidx.arch.core.testing)
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
 }
 
 tasks.withType<Test> {

--- a/app-phone/proguard-rules.pro
+++ b/app-phone/proguard-rules.pro
@@ -41,11 +41,6 @@
 # ── Hilt / Dagger ────────────────────────────────────────────────────────────
 -dontwarn dagger.hilt.android.internal.**
 
-# ── Room ─────────────────────────────────────────────────────────────────────
--keep class * extends androidx.room.RoomDatabase
--keep @androidx.room.Entity class *
--dontwarn androidx.room.paging.**
-
 # ── Ktor (phone HTTP server) ────────────────────────────────────────────────
 -keep class io.ktor.** { *; }
 -dontwarn io.ktor.**

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmOrchestrator.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmOrchestrator.kt
@@ -20,7 +20,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class LlmOrchestrator @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) {
     data class LlmConfig(
         val backend: LlmBackend,

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
@@ -20,7 +20,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class LlmProviderFactory @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val llmOrchestrator: LlmOrchestrator,
     private val settingsRepository: SettingsRepository,
     private val httpClient: OkHttpClient

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
@@ -14,7 +14,7 @@ import javax.inject.Singleton
 
 @Singleton
 class DeviceCapabilityProvider @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val llmOrchestrator: LlmOrchestrator,
     private val traktApiService: TraktApiService,
     private val tokenRepository: TokenRepository

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
@@ -27,7 +27,7 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 
 @Singleton
 class SettingsRepository @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val tokenRepository: TokenRepository
 ) {
     private object Keys {

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
@@ -43,7 +43,7 @@ class OnboardingViewModel @Inject constructor(
     private val traktApi: TraktApiService,
     /** Null, wenn TOKEN_BACKEND_URL in BuildConfig leer ist. */
     private val tokenProxy: TokenProxyService?,
-    @Named("traktClientId") private val clientId: String,
+    @param:Named("traktClientId") private val clientId: String,
     private val tokenRepository: TokenRepository
 ) : AndroidViewModel(application) {
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -43,7 +43,7 @@ fun SettingsScreen(
                 title = { Text(stringResource(R.string.settings_title)) },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.settings_cd_back))
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.settings_cd_back))
                     }
                 },
                 colors = TopAppBarDefaults.topAppBarColors(

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -16,23 +16,25 @@ android {
         minSdk = 26
         targetSdk = 35
 
-        // versionCode: CI setzt VERSION_CODE (run_number). TV-Offset 2000 (höher → Play bevorzugt für TV).
-        val ciVersionCode = System.getenv("VERSION_CODE")?.toIntOrNull() ?: 1
+        // versionCode: CI sets VERSION_CODE (run_number). TV offset 2000 (higher → Play prefers for TV).
+        val ciVersionCode = providers.environmentVariable("VERSION_CODE")
+            .orElse("1").get().toIntOrNull() ?: 1
         versionCode = 2000 + ciVersionCode
 
-        // versionName: release-please setzt VERSION_NAME, Fallback auf x-generic-string
-        versionName = System.getenv("VERSION_NAME") ?: "0.1.5" // x-release-please-version
+        // versionName: release-please sets VERSION_NAME, fallback to hardcoded value
+        versionName = providers.environmentVariable("VERSION_NAME")
+            .orElse("0.1.5").get() // x-release-please-version
     }
 
-    // CI-Signing: Keystore-Pfad + Credentials über Umgebungsvariablen
-    val keystoreFile = System.getenv("KEYSTORE_FILE")
+    // CI signing: keystore path + credentials via environment variables
+    val keystoreFile = providers.environmentVariable("KEYSTORE_FILE").orNull
     if (keystoreFile != null) {
         signingConfigs {
             create("release") {
                 storeFile = file(keystoreFile)
-                storePassword = System.getenv("KEYSTORE_PASSWORD")
-                keyAlias = System.getenv("KEY_ALIAS")
-                keyPassword = System.getenv("KEY_PASSWORD")
+                storePassword = providers.environmentVariable("KEYSTORE_PASSWORD").orNull
+                keyAlias = providers.environmentVariable("KEY_ALIAS").orNull
+                keyPassword = providers.environmentVariable("KEY_PASSWORD").orNull
             }
         }
     }
@@ -78,10 +80,10 @@ dependencies {
     debugImplementation(libs.compose.ui.tooling)
 
     // Compose for TV (Leanback replacement)
-    // tv-foundation ist transitiv in tv-material enthalten
+    // tv-foundation is transitively included in tv-material
     implementation(libs.compose.tv.material)
 
-    // Standard Material3 — CircularProgressIndicator / LinearProgressIndicator für TV
+    // Standard Material3 — CircularProgressIndicator / LinearProgressIndicator for TV
     implementation(libs.compose.material3)
 
     // Lifecycle
@@ -99,7 +101,7 @@ dependencies {
     // Image loading
     implementation(libs.coil)
 
-    // WorkManager (background Trakt sync)
+    // WorkManager (background Trakt sync / scrobble history)
     implementation(libs.work.runtime)
 
     // Testing

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt)
@@ -61,7 +60,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions { jvmTarget = "17" }
 
     buildFeatures {
         compose = true
@@ -115,6 +113,12 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.androidx.arch.core.testing)
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+    }
 }
 
 tasks.withType<Test> {

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -106,6 +106,7 @@ dependencies {
     testImplementation(libs.junit5.api)
     testImplementation(libs.junit5.params)
     testRuntimeOnly(libs.junit5.engine)
+    testRuntimeOnly(libs.junit5.platform.launcher)
     testImplementation(libs.mockk)
     testImplementation(libs.mockk.android)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app-tv/proguard-rules.pro
+++ b/app-tv/proguard-rules.pro
@@ -41,11 +41,6 @@
 # ── Hilt / Dagger ────────────────────────────────────────────────────────────
 -dontwarn dagger.hilt.android.internal.**
 
-# ── Room ─────────────────────────────────────────────────────────────────────
--keep class * extends androidx.room.RoomDatabase
--keep @androidx.room.Entity class *
--dontwarn androidx.room.paging.**
-
 # ── Coil ─────────────────────────────────────────────────────────────────────
 -dontwarn coil.**
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepository.kt
@@ -19,7 +19,7 @@ private val Context.streamingDataStore: DataStore<Preferences> by preferencesDat
 
 @Singleton
 class StreamingPreferencesRepository @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) {
     private val subscribedKey = stringSetPreferencesKey("subscribed_service_ids")
     private val orderKey = stringPreferencesKey("service_order")

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/UserSessionRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/UserSessionRepository.kt
@@ -18,7 +18,7 @@ private val Context.userSessionDataStore: DataStore<Preferences> by preferencesD
 
 @Singleton
 class UserSessionRepository @Inject constructor(
-    @ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context
 ) {
     private val selectedUserIdsKey = stringSetPreferencesKey("selected_user_ids")
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -23,7 +23,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class PhoneDiscoveryManager @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val httpClient: OkHttpClient
 ) {
     companion object {
@@ -50,6 +50,7 @@ class PhoneDiscoveryManager @Inject constructor(
         override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {}
 
         override fun onServiceFound(service: NsdServiceInfo) {
+            @Suppress("DEPRECATION")
             nsdManager.resolveService(service, object : NsdManager.ResolveListener {
                 override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {}
                 override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
@@ -79,6 +80,7 @@ class PhoneDiscoveryManager @Inject constructor(
             .maxByOrNull { it.score }
 
     private fun fetchCapabilityAndAdd(serviceInfo: NsdServiceInfo) {
+        @Suppress("DEPRECATION")
         val hostAddress = serviceInfo.host?.hostAddress ?: return
         val url = "http://${hostAddress}:${serviceInfo.port}${CAPABILITY_PATH}"
         try {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
@@ -29,7 +29,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class MediaSessionScrobbler @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     private val traktApi: TraktApiService,
     private val tvShowCache: TvShowCache,
     private val tvTokenCache: TvTokenCache

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModel.kt
@@ -58,6 +58,7 @@ class RecapViewModel @Inject constructor(
                 val deviceName = phone.capability?.deviceName ?: getApplication<Application>().getString(R.string.tv_default_device_name)
                 _state.value = RecapUiState.Generating(deviceName)
                 try {
+                    @Suppress("DEPRECATION")
                     val host = phone.serviceInfo.host?.hostAddress ?: continue
                     val port = phone.serviceInfo.port
                     val url  = "http://$host:$port/recap/$traktShowId"

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModelTest.kt
@@ -70,6 +70,7 @@ class RecapViewModelTest {
         }
         every { phone.score } returns 100
         every { phone.serviceInfo } returns mockk {
+            @Suppress("DEPRECATION")
             every { host } returns mockk {
                 every { hostAddress } returns "192.168.1.1"
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,6 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt) apply false

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -40,11 +40,6 @@ dependencies {
     // Coroutines
     api(libs.kotlinx.coroutines)
 
-    // Room
-    api(libs.room.runtime)
-    api(libs.room.ktx)
-    ksp(libs.room.compiler)
-
     // DataStore
     api(libs.datastore.preferences)
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     testImplementation(libs.junit5.api)
     testImplementation(libs.junit5.params)
     testRuntimeOnly(libs.junit5.engine)
+    testRuntimeOnly(libs.junit5.platform.launcher)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
@@ -22,8 +21,11 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ android.useAndroidX=true
 android.enableJetifier=false
 android.nonTransitiveRClass=true
 android.enableR8.fullMode=true
+android.disallowKotlinSourceSets=false
 
 # Kotlin
 kotlin.code.style=official
@@ -17,4 +18,3 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.vfs.watch=true
 org.gradle.configuration-cache=true
-org.gradle.configuration-cache.problems=warn

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,20 @@
 # Android
 android.useAndroidX=true
 android.enableJetifier=false
+android.nonTransitiveRClass=true
+android.enableR8.fullMode=true
 
 # Kotlin
 kotlin.code.style=official
+kotlin.incremental=true
+
+# KSP
+ksp.incremental=true
 
 # Gradle
-org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.vfs.watch=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=warn

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
-agp = "8.10.0"
-kotlin = "2.0.21"
-ksp = "2.0.21-1.0.27"
-hilt = "2.56"
+agp = "9.0.1"
+kotlin = "2.1.21"
+ksp = "2.1.21-2.0.2"
+hilt = "2.59.1"
 compose-bom = "2025.04.01"
 compose-tv = "1.0.0"
 lifecycle = "2.9.0"
@@ -99,7 +99,6 @@ androidx-arch-core-testing = { group = "androidx.arch.core", name = "core-testin
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -86,6 +86,7 @@ coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 # Testing
 junit5-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit5" }
 junit5-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit5" }
+junit5-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 junit5-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit5" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,22 +1,21 @@
 [versions]
-agp = "8.7.0"
+agp = "8.10.0"
 kotlin = "2.0.21"
 ksp = "2.0.21-1.0.27"
-hilt = "2.52"
+hilt = "2.56"
 compose-bom = "2025.04.01"
 compose-tv = "1.0.0"
-lifecycle = "2.8.7"
-room = "2.6.1"
-ktor = "2.3.12"
+lifecycle = "2.9.0"
+ktor = "2.3.13"
 retrofit = "2.11.0"
 okhttp = "4.12.0"
-coroutines = "1.9.0"
+coroutines = "1.10.1"
 serialization = "1.7.3"
-mediapipe = "0.10.14"
+mediapipe = "0.10.24"
 coil = "2.7.0"
-navigation = "2.8.5"
+navigation = "2.9.0"
 datastore = "1.1.1"
-work = "2.10.0"
+work = "2.10.1"
 security-crypto = "1.1.0-alpha06"
 junit5 = "5.10.3"
 mockk = "1.13.12"
@@ -68,11 +67,6 @@ kotlinx-serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-seria
 
 # Coroutines
 kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
-
-# Room DB
-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 
 # DataStore
 datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

### Phase 1: Gradle 8.x optimization + build improvements
- **Gradle wrapper** 8.9 → 8.14.4
- **AGP** 8.7.0 → 8.10.0, **Hilt** 2.52 → 2.56, **Lifecycle** 2.8.7 → 2.9.0, **Navigation** 2.8.5 → 2.9.0, **Coroutines** 1.9.0 → 1.10.1, **Ktor** 2.3.12 → 2.3.13, **MediaPipe** 0.10.14 → 0.10.24, **WorkManager** 2.10.0 → 2.10.1
- Enable **configuration cache** with `System.getenv()` → `providers.environmentVariable()` migration
- Enable **non-transitive R classes** for faster incremental builds
- Enable **R8 full mode** for smaller release APKs
- Enable **VFS watching**, **KSP incremental processing**
- Tune JVM args (`MaxMetaspaceSize`, `HeapDumpOnOutOfMemoryError`)
- Remove unused **Room dependency** (no `@Database`/`@Entity`/`@Dao` in codebase)
- Combine CI `build-phone`/`build-tv` into single job (avoids duplicate `:core` compilation)

### Phase 2: Gradle 9.x migration
- **Gradle** 8.14.4 → 9.4.1
- **AGP** 8.10.0 → 9.0.1 (built-in Kotlin — removes explicit `kotlin-android` plugin)
- **Kotlin** 2.0.21 → 2.1.21
- **KSP** 2.0.21-1.0.27 → 2.1.21-2.0.2
- **Hilt** 2.56 → 2.59.1 (AGP 9 compatibility)
- Migrate `kotlinOptions` → top-level `kotlin { compilerOptions {} }`
- Add `junit-platform-launcher` (required by Gradle 9)
- Add `android.disallowKotlinSourceSets=false` for KSP compatibility

### Warning cleanup
- Fix Kotlin 2.1 KT-73255 warnings: add `@param:` target to `@ApplicationContext`/`@Named` on constructor properties (10 files)
- Replace deprecated `Icons.Default.ArrowBack` → `Icons.AutoMirrored.Filled.ArrowBack`
- Suppress `NsdServiceInfo.host` and `NsdManager.resolveService` deprecations (new API requires API 34+, `minSdk` is 26)

### Related issues
- Partially addresses #53 — updates Ktor (2.3.12 → 2.3.13), confirms Compose BOM is already at latest stable (2025.04.01), removes stale Compose Compiler version entry (now managed by `kotlin.plugin.compose`). Ktor 3.x major migration and backend npm updates are out of scope for this PR.

## Test plan

- [x] CI unit tests pass (all 3 modules)
- [x] CI build passes (`assembleDebug` for both phone and TV)
- [x] Configuration cache entry stored without errors
- [ ] Manual release build test to validate R8 full mode + non-transitive R classes

https://claude.ai/code/session_015X6kQfN5XncYnQJAD2Hq9W