### PR TITLE
fix: add Connect to Trakt buttons to Home and Settings screens

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
@@ -27,6 +27,7 @@ import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 @Composable
 fun HomeScreen(
     onSettingsClick: () -> Unit,
+    onConnectClick: () -> Unit,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -93,12 +94,20 @@ fun HomeScreen(
                 }
 
                 uiState.shows.isEmpty() -> {
-                    Text(
-                        text      = stringResource(R.string.home_no_shows),
-                        modifier  = Modifier.align(Alignment.Center).padding(32.dp),
-                        color     = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
-                        style     = MaterialTheme.typography.bodyLarge
-                    )
+                    Column(
+                        modifier = Modifier.align(Alignment.Center).padding(32.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        Text(
+                            text  = stringResource(R.string.home_no_shows),
+                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        Button(onClick = onConnectClick) {
+                            Text(stringResource(R.string.home_connect_to_trakt))
+                        }
+                    }
                 }
 
                 else -> {

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
@@ -12,6 +12,7 @@ sealed class PhoneRoute(val route: String) {
     object Onboarding : PhoneRoute("onboarding")
     object Home       : PhoneRoute("home")
     object Settings   : PhoneRoute("settings")
+    object Connect    : PhoneRoute("connect")
 }
 
 @Composable
@@ -41,7 +42,8 @@ fun PhoneNavGraph(
 
         composable(PhoneRoute.Home.route) {
             HomeScreen(
-                onSettingsClick = { navController.navigate(PhoneRoute.Settings.route) }
+                onSettingsClick = { navController.navigate(PhoneRoute.Settings.route) },
+                onConnectClick  = { navController.navigate(PhoneRoute.Connect.route) }
             )
         }
 
@@ -52,7 +54,19 @@ fun PhoneNavGraph(
                     navController.navigate(PhoneRoute.Onboarding.route) {
                         popUpTo(navController.graph.id) { inclusive = true }
                     }
-                }
+                },
+                onConnectClick = { navController.navigate(PhoneRoute.Connect.route) }
+            )
+        }
+
+        composable(PhoneRoute.Connect.route) {
+            OnboardingScreen(
+                onSuccess = {
+                    navController.navigate(PhoneRoute.Home.route) {
+                        popUpTo(navController.graph.id) { inclusive = true }
+                    }
+                },
+                onSkip = { navController.popBackStack() }
             )
         }
     }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -21,6 +21,7 @@ import com.justb81.watchbuddy.R
 fun SettingsScreen(
     onBack: () -> Unit,
     onDisconnected: () -> Unit,
+    onConnectClick: () -> Unit,
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -79,6 +80,13 @@ fun SettingsScreen(
                             stringResource(R.string.settings_disconnect),
                             color = MaterialTheme.colorScheme.error
                         )
+                    }
+                } else {
+                    TextButton(
+                        onClick  = onConnectClick,
+                        modifier = Modifier.padding(horizontal = 8.dp)
+                    ) {
+                        Text(stringResource(R.string.settings_connect_to_trakt))
                     }
                 }
             }

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -24,6 +24,7 @@
     <string name="home_continue_watching">Weiterschauen</string>
     <string name="home_all_shows">Alle Serien</string>
     <string name="home_no_shows">Noch keine Serien vorhanden.\nVerbinde dich mit Trakt, um loszulegen.</string>
+    <string name="home_connect_to_trakt">Mit Trakt verbinden</string>
     <string name="home_syncing">Synchronisiere mit Trakt…</string>
     <string name="home_last_sync">Zuletzt synchronisiert: %1$s</string>
     <string name="home_episode_progress">S%1$02dE%2$02d — %3$d/%4$d Folgen gesehen</string>
@@ -71,6 +72,7 @@
     <string name="settings_disconnect_title">Trakt trennen?</string>
     <string name="settings_disconnect_message">Deine lokalen Daten werden gelöscht. Du kannst dich jederzeit wieder verbinden.</string>
     <string name="settings_not_connected">Nicht verbunden</string>
+    <string name="settings_connect_to_trakt">Mit Trakt verbinden</string>
     <string name="settings_llm_detecting">Wird erkannt…</string>
 
     <!-- Companion Service -->

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -24,6 +24,7 @@
     <string name="home_continue_watching">Seguir viendo</string>
     <string name="home_all_shows">Todas las series</string>
     <string name="home_no_shows">Aún no hay series.\nConéctate con Trakt para empezar.</string>
+    <string name="home_connect_to_trakt">Conectar con Trakt</string>
     <string name="home_syncing">Sincronizando con Trakt…</string>
     <string name="home_last_sync">Última sincronización: %1$s</string>
     <string name="home_episode_progress">S%1$02dE%2$02d — %3$d/%4$d episodios vistos</string>
