### PR TITLE
fix: add skip button and NotConfigured state to onboarding

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
@@ -30,6 +30,11 @@ fun PhoneNavGraph(
                     navController.navigate(PhoneRoute.Home.route) {
                         popUpTo(PhoneRoute.Onboarding.route) { inclusive = true }
                     }
+                },
+                onSkip = {
+                    navController.navigate(PhoneRoute.Home.route) {
+                        popUpTo(PhoneRoute.Onboarding.route) { inclusive = true }
+                    }
                 }
             )
         }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingScreen.kt
@@ -22,6 +22,7 @@ import com.justb81.watchbuddy.R
 @Composable
 fun OnboardingScreen(
     onSuccess: () -> Unit,
+    onSkip: () -> Unit,
     viewModel: OnboardingViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsState()
@@ -106,8 +107,26 @@ fun OnboardingScreen(
                         }
                     }
 
+                    is OnboardingState.NotConfigured -> {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Text(
+                                text = stringResource(R.string.onboarding_not_configured),
+                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                                textAlign = TextAlign.Center,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                        }
+                    }
+
                     else -> {}
                 }
+            }
+
+            TextButton(onClick = onSkip) {
+                Text(
+                    stringResource(R.string.onboarding_skip),
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+                )
             }
         }
     }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -11,6 +11,7 @@ import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.service.CompanionService
 import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
@@ -51,6 +52,7 @@ data class SettingsUiState(
 class SettingsViewModel @Inject constructor(
     application: Application,
     private val llmOrchestrator: LlmOrchestrator,
+    private val traktApi: TraktApiService,
     private val tokenRepository: TokenRepository,
     private val deviceCapabilityProvider: DeviceCapabilityProvider,
     private val settingsRepository: SettingsRepository
@@ -66,8 +68,21 @@ class SettingsViewModel @Inject constructor(
 
     init {
         loadPersistedSettings()
+        loadTraktUsername()
         detectLlm()
         observeModelReadyState()
+    }
+
+    private fun loadTraktUsername() {
+        val accessToken = tokenRepository.getAccessToken() ?: return
+        viewModelScope.launch {
+            try {
+                val profile = traktApi.getProfile("Bearer $accessToken")
+                _uiState.value = _uiState.value.copy(traktUsername = profile.username)
+            } catch (_: Exception) {
+                // Token may be expired or network unavailable — keep showing "Not connected"
+            }
+        }
     }
 
     private fun loadPersistedSettings() {

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -16,6 +16,8 @@
     <string name="onboarding_code_expires">Code läuft ab in %1$d Sekunden</string>
     <string name="onboarding_error_loading_code">Fehler beim Laden des Codes: %1$s</string>
     <string name="onboarding_code_expired">Code abgelaufen. Bitte erneut versuchen.</string>
+    <string name="onboarding_not_configured">Trakt ist noch nicht konfiguriert. Du kannst deine Zugangsdaten in den Einstellungen einrichten.</string>
+    <string name="onboarding_skip">Jetzt überspringen</string>
 
     <!-- Home -->
     <string name="home_title">Meine Serien</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -16,6 +16,8 @@
     <string name="onboarding_code_expires">El código expira en %1$d segundos</string>
     <string name="onboarding_error_loading_code">Error al cargar el código: %1$s</string>
     <string name="onboarding_code_expired">Código expirado. Por favor, inténtalo de nuevo.</string>
+    <string name="onboarding_not_configured">Trakt aún no está configurado. Puedes configurar tus credenciales en los ajustes.</string>
+    <string name="onboarding_skip">Omitir por ahora</string>
 
     <!-- Home -->
     <string name="home_title">Mis series</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -16,6 +16,8 @@
     <string name="onboarding_code_expires">Le code expire dans %1$d secondes</string>
     <string name="onboarding_error_loading_code">Erreur lors du chargement du code : %1$s</string>
     <string name="onboarding_code_expired">Code expiré. Veuillez réessayer.</string>
+    <string name="onboarding_not_configured">Trakt n\'est pas encore configuré. Vous pouvez configurer vos identifiants dans les paramètres.</string>
+    <string name="onboarding_skip">Ignorer pour le moment</string>
 
     <!-- Home -->
     <string name="home_title">Mes séries</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -16,6 +16,8 @@
     <string name="onboarding_code_expires">Code expires in %1$d seconds</string>
     <string name="onboarding_error_loading_code">Error loading code: %1$s</string>
     <string name="onboarding_code_expired">Code expired. Please try again.</string>
+    <string name="onboarding_not_configured">Trakt is not configured yet. You can set up your credentials in Settings.</string>
+    <string name="onboarding_skip">Skip for now</string>
 
     <!-- Home -->
     <string name="home_title">My Shows</string>


### PR DESCRIPTION
## Summary

- **Handle `OnboardingState.NotConfigured`** — previously rendered nothing (`else -> {}`), leaving users stuck on a blank screen with no way to navigate when Trakt wasn't configured
- **Add a persistent "Skip for now" button** to the onboarding screen so users can always proceed to the Home screen, regardless of auth state
- **Load Trakt username in `SettingsViewModel`** — `traktUsername` was never populated, so the Settings screen always showed "Not connected" even after successful authentication
- Add localized strings for all four supported languages (EN, DE, FR, ES)

## Test plan

- [ ] Launch app without Trakt configured → verify `NotConfigured` message is shown with "Skip for now" button
- [ ] Tap "Skip for now" → verify navigation to Home screen works
- [ ] From Home, tap Settings icon → verify Settings screen opens
- [ ] Launch app with valid Trakt token → verify Home screen loads directly
- [ ] On Settings screen with valid token → verify Trakt username is displayed (not "Not connected")
- [ ] Disconnect Trakt in Settings → verify navigation back to Onboarding
- [ ] Verify localized strings appear correctly for DE, FR, ES locales

Fixes #90

https://claude.ai/code/session_017cexAE9EibpUtdNm2JhGBN