### PR TITLE
fix: correct activity class references in AndroidManifest.xml

### DIFF
--- a/app-phone/src/main/AndroidManifest.xml
+++ b/app-phone/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
 
         <!-- Main launcher activity -->
         <activity
-            android:name=".ui.MainActivity"
+            android:name=".phone.ui.MainActivity"
             android:exported="true"
             android:theme="@style/Theme.WatchBuddy">
             <intent-filter>

--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
 
         <!-- TV Leanback launcher -->
         <activity
-            android:name=".ui.TvMainActivity"
+            android:name=".tv.ui.TvMainActivity"
             android:exported="true"
             android:configChanges="keyboard|keyboardHidden|navigation"
             android:theme="@style/Theme.WatchBuddy">


### PR DESCRIPTION
## Summary

- Fix `ClassNotFoundException` crash on launch for both phone and TV apps caused by incorrect activity class paths in `AndroidManifest.xml`
- Phone manifest referenced `.ui.MainActivity` instead of `.phone.ui.MainActivity`
- TV manifest referenced `.ui.TvMainActivity` instead of `.tv.ui.TvMainActivity`

Closes #86

## Test plan

- [ ] `./gradlew assembleDebug` builds both APKs without errors
- [ ] Install phone APK on device/emulator — app launches without crashing
- [ ] Install TV APK on device/emulator — app launches without crashing
- [ ] Verify navigation (onboarding → home → settings) works on phone app
- [ ] Verify TV home screen loads correctly

https://claude.ai/code/session_01SPNK1BburuoA7oRFfi82RL