### PR TITLE
fix: prevent OOM crash during model download and add GPU fallback

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LiteRtLlmProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LiteRtLlmProvider.kt
@@ -1,6 +1,7 @@
 package com.justb81.watchbuddy.phone.llm
 
 import android.content.Context
+import android.util.Log
 import com.google.ai.edge.litertlm.Backend
 import com.google.ai.edge.litertlm.ConversationConfig
 import com.google.ai.edge.litertlm.Engine
@@ -37,15 +38,21 @@ class LiteRtLlmProvider(
             )
         }
 
-        val config = EngineConfig(
-            modelPath = modelPath,
-            backend = Backend.GPU()
-        )
+        val newEngine = try {
+            val gpuConfig = EngineConfig(modelPath = modelPath, backend = Backend.GPU())
+            Engine(gpuConfig).also { it.initialize() }
+        } catch (e: Exception) {
+            Log.w(TAG, "GPU backend unavailable, falling back to CPU", e)
+            val cpuConfig = EngineConfig(modelPath = modelPath, backend = Backend.CPU())
+            Engine(cpuConfig).also { it.initialize() }
+        }
 
-        val newEngine = Engine(config)
-        newEngine.initialize()
         engine = newEngine
         return newEngine
+    }
+
+    companion object {
+        private const val TAG = "LiteRtLlmProvider"
     }
 
     override suspend fun generate(prompt: String): String = withContext(Dispatchers.IO) {

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorker.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorker.kt
@@ -9,18 +9,21 @@ import androidx.work.workDataOf
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
 import java.io.FileOutputStream
-import java.util.concurrent.TimeUnit
+import javax.inject.Named
 
 @HiltWorker
 class ModelDownloadWorker @AssistedInject constructor(
     @Assisted appContext: Context,
     @Assisted workerParams: WorkerParameters,
     private val settingsRepository: SettingsRepository,
-    private val httpClient: OkHttpClient
+    @Named("download") private val downloadClient: OkHttpClient
 ) : CoroutineWorker(appContext, workerParams) {
 
     override suspend fun doWork(): Result {
@@ -34,7 +37,9 @@ class ModelDownloadWorker @AssistedInject constructor(
 
         try {
             downloadFile(modelUrl, tempFile)
-            tempFile.renameTo(outputFile)
+            if (!tempFile.renameTo(outputFile)) {
+                throw RuntimeException("Failed to rename downloaded model to final path")
+            }
             settingsRepository.setModelReady(true)
             setProgress(workDataOf(KEY_PROGRESS to 100))
             return Result.success(workDataOf(KEY_PROGRESS to 100))
@@ -49,41 +54,43 @@ class ModelDownloadWorker @AssistedInject constructor(
         }
     }
 
-    private suspend fun downloadFile(url: String, target: File) {
-        val client = httpClient.newBuilder()
-            .connectTimeout(30, TimeUnit.SECONDS)
-            .readTimeout(60, TimeUnit.SECONDS)
-            .build()
-
+    private suspend fun downloadFile(url: String, target: File) = withContext(Dispatchers.IO) {
         val request = Request.Builder().url(url).build()
-        val response = client.newCall(request).execute()
+        downloadClient.newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw RuntimeException("HTTP ${response.code}: ${response.message}")
+            }
 
-        if (!response.isSuccessful) {
-            throw RuntimeException("HTTP ${response.code}: ${response.message}")
-        }
+            val body = response.body ?: throw RuntimeException("Empty response body")
+            val contentLength = body.contentLength()
 
-        val body = response.body ?: throw RuntimeException("Empty response body")
-        val contentLength = body.contentLength()
+            body.byteStream().use { input ->
+                FileOutputStream(target).use { output ->
+                    val buffer = ByteArray(BUFFER_SIZE)
+                    var bytesRead: Long = 0
+                    var lastReportedProgress = -1
 
-        body.byteStream().use { input ->
-            FileOutputStream(target).use { output ->
-                val buffer = ByteArray(BUFFER_SIZE)
-                var bytesRead: Long = 0
-                var lastReportedProgress = -1
+                    while (true) {
+                        if (isStopped) throw CancellationException("Download cancelled")
+                        val read = input.read(buffer)
+                        if (read == -1) break
+                        output.write(buffer, 0, read)
+                        bytesRead += read
 
-                while (true) {
-                    val read = input.read(buffer)
-                    if (read == -1) break
-                    output.write(buffer, 0, read)
-                    bytesRead += read
-
-                    if (contentLength > 0) {
-                        val progress = ((bytesRead * 100) / contentLength).toInt()
-                            .coerceIn(0, 99)
-                        if (progress != lastReportedProgress) {
-                            setProgress(workDataOf(KEY_PROGRESS to progress))
-                            lastReportedProgress = progress
+                        if (contentLength > 0) {
+                            val progress = ((bytesRead * 100) / contentLength).toInt()
+                                .coerceIn(0, 99)
+                            if (progress != lastReportedProgress) {
+                                setProgress(workDataOf(KEY_PROGRESS to progress))
+                                lastReportedProgress = progress
+                            }
                         }
+                    }
+
+                    if (contentLength > 0 && bytesRead != contentLength) {
+                        throw RuntimeException(
+                            "Incomplete download: expected $contentLength bytes, got $bytesRead"
+                        )
                     }
                 }
             }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorkerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorkerTest.kt
@@ -185,11 +185,12 @@ class ModelDownloadWorkerTest {
         @Test
         fun `detects incomplete download when content-length mismatches`() = runTest {
             val fullContent = "complete model data here"
-            // Advertise full content-length but disconnect early
+            // setBody() overrides Content-Length, so set the header AFTER setBody
+            // to advertise the full length while only sending partial data
             server.enqueue(
                 MockResponse()
-                    .setHeader("Content-Length", fullContent.length)
                     .setBody("partial")
+                    .setHeader("Content-Length", fullContent.length)
                     .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END)
             )
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorkerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorkerTest.kt
@@ -16,10 +16,12 @@ import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
@@ -32,7 +34,7 @@ class ModelDownloadWorkerTest {
     }
 
     private lateinit var server: MockWebServer
-    private val client = OkHttpClient()
+    private val downloadClient = OkHttpClient()
     private val context: Context = mockk(relaxed = true)
     private val workerParams: WorkerParameters = mockk(relaxed = true)
     private val settingsRepository: SettingsRepository = mockk(relaxed = true)
@@ -66,98 +68,171 @@ class ModelDownloadWorkerTest {
             Data.EMPTY
         }
         every { workerParams.inputData } returns inputData
-        // Must be set before construction — ListenableWorker caches this value
         every { workerParams.runAttemptCount } returns attemptCount
-        // Use spyk to intercept setProgress which would otherwise hang
-        // because the mocked WorkerParameters cannot provide a real ProgressUpdater
         val worker = spyk(
-            ModelDownloadWorker(context, workerParams, settingsRepository, client)
+            ModelDownloadWorker(context, workerParams, settingsRepository, downloadClient)
         )
         coEvery { worker.setProgress(any()) } just Runs
         return worker
     }
 
-    @Test
-    fun `downloads file using injected OkHttpClient`() = runTest {
-        val content = "model binary data"
-        server.enqueue(
-            MockResponse()
-                .setBody(content)
-                .setHeader("Content-Length", content.length)
-        )
+    @Nested
+    @DisplayName("Successful downloads")
+    inner class SuccessfulDownloads {
 
-        val worker = createWorker(server.url("/model.bin").toString())
-        val result = worker.doWork()
+        @Test
+        fun `downloads file using dedicated download client`() = runTest {
+            val content = "model binary data"
+            server.enqueue(
+                MockResponse()
+                    .setBody(content)
+                    .setHeader("Content-Length", content.length)
+            )
 
-        assertTrue(result is Result.Success)
+            val worker = createWorker(server.url("/model.bin").toString())
+            val result = worker.doWork()
 
-        val request = server.takeRequest()
-        assertEquals("GET", request.method)
+            assertTrue(result is Result.Success)
 
-        val outputFile = File(tempDir, MODEL_FILENAME)
-        assertTrue(outputFile.exists())
-        assertEquals(content, outputFile.readText())
+            val request = server.takeRequest()
+            assertEquals("GET", request.method)
+
+            val outputFile = File(tempDir, MODEL_FILENAME)
+            assertTrue(outputFile.exists())
+            assertEquals(content, outputFile.readText())
+        }
+
+        @Test
+        fun `sets model ready on successful download`() = runTest {
+            server.enqueue(MockResponse().setBody("data"))
+
+            val worker = createWorker(server.url("/model.bin").toString())
+            worker.doWork()
+
+            verify { settingsRepository.setModelReady(true) }
+        }
+
+        @Test
+        fun `does not send Trakt headers on download requests`() = runTest {
+            server.enqueue(MockResponse().setBody("data"))
+
+            val worker = createWorker(server.url("/model.bin").toString())
+            worker.doWork()
+
+            val request = server.takeRequest()
+            assertNull(request.getHeader("trakt-api-version"))
+        }
+
+        @Test
+        fun `removes temp file after successful rename`() = runTest {
+            server.enqueue(MockResponse().setBody("data"))
+
+            val worker = createWorker(server.url("/model.bin").toString())
+            worker.doWork()
+
+            val tempFile = File(tempDir, "$MODEL_FILENAME.tmp")
+            assertFalse(tempFile.exists())
+        }
     }
 
-    @Test
-    fun `returns failure when no model URL provided`() = runTest {
-        val worker = createWorker(null)
-        val result = worker.doWork()
-        assertTrue(result is Result.Failure)
+    @Nested
+    @DisplayName("Failure handling")
+    inner class FailureHandling {
+
+        @Test
+        fun `returns failure when no model URL provided`() = runTest {
+            val worker = createWorker(null)
+            val result = worker.doWork()
+            assertTrue(result is Result.Failure)
+        }
+
+        @Test
+        fun `returns retry on HTTP error when attempts remain`() = runTest {
+            server.enqueue(MockResponse().setResponseCode(500).setBody("Server Error"))
+
+            val worker = createWorker(server.url("/model.bin").toString(), attemptCount = 1)
+            val result = worker.doWork()
+
+            assertTrue(result is Result.Retry)
+        }
+
+        @Test
+        fun `returns failure on HTTP error when max retries exceeded`() = runTest {
+            server.enqueue(MockResponse().setResponseCode(500).setBody("Server Error"))
+
+            val worker = createWorker(server.url("/model.bin").toString(), attemptCount = 3)
+            val result = worker.doWork()
+
+            assertTrue(result is Result.Failure)
+        }
+
+        @Test
+        fun `cleans up temp file on failure`() = runTest {
+            server.enqueue(MockResponse().setResponseCode(500).setBody("Server Error"))
+
+            val worker = createWorker(server.url("/model.bin").toString())
+            worker.doWork()
+
+            val tempFile = File(tempDir, "$MODEL_FILENAME.tmp")
+            assertFalse(tempFile.exists())
+        }
     }
 
-    @Test
-    fun `returns retry on HTTP error when attempts remain`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(500).setBody("Server Error"))
+    @Nested
+    @DisplayName("Download integrity")
+    inner class DownloadIntegrity {
 
-        val worker = createWorker(server.url("/model.bin").toString(), attemptCount = 1)
-        val result = worker.doWork()
+        @Test
+        fun `detects incomplete download when content-length mismatches`() = runTest {
+            val fullContent = "complete model data here"
+            // Advertise full content-length but disconnect early
+            server.enqueue(
+                MockResponse()
+                    .setHeader("Content-Length", fullContent.length)
+                    .setBody("partial")
+                    .setSocketPolicy(SocketPolicy.DISCONNECT_AT_END)
+            )
 
-        assertTrue(result is Result.Retry)
+            val worker = createWorker(server.url("/model.bin").toString(), attemptCount = 3)
+            val result = worker.doWork()
+
+            // Should fail because bytesRead ("partial".length) != contentLength (fullContent.length)
+            assertTrue(result is Result.Failure)
+        }
+
+        @Test
+        fun `succeeds when content-length matches downloaded bytes`() = runTest {
+            val content = "exact content"
+            server.enqueue(
+                MockResponse()
+                    .setBody(content)
+                    .setHeader("Content-Length", content.length)
+            )
+
+            val worker = createWorker(server.url("/model.bin").toString())
+            val result = worker.doWork()
+
+            assertTrue(result is Result.Success)
+            assertEquals(content, File(tempDir, MODEL_FILENAME).readText())
+        }
     }
 
-    @Test
-    fun `returns failure on HTTP error when max retries exceeded`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(500).setBody("Server Error"))
+    @Nested
+    @DisplayName("Client isolation")
+    inner class ClientIsolation {
 
-        val worker = createWorker(server.url("/model.bin").toString(), attemptCount = 3)
-        val result = worker.doWork()
+        @Test
+        fun `uses dedicated download client for multiple workers`() = runTest {
+            server.enqueue(MockResponse().setBody("data1"))
+            server.enqueue(MockResponse().setBody("data2"))
 
-        assertTrue(result is Result.Failure)
-    }
+            val worker1 = createWorker(server.url("/model1.bin").toString())
+            worker1.doWork()
 
-    @Test
-    fun `cleans up temp file on failure`() = runTest {
-        server.enqueue(MockResponse().setResponseCode(500).setBody("Server Error"))
+            val worker2 = createWorker(server.url("/model2.bin").toString())
+            worker2.doWork()
 
-        val worker = createWorker(server.url("/model.bin").toString())
-        worker.doWork()
-
-        val tempFile = File(tempDir, "$MODEL_FILENAME.tmp")
-        assertFalse(tempFile.exists())
-    }
-
-    @Test
-    fun `sets model ready on successful download`() = runTest {
-        server.enqueue(MockResponse().setBody("data"))
-
-        val worker = createWorker(server.url("/model.bin").toString())
-        worker.doWork()
-
-        verify { settingsRepository.setModelReady(true) }
-    }
-
-    @Test
-    fun `uses shared OkHttpClient instead of creating new instance`() = runTest {
-        server.enqueue(MockResponse().setBody("data1"))
-        server.enqueue(MockResponse().setBody("data2"))
-
-        val worker1 = createWorker(server.url("/model1.bin").toString())
-        worker1.doWork()
-
-        val worker2 = createWorker(server.url("/model2.bin").toString())
-        worker2.doWork()
-
-        assertEquals(2, server.requestCount)
+            assertEquals(2, server.requestCount)
+        }
     }
 }

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
@@ -14,6 +14,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -55,6 +56,22 @@ object NetworkModule {
             level = if (isDebug) HttpLoggingInterceptor.Level.BODY
                     else HttpLoggingInterceptor.Level.NONE
         })
+        .build()
+
+    /**
+     * Plain OkHttpClient for large file downloads (e.g. LLM models from Hugging Face).
+     *
+     * Intentionally omits all API-specific configuration: no logging interceptor
+     * (which would buffer the entire response body in memory, causing OOM on
+     * multi-GB downloads), no certificate pinning (not needed for CDN hosts),
+     * and no Trakt headers.
+     */
+    @Provides
+    @Singleton
+    @Named("download")
+    fun provideDownloadClient(): OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(30, TimeUnit.SECONDS)
+        .readTimeout(60, TimeUnit.SECONDS)
         .build()
 
     @Provides

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
@@ -108,6 +108,47 @@ class NetworkModuleTest {
     }
 
     @Nested
+    @DisplayName("provideDownloadClient")
+    inner class DownloadClientTest {
+
+        private lateinit var server: MockWebServer
+
+        @BeforeEach
+        fun setUp() {
+            server = MockWebServer()
+            server.start()
+        }
+
+        @AfterEach
+        fun tearDown() {
+            server.shutdown()
+        }
+
+        @Test
+        fun `does not add Trakt headers`() {
+            server.enqueue(MockResponse().setBody("data"))
+            val client = NetworkModule.provideDownloadClient()
+            client.newCall(Request.Builder().url(server.url("/download")).build()).execute()
+            val recorded = server.takeRequest()
+            assertNull(recorded.getHeader("trakt-api-version"))
+            assertNull(recorded.getHeader("Content-Type"))
+        }
+
+        @Test
+        fun `does not include logging interceptor`() {
+            val client = NetworkModule.provideDownloadClient()
+            assertTrue(client.interceptors.isEmpty())
+        }
+
+        @Test
+        fun `has appropriate timeouts`() {
+            val client = NetworkModule.provideDownloadClient()
+            assertEquals(30_000, client.connectTimeoutMillis)
+            assertEquals(60_000, client.readTimeoutMillis)
+        }
+    }
+
+    @Nested
     @DisplayName("Retrofit base URLs")
     inner class RetrofitBaseUrlTest {
         @Test


### PR DESCRIPTION
## Summary

Fixes #99 — Model download force-closes the phone app due to `OutOfMemoryError`.

**Root cause:** The shared singleton `OkHttpClient` (from `NetworkModule`) has `HttpLoggingInterceptor` set to `Level.BODY` in debug builds. When downloading a 2–3 GB Gemma model from Hugging Face, the logging interceptor buffers the **entire response body in memory** before passing it downstream, causing an immediate OOM crash.

**Additional issues fixed:**
- HTTP `Response` object was never properly closed (only the body stream via `.use{}`)
- `renameTo()` return value was ignored — silent rename failures left the model in `.tmp` state while marking it as ready
- No cooperative cancellation — `isStopped` was never checked, so WorkManager couldn't cancel an in-progress download
- No download integrity check — truncated downloads were marked as ready
- Download ran on `Dispatchers.Default` instead of `Dispatchers.IO`
- `LiteRtLlmProvider` used `Backend.GPU()` with no fallback — devices without GPU support would crash

### Changes

| File | Change |
|------|--------|
| `core/.../NetworkModule.kt` | Add `@Named("download")` OkHttpClient — plain client with no interceptors, no cert pinning, no Trakt headers |
| `app-phone/.../ModelDownloadWorker.kt` | Inject download client, use `response.use{}`, add `isStopped` cancellation check, validate Content-Length, check `renameTo()`, use `Dispatchers.IO` |
| `app-phone/.../LiteRtLlmProvider.kt` | Add GPU→CPU fallback with try-catch around engine initialization |
| `core/.../NetworkModuleTest.kt` | Add tests for download client (no headers, no interceptors, correct timeouts) |
| `app-phone/.../ModelDownloadWorkerTest.kt` | Update tests for new constructor, add integrity check and client isolation tests |

## Test plan

- [ ] `./gradlew assembleDebug` builds successfully
- [ ] `./gradlew :core:test :app-phone:test` — all unit tests pass
- [ ] Verify model download completes without OOM crash in debug builds
- [ ] Verify download requests do not include Trakt headers or logging
- [ ] Verify incomplete downloads are detected and retried
- [ ] Verify `renameTo()` failure is caught and reported
- [ ] Verify LiteRT-LM falls back to CPU backend when GPU is unavailable

https://claude.ai/code/session_01KN5e6ZCAYDYV6KrZaLoX1x