### PR TITLE
feat: implement AICore LLM provider (Gemini Nano)

### DIFF
--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -130,6 +130,9 @@ dependencies {
     // LiteRT-LM (Gemma — RAM-adaptive)
     implementation(libs.litertlm.android)
 
+    // AICore (Gemini Nano)
+    implementation(libs.aicore)
+
     // WorkManager (background model updates)
     implementation(libs.work.runtime)
 

--- a/app-phone/proguard-rules.pro
+++ b/app-phone/proguard-rules.pro
@@ -51,6 +51,10 @@
 -keep class com.google.ai.edge.litertlm.** { *; }
 -dontwarn com.google.ai.edge.litertlm.**
 
+# ── AICore (Gemini Nano) ─────────────────────────────────────────────────────
+-keep class com.google.ai.edge.aicore.** { *; }
+-dontwarn com.google.ai.edge.aicore.**
+
 # ── Coil ─────────────────────────────────────────────────────────────────────
 -dontwarn coil.**
 

--- a/app-phone/src/main/AndroidManifest.xml
+++ b/app-phone/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- AICore declares minSdk 31, but we support 26+.
+         Runtime guard in LlmOrchestrator.isAiCoreAvailable() ensures AICore
+         is only used on Android 14+ (SDK 34+) devices. -->
+    <uses-sdk tools:overrideLibrary="com.google.ai.edge.aicore" />
+
     <!-- Network -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/AiCoreLlmProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/AiCoreLlmProvider.kt
@@ -1,16 +1,16 @@
 package com.justb81.watchbuddy.phone.llm
 
 import android.content.Context
+import com.google.ai.edge.aicore.GenerativeModel
+import com.google.ai.edge.aicore.generationConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * LLM provider backed by Android AICore (Gemini Nano).
  *
  * AICore is available on Android 14+ with supported hardware (Pixel 8+ class).
  * The model is managed by Google Play Services — no manual download required.
- *
- * TODO: Replace stub with real AICore GenerativeModel calls once
- *       com.google.android.gms:play-services-aicore is added as a dependency.
- *       API reference: https://developer.android.com/ai/aicore
  */
 class AiCoreLlmProvider(
     private val context: Context
@@ -18,15 +18,27 @@ class AiCoreLlmProvider(
 
     override val displayName: String = "AICore (Gemini Nano)"
 
-    override suspend fun generate(prompt: String): String {
-        // TODO: Implement with play-services-aicore GenerativeModel API:
-        //   val generativeModel = GenerativeModel.newBuilder()
-        //       .setModelName("gemini-nano")
-        //       .build()
-        //   val response = generativeModel.generateContent(prompt)
-        //   return response.text ?: throw IllegalStateException("AICore returned empty response")
-        throw UnsupportedOperationException(
-            "AICore provider not yet implemented — add play-services-aicore dependency"
-        )
+    private var generativeModel: GenerativeModel? = null
+
+    private fun getOrCreateModel(): GenerativeModel {
+        generativeModel?.let { return it }
+
+        val config = generationConfig {
+            this.context = this@AiCoreLlmProvider.context
+        }
+
+        val model = GenerativeModel(config)
+        generativeModel = model
+        return model
+    }
+
+    override suspend fun generate(prompt: String): String = withContext(Dispatchers.IO) {
+        val model = getOrCreateModel()
+        val response = model.generateContent(prompt)
+        val text = response.text
+        if (text.isNullOrBlank()) {
+            throw IllegalStateException("AICore returned empty response")
+        }
+        text
     }
 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/AiCoreLlmProviderTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/AiCoreLlmProviderTest.kt
@@ -1,9 +1,19 @@
 package com.justb81.watchbuddy.phone.llm
 
 import android.content.Context
+import com.google.ai.edge.aicore.GenerateContentResponse
+import com.google.ai.edge.aicore.GenerativeModel
+import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -13,18 +23,85 @@ class AiCoreLlmProviderTest {
     private val context: Context = mockk(relaxed = true)
     private val provider = AiCoreLlmProvider(context)
 
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
     @Test
     fun `displayName is AICore (Gemini Nano)`() {
         assertEquals("AICore (Gemini Nano)", provider.displayName)
     }
 
-    @Test
-    fun `generate throws UnsupportedOperationException`() {
-        val exception = assertThrows<UnsupportedOperationException> {
-            kotlinx.coroutines.test.runTest {
+    @Nested
+    @DisplayName("generate")
+    inner class GenerateTest {
+
+        @BeforeEach
+        fun setUp() {
+            mockkConstructor(GenerativeModel::class)
+        }
+
+        @Test
+        fun `returns text from GenerativeModel response`() = runTest {
+            val mockResponse = mockk<GenerateContentResponse>()
+            every { mockResponse.text } returns "Generated recap HTML"
+            coEvery {
+                anyConstructed<GenerativeModel>().generateContent(any<String>())
+            } returns mockResponse
+
+            val result = provider.generate("test prompt")
+            assertEquals("Generated recap HTML", result)
+        }
+
+        @Test
+        fun `throws IllegalStateException on null response text`() = runTest {
+            val mockResponse = mockk<GenerateContentResponse>()
+            every { mockResponse.text } returns null
+            coEvery {
+                anyConstructed<GenerativeModel>().generateContent(any<String>())
+            } returns mockResponse
+
+            assertThrows<IllegalStateException> {
                 provider.generate("test prompt")
             }
         }
-        assertTrue(exception.message!!.contains("play-services-aicore"))
+
+        @Test
+        fun `throws IllegalStateException on blank response text`() = runTest {
+            val mockResponse = mockk<GenerateContentResponse>()
+            every { mockResponse.text } returns "   "
+            coEvery {
+                anyConstructed<GenerativeModel>().generateContent(any<String>())
+            } returns mockResponse
+
+            assertThrows<IllegalStateException> {
+                provider.generate("test prompt")
+            }
+        }
+
+        @Test
+        fun `propagates AICore exceptions for cascade fallback`() = runTest {
+            coEvery {
+                anyConstructed<GenerativeModel>().generateContent(any<String>())
+            } throws RuntimeException("AICore service unavailable")
+
+            assertThrows<RuntimeException> {
+                provider.generate("test prompt")
+            }
+        }
+
+        @Test
+        fun `reuses cached model on subsequent calls`() = runTest {
+            val mockResponse = mockk<GenerateContentResponse>()
+            every { mockResponse.text } returns "response"
+            coEvery {
+                anyConstructed<GenerativeModel>().generateContent(any<String>())
+            } returns mockResponse
+
+            // Both calls should succeed using the same cached model
+            assertEquals("response", provider.generate("first prompt"))
+            assertEquals("response", provider.generate("second prompt"))
+        }
     }
 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactoryTest.kt
@@ -93,7 +93,7 @@ class LlmProviderFactoryTest {
             every { orchestrator.selectConfig() } returns LlmOrchestrator.LlmConfig(
                 LlmBackend.AICORE, null, 150
             )
-            // AICore throws UnsupportedOperationException, then cascade continues
+            // AICore fails (no Play Services in test), then cascade continues
             val result = factory.generateWithCascade("prompt", episodes)
             assertNotNull(result)
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ okhttp = "4.12.0"
 coroutines = "1.10.1"
 serialization = "1.7.3"
 litertlm = "0.10.0"
+aicore = "0.0.1-exp02"
 coil = "2.7.0"
 navigation = "2.9.0"
 datastore = "1.1.1"
@@ -79,6 +80,9 @@ security-crypto = { group = "androidx.security", name = "security-crypto", versi
 
 # LiteRT-LM (phone)
 litertlm-android = { group = "com.google.ai.edge.litertlm", name = "litertlm-android", version.ref = "litertlm" }
+
+# AICore (Gemini Nano)
+aicore = { group = "com.google.ai.edge.aicore", name = "aicore", version.ref = "aicore" }
 
 # Image loading
 coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }


### PR DESCRIPTION
## Summary

- Implement `AiCoreLlmProvider` using Google's AICore library (`com.google.ai.edge.aicore:aicore:0.0.1-exp02`) with the `GenerativeModel` API
- Add dependency to version catalog and app-phone build, ProGuard keep rules, and manifest `tools:overrideLibrary` for AICore's minSdk 31 (runtime-guarded to SDK 34+ by `LlmOrchestrator`)
- Rewrite `AiCoreLlmProviderTest` with 6 test cases covering happy path, null/blank response, exception propagation, and model caching

## Details

The provider follows the same patterns as `LiteRtLlmProvider`:
- Lazy-initializes `GenerativeModel` via `generationConfig { context = ... }`, caches as instance field
- Runs inference on `Dispatchers.IO` via `withContext`
- Validates `response.text` is non-null/non-blank, throws `IllegalStateException` if empty
- Lets AICore exceptions propagate for cascade fallback in `LlmProviderFactory`

### Files changed

| File | Change |
|------|--------|
| `gradle/libs.versions.toml` | Add `aicore = "0.0.1-exp02"` version + library entry |
| `app-phone/build.gradle.kts` | Add `implementation(libs.aicore)` |
| `app-phone/.../AiCoreLlmProvider.kt` | Replace stub with real GenerativeModel implementation |
| `app-phone/.../AiCoreLlmProviderTest.kt` | Rewrite with mocked GenerativeModel (6 tests) |
| `app-phone/.../LlmProviderFactoryTest.kt` | Update outdated comment |
| `app-phone/proguard-rules.pro` | Add AICore keep/dontwarn rules |
| `app-phone/src/main/AndroidManifest.xml` | Add `tools:overrideLibrary` for AICore minSdk |

## Test plan

- [x] `./gradlew :app-phone:compileDebugKotlin` — compiles successfully
- [x] `./gradlew :app-phone:test` — all unit tests pass (including 6 new AICore tests + existing cascade tests)
- [x] `./gradlew :app-phone:assembleDebug` — debug APK builds successfully
- [ ] CI green on `build-android.yml`

Closes #83

https://claude.ai/code/session_01UX7hmN4w8VRm7ina9HgPoP