### PR TITLE
feat: add TMDB API key configuration UI and propagation

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -4,6 +4,8 @@ import android.util.Log
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.llm.RecapGenerator
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import kotlinx.coroutines.flow.first
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
@@ -34,7 +36,8 @@ class CompanionHttpServer @Inject constructor(
     private val capabilityProvider: DeviceCapabilityProvider,
     private val showRepository: ShowRepository,
     private val tokenRepository: TokenRepository,
-    private val tmdbApiService: TmdbApiService
+    private val tmdbApiService: TmdbApiService,
+    private val settingsRepository: SettingsRepository
 ) {
     companion object {
         const val PORT = 8765
@@ -74,6 +77,9 @@ class CompanionHttpServer @Inject constructor(
 
                     try {
                         val body = try { call.receive<RecapRequest>() } catch (_: Exception) { RecapRequest() }
+                        val apiKey = body.tmdbApiKey.ifBlank {
+                            settingsRepository.getTmdbApiKey().first()
+                        }
 
                         val shows = showRepository.getShows()
                         val watchedEntry = shows.find { it.show.ids.trakt == showId }
@@ -82,7 +88,7 @@ class CompanionHttpServer @Inject constructor(
                         val tmdbId = watchedEntry.show.ids.tmdb
                             ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("No TMDB ID for show"))
 
-                        val tmdbShow = tmdbApiService.getShow(tmdbId, body.tmdbApiKey)
+                        val tmdbShow = tmdbApiService.getShow(tmdbId, apiKey)
 
                         // Collect watched episode numbers from Trakt data
                         val watchedEpisodeRefs = watchedEntry.seasons.flatMap { season ->
@@ -94,7 +100,7 @@ class CompanionHttpServer @Inject constructor(
                             .takeLast(8)
                             .mapNotNull { (season, episode) ->
                                 try {
-                                    tmdbApiService.getEpisode(tmdbId, season, episode, body.tmdbApiKey)
+                                    tmdbApiService.getEpisode(tmdbId, season, episode, apiKey)
                                 } catch (e: Exception) {
                                     Log.w(TAG, "Failed to load TMDB episode S${season}E${episode}", e)
                                     null
@@ -113,7 +119,7 @@ class CompanionHttpServer @Inject constructor(
                             show = tmdbShow,
                             watchedEpisodes = watchedEpisodes,
                             targetEpisode = targetEpisode,
-                            apiKey = body.tmdbApiKey
+                            apiKey = apiKey
                         )
                         call.respond(mapOf("html" to html))
                     } catch (e: Exception) {

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
@@ -8,7 +8,9 @@ import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.core.trakt.TraktUserProfile
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -17,7 +19,8 @@ class DeviceCapabilityProvider @Inject constructor(
     @param:ApplicationContext private val context: Context,
     private val llmOrchestrator: LlmOrchestrator,
     private val traktApiService: TraktApiService,
-    private val tokenRepository: TokenRepository
+    private val tokenRepository: TokenRepository,
+    private val settingsRepository: SettingsRepository
 ) {
     private var cachedProfile: TraktUserProfile? = null
 
@@ -39,6 +42,7 @@ class DeviceCapabilityProvider @Inject constructor(
         val freeRamMb = (memInfo.availMem / 1_048_576).toInt()
 
         val profile = getCachedProfile()
+        val tmdbKey = settingsRepository.getTmdbApiKey().first()
 
         return DeviceCapability(
             deviceId = Build.ID,
@@ -48,7 +52,8 @@ class DeviceCapabilityProvider @Inject constructor(
             llmBackend = config.backend,
             modelQuality = config.qualityScore,
             freeRamMb = freeRamMb,
-            isAvailable = true
+            isAvailable = true,
+            tmdbConfigured = tmdbKey.isNotBlank()
         )
     }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/AppSettings.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/AppSettings.kt
@@ -8,7 +8,8 @@ data class AppSettings(
     val directClientId: String = "",
     val companionEnabled: Boolean = false,
     val ollamaUrl: String = DEFAULT_OLLAMA_URL,
-    val modelBaseUrl: String = ""
+    val modelBaseUrl: String = "",
+    val tmdbApiKey: String = ""
 ) {
     companion object {
         const val DEFAULT_OLLAMA_URL = "http://localhost:11434"

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
@@ -38,6 +38,7 @@ class SettingsRepository @Inject constructor(
         val OLLAMA_URL = stringPreferencesKey("ollama_url")
         val MODEL_BASE_URL = stringPreferencesKey("model_base_url")
         val MODEL_READY = booleanPreferencesKey("model_ready")
+        val TMDB_API_KEY = stringPreferencesKey("tmdb_api_key")
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -62,7 +63,8 @@ class SettingsRepository @Inject constructor(
             directClientId = prefs[Keys.DIRECT_CLIENT_ID] ?: "",
             companionEnabled = prefs[Keys.COMPANION_ENABLED] ?: false,
             ollamaUrl = prefs[Keys.OLLAMA_URL] ?: AppSettings.DEFAULT_OLLAMA_URL,
-            modelBaseUrl = prefs[Keys.MODEL_BASE_URL] ?: ""
+            modelBaseUrl = prefs[Keys.MODEL_BASE_URL] ?: "",
+            tmdbApiKey = prefs[Keys.TMDB_API_KEY] ?: ""
         )
     }
 
@@ -74,6 +76,7 @@ class SettingsRepository @Inject constructor(
             prefs[Keys.COMPANION_ENABLED] = settings.companionEnabled
             prefs[Keys.OLLAMA_URL] = settings.ollamaUrl
             prefs[Keys.MODEL_BASE_URL] = settings.modelBaseUrl
+            prefs[Keys.TMDB_API_KEY] = settings.tmdbApiKey
         }
     }
 
@@ -81,6 +84,10 @@ class SettingsRepository @Inject constructor(
 
     fun saveClientSecret(secret: String) {
         tokenRepository.saveClientSecret(secret)
+    }
+
+    fun getTmdbApiKey(): Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[Keys.TMDB_API_KEY] ?: ""
     }
 
     fun setModelReady(ready: Boolean) {

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -83,6 +83,57 @@ fun SettingsScreen(
                 }
             }
 
+            // ── TMDB Section ─────────────────────────────────────────────────
+            SettingsSectionHeader(stringResource(R.string.settings_tmdb))
+
+            SettingsCard {
+                SettingsRow(
+                    label    = stringResource(R.string.settings_tmdb_account),
+                    value    = if (uiState.tmdbConnected)
+                                   stringResource(R.string.settings_tmdb_connected)
+                               else
+                                   stringResource(R.string.settings_not_connected),
+                    showDivider = true
+                )
+                if (uiState.tmdbConnected) {
+                    TextButton(
+                        onClick  = { viewModel.disconnectTmdb() },
+                        modifier = Modifier.padding(horizontal = 8.dp)
+                    ) {
+                        Text(
+                            stringResource(R.string.settings_disconnect),
+                            color = MaterialTheme.colorScheme.error
+                        )
+                    }
+                } else {
+                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                        OutlinedTextField(
+                            value         = uiState.tmdbApiKey,
+                            onValueChange = viewModel::setTmdbApiKey,
+                            label         = { Text(stringResource(R.string.settings_tmdb_api_key)) },
+                            modifier      = Modifier.fillMaxWidth(),
+                            singleLine    = true,
+                            visualTransformation = PasswordVisualTransformation()
+                        )
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            text  = stringResource(R.string.settings_tmdb_helper),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+                        )
+                        Spacer(Modifier.height(8.dp))
+                        Button(
+                            onClick  = { viewModel.saveTmdbApiKey() },
+                            modifier = Modifier.fillMaxWidth(),
+                            enabled  = uiState.tmdbApiKey.isNotBlank()
+                        ) {
+                            Text(stringResource(R.string.settings_save))
+                        }
+                        Spacer(Modifier.height(4.dp))
+                    }
+                }
+            }
+
             // ── Companion Service ─────────────────────────────────────────────
             SettingsSectionHeader(stringResource(R.string.settings_companion))
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -33,6 +33,7 @@ enum class AuthMode { MANAGED, SELF_HOSTED, DIRECT }
 data class SettingsUiState(
     val traktUsername: String?     = null,
     val tmdbConnected: Boolean     = false,
+    val tmdbApiKey: String         = "",
     val companionRunning: Boolean  = false,
     val authMode: AuthMode         = AuthMode.MANAGED,
     val customBackendUrl: String   = "",
@@ -96,7 +97,9 @@ class SettingsViewModel @Inject constructor(
                 directClientSecret = clientSecret,
                 companionRunning = saved.companionEnabled,
                 ollamaUrl = saved.ollamaUrl,
-                modelBaseUrl = saved.modelBaseUrl
+                modelBaseUrl = saved.modelBaseUrl,
+                tmdbApiKey = saved.tmdbApiKey,
+                tmdbConnected = saved.tmdbApiKey.isNotBlank()
             )
         }
     }
@@ -142,6 +145,33 @@ class SettingsViewModel @Inject constructor(
 
     fun setModelBaseUrl(url: String) {
         _uiState.value = _uiState.value.copy(modelBaseUrl = url)
+    }
+
+    fun setTmdbApiKey(key: String) {
+        _uiState.value = _uiState.value.copy(tmdbApiKey = key)
+    }
+
+    fun saveTmdbApiKey() {
+        viewModelScope.launch {
+            val current = settingsRepository.settings.first()
+            val key = _uiState.value.tmdbApiKey
+            settingsRepository.saveSettings(current.copy(tmdbApiKey = key))
+            _uiState.value = _uiState.value.copy(
+                tmdbConnected = key.isNotBlank(),
+                saveSuccess = true
+            )
+        }
+    }
+
+    fun disconnectTmdb() {
+        viewModelScope.launch {
+            val current = settingsRepository.settings.first()
+            settingsRepository.saveSettings(current.copy(tmdbApiKey = ""))
+            _uiState.value = _uiState.value.copy(
+                tmdbApiKey = "",
+                tmdbConnected = false
+            )
+        }
     }
 
     fun saveAdvancedSettings() {

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -37,7 +37,11 @@
     <string name="settings_title">Einstellungen</string>
     <string name="settings_account">Konto</string>
     <string name="settings_trakt_account">Trakt-Konto</string>
+    <string name="settings_tmdb">TMDB</string>
     <string name="settings_tmdb_account">TMDB-Konto</string>
+    <string name="settings_tmdb_connected">Verbunden</string>
+    <string name="settings_tmdb_api_key">TMDB-API-Schlüssel (v3 Auth)</string>
+    <string name="settings_tmdb_helper">Hol dir deinen kostenlosen API-Schlüssel auf themoviedb.org unter Einstellungen → API.</string>
     <string name="settings_disconnect">Trennen</string>
     <string name="settings_companion">Companion-Dienst</string>
     <string name="settings_companion_running">Läuft (Port 8765)</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -37,7 +37,11 @@
     <string name="settings_title">Ajustes</string>
     <string name="settings_account">Cuenta</string>
     <string name="settings_trakt_account">Cuenta de Trakt</string>
+    <string name="settings_tmdb">TMDB</string>
     <string name="settings_tmdb_account">Cuenta de TMDB</string>
+    <string name="settings_tmdb_connected">Conectado</string>
+    <string name="settings_tmdb_api_key">Clave API de TMDB (auth v3)</string>
+    <string name="settings_tmdb_helper">Obtén tu clave API gratuita en themoviedb.org en Ajustes → API.</string>
     <string name="settings_disconnect">Desconectar</string>
     <string name="settings_companion">Servicio compañero</string>
     <string name="settings_companion_running">En ejecución (puerto 8765)</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -37,7 +37,11 @@
     <string name="settings_title">Paramètres</string>
     <string name="settings_account">Compte</string>
     <string name="settings_trakt_account">Compte Trakt</string>
+    <string name="settings_tmdb">TMDB</string>
     <string name="settings_tmdb_account">Compte TMDB</string>
+    <string name="settings_tmdb_connected">Connecté</string>
+    <string name="settings_tmdb_api_key">Clé API TMDB (auth v3)</string>
+    <string name="settings_tmdb_helper">Obtenez votre clé API gratuite sur themoviedb.org sous Paramètres → API.</string>
     <string name="settings_disconnect">Déconnecter</string>
     <string name="settings_companion">Service compagnon</string>
     <string name="settings_companion_running">En cours (port 8765)</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -37,7 +37,11 @@
     <string name="settings_title">Settings</string>
     <string name="settings_account">Account</string>
     <string name="settings_trakt_account">Trakt account</string>
+    <string name="settings_tmdb">TMDB</string>
     <string name="settings_tmdb_account">TMDB account</string>
+    <string name="settings_tmdb_connected">Connected</string>
+    <string name="settings_tmdb_api_key">TMDB API key (v3 auth)</string>
+    <string name="settings_tmdb_helper">Get your free API key at themoviedb.org under Settings → API.</string>
     <string name="settings_disconnect">Disconnect</string>
     <string name="settings_companion">Companion service</string>
     <string name="settings_companion_running">Running (port 8765)</string>

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/TestFixtures.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/TestFixtures.kt
@@ -39,10 +39,12 @@ object TestFixtures {
         llmBackend: LlmBackend = LlmBackend.LITERT,
         modelQuality: Int = 75,
         freeRamMb: Int = 4000,
-        isAvailable: Boolean = true
+        isAvailable: Boolean = true,
+        tmdbConfigured: Boolean = false
     ) = DeviceCapability(
         deviceId = deviceId, userName = userName, deviceName = deviceName,
         llmBackend = llmBackend, modelQuality = modelQuality,
-        freeRamMb = freeRamMb, isAvailable = isAvailable
+        freeRamMb = freeRamMb, isAvailable = isAvailable,
+        tmdbConfigured = tmdbConfigured
     )
 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProviderTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProviderTest.kt
@@ -7,7 +7,9 @@ import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.core.trakt.TraktUserProfile
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import io.mockk.*
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -22,6 +24,7 @@ class DeviceCapabilityProviderTest {
     private val orchestrator: LlmOrchestrator = mockk()
     private val traktApi: TraktApiService = mockk()
     private val tokenRepository: TokenRepository = mockk()
+    private val settingsRepository: SettingsRepository = mockk()
     private val activityManager: ActivityManager = mockk(relaxed = true)
     private lateinit var provider: DeviceCapabilityProvider
 
@@ -42,7 +45,8 @@ class DeviceCapabilityProviderTest {
             LlmOrchestrator.ModelVariant.GEMMA4_E2B,
             70
         )
-        provider = DeviceCapabilityProvider(context, orchestrator, traktApi, tokenRepository)
+        every { settingsRepository.getTmdbApiKey() } returns flowOf("")
+        provider = DeviceCapabilityProvider(context, orchestrator, traktApi, tokenRepository, settingsRepository)
     }
 
     private fun setStaticField(fieldName: String, value: String) {

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/TestFixtures.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/TestFixtures.kt
@@ -36,11 +36,13 @@ object TestFixtures {
         llmBackend: LlmBackend = LlmBackend.LITERT,
         modelQuality: Int = 75,
         freeRamMb: Int = 4000,
-        isAvailable: Boolean = true
+        isAvailable: Boolean = true,
+        tmdbConfigured: Boolean = false
     ) = DeviceCapability(
         deviceId = deviceId, userName = userName, deviceName = deviceName,
         llmBackend = llmBackend, modelQuality = modelQuality,
-        freeRamMb = freeRamMb, isAvailable = isAvailable
+        freeRamMb = freeRamMb, isAvailable = isAvailable,
+        tmdbConfigured = tmdbConfigured
     )
 
     fun scrobbleCandidate(

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -81,7 +81,8 @@ data class DeviceCapability(
     val llmBackend: LlmBackend,         // AICORE, LITERT, NONE
     val modelQuality: Int,              // 0–150 (see scoring docs)
     val freeRamMb: Int,
-    val isAvailable: Boolean = true
+    val isAvailable: Boolean = true,
+    val tmdbConfigured: Boolean = false
 )
 
 enum class LlmBackend { AICORE, LITERT, NONE }

--- a/core/src/test/java/com/justb81/watchbuddy/core/TestFixtures.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/TestFixtures.kt
@@ -76,11 +76,13 @@ object TestFixtures {
         llmBackend: LlmBackend = LlmBackend.LITERT,
         modelQuality: Int = 75,
         freeRamMb: Int = 4000,
-        isAvailable: Boolean = true
+        isAvailable: Boolean = true,
+        tmdbConfigured: Boolean = false
     ) = DeviceCapability(
         deviceId = deviceId, userName = userName, userAvatarUrl = userAvatarUrl,
         deviceName = deviceName, llmBackend = llmBackend, modelQuality = modelQuality,
-        freeRamMb = freeRamMb, isAvailable = isAvailable
+        freeRamMb = freeRamMb, isAvailable = isAvailable,
+        tmdbConfigured = tmdbConfigured
     )
 
     fun scrobbleCandidate(

--- a/core/src/test/java/com/justb81/watchbuddy/core/model/ModelsSerializationTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/model/ModelsSerializationTest.kt
@@ -174,16 +174,17 @@ class ModelsSerializationTest {
     inner class DeviceCapabilityTest {
         @Test
         fun `round-trip with all fields`() {
-            val cap = DeviceCapability("d1", "user", null, "Pixel", LlmBackend.AICORE, 150, 8000, true)
+            val cap = DeviceCapability("d1", "user", null, "Pixel", LlmBackend.AICORE, 150, 8000, true, true)
             val decoded = json.decodeFromString<DeviceCapability>(json.encodeToString(cap))
             assertEquals(cap, decoded)
         }
 
         @Test
-        fun `default isAvailable is true`() {
+        fun `default isAvailable is true and tmdbConfigured is false`() {
             val jsonStr = """{"deviceId":"d1","userName":"u","deviceName":"P","llmBackend":"NONE","modelQuality":0,"freeRamMb":1000}"""
             val cap = json.decodeFromString<DeviceCapability>(jsonStr)
             assertTrue(cap.isAvailable)
+            assertFalse(cap.tmdbConfigured)
         }
     }
 
@@ -193,7 +194,7 @@ class ModelsSerializationTest {
         @ParameterizedTest
         @EnumSource(LlmBackend::class)
         fun `all enum values serialize as strings`(backend: LlmBackend) {
-            val cap = DeviceCapability("d", "u", null, "P", backend, 0, 0, true)
+            val cap = DeviceCapability("d", "u", null, "P", backend, 0, 0, true, false)
             val encoded = json.encodeToString(cap)
             assertTrue(encoded.contains("\"${backend.name}\""))
         }


### PR DESCRIPTION
## Summary

- Add end-to-end TMDB API key management: storage (DataStore), settings UI (phone app), and propagation to all TMDB API calls
- Add a new "TMDB" section to the phone Settings screen with API key input, save/disconnect, connection status, and helper text
- Fall back to the phone's locally stored TMDB API key in `CompanionHttpServer` when the TV sends an empty request body
- Expose `tmdbConfigured` flag in the `/capability` endpoint so the TV knows whether TMDB enrichment is available
- Add localized string resources for EN, DE, FR, ES
- Update `DeviceCapability` model, test fixtures, and serialization tests

## Files changed (16)

| Layer | File | Change |
|-------|------|--------|
| Core model | `core/.../model/Models.kt` | Add `tmdbConfigured` field to `DeviceCapability` |
| Phone settings | `app-phone/.../settings/AppSettings.kt` | Add `tmdbApiKey` field |
| Phone settings | `app-phone/.../settings/SettingsRepository.kt` | Add `TMDB_API_KEY` preference key, `getTmdbApiKey()` flow |
| Phone UI | `app-phone/.../ui/settings/SettingsViewModel.kt` | Add `tmdbApiKey`/`tmdbConnected` state, save/disconnect methods |
| Phone UI | `app-phone/.../ui/settings/SettingsScreen.kt` | Add TMDB configuration section |
| Phone server | `app-phone/.../server/CompanionHttpServer.kt` | Use stored key as fallback in `/recap` endpoint |
| Phone server | `app-phone/.../server/DeviceCapabilityProvider.kt` | Report `tmdbConfigured` in `/capability` |
| Strings | `values/strings.xml` + `values-de/`, `values-fr/`, `values-es/` | Add TMDB UI strings |
| Tests | 4 TestFixtures + `DeviceCapabilityProviderTest` + `ModelsSerializationTest` | Update for new field |

## Test plan

- [ ] Verify CI build passes (compilation + unit tests)
- [ ] On phone app: open Settings → confirm new TMDB section appears below Account
- [ ] Enter a TMDB API key → tap Save → confirm status changes to "Connected"
- [ ] Tap Disconnect → confirm key is cleared and input field reappears
- [ ] On TV app: request a recap → confirm phone uses stored TMDB key (no empty key errors)
- [ ] Verify `/capability` endpoint returns `tmdbConfigured: true` when key is set

Closes #94

https://claude.ai/code/session_01LQfZk4bgmU4Z5HMkTzVjU9