@@ -71,6 +72,7 @@
     <string name="settings_disconnect_title">¿Desconectar Trakt?</string>
     <string name="settings_disconnect_message">Tus datos locales serán eliminados. Puedes volver a conectarte en cualquier momento.</string>
     <string name="settings_not_connected">No conectado</string>
+    <string name="settings_connect_to_trakt">Conectar con Trakt</string>
     <string name="settings_llm_detecting">Detectando…</string>
 
     <!-- Companion Service -->

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -24,6 +24,7 @@
     <string name="home_continue_watching">Continuer à regarder</string>
     <string name="home_all_shows">Toutes les séries</string>
     <string name="home_no_shows">Aucune série pour le moment.\nConnectez-vous avec Trakt pour commencer.</string>
+    <string name="home_connect_to_trakt">Se connecter à Trakt</string>
     <string name="home_syncing">Synchronisation avec Trakt…</string>
     <string name="home_last_sync">Dernière synchronisation : %1$s</string>
     <string name="home_episode_progress">S%1$02dE%2$02d — %3$d/%4$d épisodes vus</string>
@@ -71,6 +72,7 @@
     <string name="settings_disconnect_title">Déconnecter Trakt ?</string>
     <string name="settings_disconnect_message">Vos données locales seront supprimées. Vous pouvez vous reconnecter à tout moment.</string>
     <string name="settings_not_connected">Non connecté</string>
+    <string name="settings_connect_to_trakt">Se connecter à Trakt</string>
     <string name="settings_llm_detecting">Détection…</string>
 
     <!-- Companion Service -->

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -24,6 +24,7 @@
     <string name="home_continue_watching">Continue Watching</string>
     <string name="home_all_shows">All Shows</string>
     <string name="home_no_shows">No shows yet.\nConnect with Trakt to get started.</string>
+    <string name="home_connect_to_trakt">Connect to Trakt</string>
     <string name="home_syncing">Syncing with Trakt…</string>
     <string name="home_last_sync">Last synced: %1$s</string>
     <string name="home_episode_progress">S%1$02dE%2$02d — %3$d/%4$d episodes watched</string>
@@ -71,6 +72,7 @@
     <string name="settings_disconnect_title">Disconnect Trakt?</string>
     <string name="settings_disconnect_message">Your local data will be deleted. You can reconnect at any time.</string>
     <string name="settings_not_connected">Not connected</string>
+    <string name="settings_connect_to_trakt">Connect to Trakt</string>
     <string name="settings_llm_detecting">Detecting…</string>
 
     <!-- Companion Service -->


### PR DESCRIPTION
## Summary

- Adds a **"Connect to Trakt"** button to the **Settings** account section when the user is not connected (`traktUsername == null`)
- Adds a **"Connect to Trakt"** button to the **Home** screen empty state, below the existing "No shows yet" message
- Introduces a new `PhoneRoute.Connect` navigation route that reuses `OnboardingScreen` — on success it navigates to Home (clearing the back stack), on skip it pops back to the previous screen
- Adds localized strings for the new button in all four supported languages (EN, DE, FR, ES)

## Files changed

| File | Change |
|------|--------|
| `SettingsScreen.kt` | Added `onConnectClick` callback; renders "Connect to Trakt" button when not authenticated |
| `HomeScreen.kt` | Added `onConnectClick` callback; replaced plain text empty state with text + connect button |
| `PhoneNavGraph.kt` | Added `PhoneRoute.Connect` route; wired `onConnectClick` for Home and Settings |
| `values/strings.xml` | Added `settings_connect_to_trakt` and `home_connect_to_trakt` |
| `values-de/strings.xml` | German translations |
| `values-fr/strings.xml` | French translations |
| `values-es/strings.xml` | Spanish translations |

## Test plan

- [ ] Launch app → skip onboarding → verify "Connect to Trakt" button appears on Home empty state
- [ ] Tap "Connect to Trakt" on Home → verify onboarding flow opens, skip returns to Home
- [ ] Open Settings while not connected → verify "Connect to Trakt" button appears in Account section
- [ ] Tap "Connect to Trakt" in Settings → verify onboarding flow opens, skip returns to Settings
- [ ] Complete Trakt auth from connect flow → verify navigation to Home with shows loaded
- [ ] While connected, verify Settings shows "Disconnect" button (not "Connect")
- [ ] Verify German, French, and Spanish localizations display correctly

Closes #93

https://claude.ai/code/session_01FV5LQctTMncovQSPJuJ8Xs