### PR TITLE
fix: make Connect with Trakt work for all auth modes

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
@@ -61,12 +61,9 @@ fun PhoneNavGraph(
 
         composable(PhoneRoute.Connect.route) {
             OnboardingScreen(
-                onSuccess = {
-                    navController.navigate(PhoneRoute.Home.route) {
-                        popUpTo(navController.graph.id) { inclusive = true }
-                    }
-                },
-                onSkip = { navController.popBackStack() }
+                onSuccess = { navController.popBackStack() },
+                onSkip = { navController.popBackStack() },
+                isReconnect = true
             )
         }
     }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingScreen.kt
@@ -23,6 +23,7 @@ import com.justb81.watchbuddy.R
 fun OnboardingScreen(
     onSuccess: () -> Unit,
     onSkip: () -> Unit,
+    isReconnect: Boolean = false,
     viewModel: OnboardingViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsState()
@@ -50,7 +51,8 @@ fun OnboardingScreen(
         ) {
             // Logo / Title
             Text(
-                text = stringResource(R.string.app_name),
+                text = if (isReconnect) stringResource(R.string.onboarding_reconnect_title)
+                       else stringResource(R.string.app_name),
                 style = MaterialTheme.typography.displaySmall,
                 color = MaterialTheme.colorScheme.primary,
                 fontWeight = FontWeight.Bold
@@ -124,7 +126,10 @@ fun OnboardingScreen(
 
             TextButton(onClick = onSkip) {
                 Text(
-                    stringResource(R.string.onboarding_skip),
+                    stringResource(
+                        if (isReconnect) R.string.settings_cancel
+                        else R.string.onboarding_skip
+                    ),
                     color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
                 )
             }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
@@ -4,19 +4,24 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.network.TokenProxyServiceFactory
 import com.justb81.watchbuddy.core.trakt.DeviceCodeRequest
 import com.justb81.watchbuddy.core.trakt.DeviceCodeResponse
+import com.justb81.watchbuddy.core.trakt.DeviceTokenRequest
 import com.justb81.watchbuddy.core.trakt.ProxyTokenRequest
 import com.justb81.watchbuddy.core.trakt.TokenProxyService
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import com.justb81.watchbuddy.phone.ui.settings.AuthMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
@@ -33,8 +38,6 @@ sealed class OnboardingState {
     object Polling : OnboardingState()
     data class Success(val username: String) : OnboardingState()
     data class Error(val message: String) : OnboardingState()
-
-    /** Trakt nicht konfiguriert — CLIENT_ID oder TOKEN_BACKEND_URL fehlt. */
     object NotConfigured : OnboardingState()
 }
 
@@ -42,42 +45,53 @@ sealed class OnboardingState {
 class OnboardingViewModel @Inject constructor(
     application: Application,
     private val traktApi: TraktApiService,
-    /** Null, wenn TOKEN_BACKEND_URL in BuildConfig leer ist. */
     private val tokenProxy: TokenProxyService?,
-    @param:Named("traktClientId") private val clientId: String,
-    private val tokenRepository: TokenRepository
+    @param:Named("traktClientId") private val buildConfigClientId: String,
+    private val tokenRepository: TokenRepository,
+    private val settingsRepository: SettingsRepository,
+    private val tokenProxyServiceFactory: TokenProxyServiceFactory
 ) : AndroidViewModel(application) {
 
     private val _state = MutableStateFlow<OnboardingState>(OnboardingState.Idle)
     val state: StateFlow<OnboardingState> = _state.asStateFlow()
 
-    /**
-     * True, wenn sowohl CLIENT_ID als auch Token-Proxy konfiguriert sind.
-     * Wird vom UI genutzt, um den Trakt-Login-Button ein-/auszublenden.
-     */
-    val isTraktConfigured: Boolean
-        get() = clientId.isNotBlank() && tokenProxy != null
-
-    init {
-        if (!isTraktConfigured) {
-            _state.value = OnboardingState.NotConfigured
-        }
-    }
-
     private var countdownJob: Job? = null
     private var pollingJob: Job? = null
 
-    fun requestDeviceCode() {
-        if (!isTraktConfigured) {
-            _state.value = OnboardingState.NotConfigured
-            return
+    /**
+     * Resolves the effective client ID based on the current auth mode.
+     * Returns null if the required configuration for the active mode is missing.
+     */
+    private fun resolveClientId(authMode: AuthMode, backendUrl: String, directClientId: String): String? {
+        return when (authMode) {
+            AuthMode.MANAGED -> buildConfigClientId.takeIf {
+                it.isNotBlank() && tokenProxy != null
+            }
+            AuthMode.SELF_HOSTED -> buildConfigClientId.takeIf {
+                it.isNotBlank() && backendUrl.isNotBlank()
+            }
+            AuthMode.DIRECT -> directClientId.takeIf {
+                it.isNotBlank() && settingsRepository.getClientSecret().isNotBlank()
+            }
         }
+    }
+
+    fun requestDeviceCode() {
         viewModelScope.launch {
             _state.value = OnboardingState.LoadingCode
             try {
+                val settings = settingsRepository.settings.first()
+                val clientId = resolveClientId(
+                    settings.authMode, settings.backendUrl, settings.directClientId
+                )
+                if (clientId == null) {
+                    _state.value = OnboardingState.NotConfigured
+                    return@launch
+                }
+
                 val response = traktApi.requestDeviceCode(DeviceCodeRequest(clientId))
                 startCountdown(response)
-                startPolling(response)
+                startPolling(response, settings.authMode, settings.backendUrl, clientId)
             } catch (e: Exception) {
                 _state.value = OnboardingState.Error(
                     getApplication<Application>().getString(
@@ -108,27 +122,62 @@ class OnboardingViewModel @Inject constructor(
         }
     }
 
-    private fun startPolling(response: DeviceCodeResponse) {
+    private fun startPolling(
+        response: DeviceCodeResponse,
+        authMode: AuthMode,
+        backendUrl: String,
+        clientId: String
+    ) {
         pollingJob?.cancel()
         pollingJob = viewModelScope.launch {
-            val proxy = tokenProxy ?: run {
-                _state.value = OnboardingState.Error("Trakt not configured")
-                return@launch
-            }
             var attempts = 0
             val maxAttempts = response.expires_in / response.interval
             while (isActive && attempts < maxAttempts) {
                 delay(response.interval * 1_000L)
                 try {
-                    val token = proxy.exchangeDeviceCode(
-                        ProxyTokenRequest(code = response.device_code)
-                    )
+                    val accessToken: String
+                    val refreshToken: String
+                    val expiresIn: Int
+
+                    when (authMode) {
+                        AuthMode.MANAGED -> {
+                            val token = tokenProxy!!.exchangeDeviceCode(
+                                ProxyTokenRequest(code = response.device_code)
+                            )
+                            accessToken = token.access_token
+                            refreshToken = token.refresh_token
+                            expiresIn = token.expires_in
+                        }
+                        AuthMode.SELF_HOSTED -> {
+                            val proxy = tokenProxyServiceFactory.create(backendUrl)
+                            val token = proxy.exchangeDeviceCode(
+                                ProxyTokenRequest(code = response.device_code)
+                            )
+                            accessToken = token.access_token
+                            refreshToken = token.refresh_token
+                            expiresIn = token.expires_in
+                        }
+                        AuthMode.DIRECT -> {
+                            val secret = settingsRepository.getClientSecret()
+                            val token = traktApi.pollDeviceToken(
+                                DeviceTokenRequest(
+                                    code = response.device_code,
+                                    client_id = clientId,
+                                    client_secret = secret
+                                )
+                            )
+                            accessToken = token.access_token
+                            refreshToken = token.refresh_token
+                            expiresIn = token.expires_in
+                        }
+                    }
+
                     tokenRepository.saveTokens(
-                        accessToken  = token.access_token,
-                        refreshToken = token.refresh_token,
-                        expiresIn    = token.expires_in
+                        accessToken  = accessToken,
+                        refreshToken = refreshToken,
+                        expiresIn    = expiresIn
                     )
-                    val profile = traktApi.getProfile("Bearer ${token.access_token}")
+                    val profile = traktApi.getProfile("Bearer $accessToken")
                     countdownJob?.cancel()
                     _state.value = OnboardingState.Success(profile.username)
                     return@launch

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -18,6 +18,7 @@
     <string name="onboarding_code_expired">Code abgelaufen. Bitte erneut versuchen.</string>
     <string name="onboarding_not_configured">Trakt ist noch nicht konfiguriert. Du kannst deine Zugangsdaten in den Einstellungen einrichten.</string>
     <string name="onboarding_skip">Jetzt überspringen</string>
+    <string name="onboarding_reconnect_title">Mit Trakt verbinden</string>
 
     <!-- Home -->
     <string name="home_title">Meine Serien</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -18,6 +18,7 @@
     <string name="onboarding_code_expired">Código expirado. Por favor, inténtalo de nuevo.</string>
     <string name="onboarding_not_configured">Trakt aún no está configurado. Puedes configurar tus credenciales en los ajustes.</string>
     <string name="onboarding_skip">Omitir por ahora</string>
+    <string name="onboarding_reconnect_title">Conectar con Trakt</string>
 
     <!-- Home -->
     <string name="home_title">Mis series</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -18,6 +18,7 @@
     <string name="onboarding_code_expired">Code expiré. Veuillez réessayer.</string>
     <string name="onboarding_not_configured">Trakt n\'est pas encore configuré. Vous pouvez configurer vos identifiants dans les paramètres.</string>
     <string name="onboarding_skip">Ignorer pour le moment</string>
+    <string name="onboarding_reconnect_title">Se connecter à Trakt</string>
 
     <!-- Home -->
     <string name="home_title">Mes séries</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="onboarding_code_expired">Code expired. Please try again.</string>
     <string name="onboarding_not_configured">Trakt is not configured yet. You can set up your credentials in Settings.</string>
     <string name="onboarding_skip">Skip for now</string>
+    <string name="onboarding_reconnect_title">Connect to Trakt</string>
 
     <!-- Home -->
     <string name="home_title">My Shows</string>

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelTest.kt
@@ -1,0 +1,240 @@
+package com.justb81.watchbuddy.phone.ui.onboarding
+
+import android.app.Application
+import com.justb81.watchbuddy.core.network.TokenProxyServiceFactory
+import com.justb81.watchbuddy.core.trakt.DeviceCodeResponse
+import com.justb81.watchbuddy.core.trakt.DeviceTokenResponse
+import com.justb81.watchbuddy.core.trakt.ProxyTokenResponse
+import com.justb81.watchbuddy.core.trakt.TokenProxyService
+import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.core.trakt.TraktUserProfile
+import com.justb81.watchbuddy.phone.MainDispatcherRule
+import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.settings.AppSettings
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import com.justb81.watchbuddy.phone.ui.settings.AuthMode
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("OnboardingViewModel")
+class OnboardingViewModelTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcherRule = MainDispatcherRule()
+
+        private const val BUILD_CLIENT_ID = "test-client-id"
+        private const val CUSTOM_BACKEND_URL = "https://my-proxy.example.com"
+        private const val DIRECT_CLIENT_ID = "direct-id"
+        private const val DIRECT_CLIENT_SECRET = "direct-secret"
+    }
+
+    private val application: Application = mockk(relaxed = true)
+    private val traktApi: TraktApiService = mockk(relaxed = true)
+    private val tokenProxy: TokenProxyService = mockk(relaxed = true)
+    private val tokenRepository: TokenRepository = mockk(relaxed = true)
+    private val settingsRepository: SettingsRepository = mockk(relaxed = true)
+    private val tokenProxyServiceFactory: TokenProxyServiceFactory = mockk(relaxed = true)
+
+    private val deviceCodeResponse = DeviceCodeResponse(
+        device_code = "device-123",
+        user_code = "ABC123",
+        verification_url = "https://trakt.tv/activate",
+        expires_in = 600,
+        interval = 5
+    )
+
+    @BeforeEach
+    fun setUp() {
+        every { settingsRepository.getClientSecret() } returns ""
+    }
+
+    private fun createViewModel(
+        buildClientId: String = BUILD_CLIENT_ID,
+        proxy: TokenProxyService? = tokenProxy
+    ): OnboardingViewModel = OnboardingViewModel(
+        application = application,
+        traktApi = traktApi,
+        tokenProxy = proxy,
+        buildConfigClientId = buildClientId,
+        tokenRepository = tokenRepository,
+        settingsRepository = settingsRepository,
+        tokenProxyServiceFactory = tokenProxyServiceFactory
+    )
+
+    @Nested
+    @DisplayName("MANAGED mode")
+    inner class ManagedMode {
+
+        @Test
+        fun `shows NotConfigured when client ID is blank`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            val vm = createViewModel(buildClientId = "")
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+            assertEquals(OnboardingState.NotConfigured, vm.state.value)
+        }
+
+        @Test
+        fun `shows NotConfigured when token proxy is null`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            val vm = createViewModel(proxy = null)
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+            assertEquals(OnboardingState.NotConfigured, vm.state.value)
+        }
+
+        @Test
+        fun `requests device code when both client ID and proxy are present`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            val state = vm.state.value
+            assertTrue(state is OnboardingState.WaitingForPin)
+            assertEquals("ABC123", (state as OnboardingState.WaitingForPin).userCode)
+        }
+    }
+
+    @Nested
+    @DisplayName("SELF_HOSTED mode")
+    inner class SelfHostedMode {
+
+        @Test
+        fun `shows NotConfigured when backend URL is blank`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.SELF_HOSTED, backendUrl = "")
+            )
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+            assertEquals(OnboardingState.NotConfigured, vm.state.value)
+        }
+
+        @Test
+        fun `shows NotConfigured when client ID is blank`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.SELF_HOSTED, backendUrl = CUSTOM_BACKEND_URL)
+            )
+            val vm = createViewModel(buildClientId = "")
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+            assertEquals(OnboardingState.NotConfigured, vm.state.value)
+        }
+
+        @Test
+        fun `requests device code when client ID and backend URL are present`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.SELF_HOSTED, backendUrl = CUSTOM_BACKEND_URL)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            val state = vm.state.value
+            assertTrue(state is OnboardingState.WaitingForPin)
+        }
+    }
+
+    @Nested
+    @DisplayName("DIRECT mode")
+    inner class DirectMode {
+
+        @Test
+        fun `shows NotConfigured when direct client ID is blank`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.DIRECT, directClientId = "")
+            )
+            every { settingsRepository.getClientSecret() } returns DIRECT_CLIENT_SECRET
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+            assertEquals(OnboardingState.NotConfigured, vm.state.value)
+        }
+
+        @Test
+        fun `shows NotConfigured when client secret is blank`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.DIRECT, directClientId = DIRECT_CLIENT_ID)
+            )
+            every { settingsRepository.getClientSecret() } returns ""
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+            assertEquals(OnboardingState.NotConfigured, vm.state.value)
+        }
+
+        @Test
+        fun `requests device code when client ID and secret are present`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.DIRECT, directClientId = DIRECT_CLIENT_ID)
+            )
+            every { settingsRepository.getClientSecret() } returns DIRECT_CLIENT_SECRET
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            val state = vm.state.value
+            assertTrue(state is OnboardingState.WaitingForPin)
+        }
+    }
+
+    @Nested
+    @DisplayName("Initial state")
+    inner class InitialState {
+
+        @Test
+        fun `starts in Idle state`() {
+            val vm = createViewModel()
+            assertEquals(OnboardingState.Idle, vm.state.value)
+        }
+    }
+
+    @Nested
+    @DisplayName("Error handling")
+    inner class ErrorHandling {
+
+        @Test
+        fun `shows Error when device code request fails`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } throws RuntimeException("Network error")
+            every { application.getString(any(), any()) } returns "Error: Network error"
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            assertTrue(vm.state.value is OnboardingState.Error)
+        }
+    }
+}

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelTest.kt
@@ -110,7 +110,8 @@ class OnboardingViewModelTest {
 
             val vm = createViewModel()
             vm.requestDeviceCode()
-            advanceUntilIdle()
+            // Don't advanceUntilIdle — the countdown coroutine would expire the code.
+            // With UnconfinedTestDispatcher, state is already set eagerly.
 
             val state = vm.state.value
             assertTrue(state is OnboardingState.WaitingForPin)
@@ -153,7 +154,6 @@ class OnboardingViewModelTest {
 
             val vm = createViewModel()
             vm.requestDeviceCode()
-            advanceUntilIdle()
 
             val state = vm.state.value
             assertTrue(state is OnboardingState.WaitingForPin)
@@ -200,7 +200,6 @@ class OnboardingViewModelTest {
 
             val vm = createViewModel()
             vm.requestDeviceCode()
-            advanceUntilIdle()
 
             val state = vm.state.value
             assertTrue(state is OnboardingState.WaitingForPin)

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/TokenProxyServiceFactory.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/TokenProxyServiceFactory.kt
@@ -1,0 +1,36 @@
+package com.justb81.watchbuddy.core.network
+
+import com.justb81.watchbuddy.core.trakt.TokenProxyService
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Factory for creating [TokenProxyService] instances from arbitrary base URLs.
+ *
+ * Used when the user configures a self-hosted token proxy via Settings
+ * instead of relying on the build-time TOKEN_BACKEND_URL.
+ */
+@Singleton
+class TokenProxyServiceFactory @Inject constructor() {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+        coerceInputValues = true
+    }
+
+    fun create(baseUrl: String): TokenProxyService {
+        val url = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
+        return Retrofit.Builder()
+            .baseUrl(url)
+            .client(OkHttpClient())
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(TokenProxyService::class.java)
+    }
+}

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/TokenProxyServiceFactoryTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/TokenProxyServiceFactoryTest.kt
@@ -1,0 +1,36 @@
+package com.justb81.watchbuddy.core.network
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("TokenProxyServiceFactory")
+class TokenProxyServiceFactoryTest {
+
+    private val factory = TokenProxyServiceFactory()
+
+    @Test
+    fun `creates non-null service from valid URL`() {
+        val service = factory.create("https://proxy.example.com")
+        assertNotNull(service)
+    }
+
+    @Test
+    fun `creates service for URL without trailing slash`() {
+        val service = factory.create("https://proxy.example.com")
+        assertNotNull(service)
+    }
+
+    @Test
+    fun `creates service for URL with trailing slash`() {
+        val service = factory.create("https://proxy.example.com/")
+        assertNotNull(service)
+    }
+
+    @Test
+    fun `creates independent instances for different URLs`() {
+        val service1 = factory.create("https://proxy1.example.com")
+        val service2 = factory.create("https://proxy2.example.com")
+        assertNotSame(service1, service2)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #98 — "Connect with Trakt does not work"

**Root cause:** `OnboardingViewModel.isTraktConfigured` only checked build-time values (`BuildConfig.TRAKT_CLIENT_ID` + `BuildConfig.TOKEN_BACKEND_URL`). When either was empty — common in debug builds or when the user configured auth at runtime via Settings → Advanced — clicking "Connect with Trakt" showed "Not Configured" with only a Skip button.

### Changes

| File | Change |
|------|--------|
| `core/.../TokenProxyServiceFactory.kt` | **NEW** — Factory for creating `TokenProxyService` from arbitrary URLs at runtime (SELF_HOSTED mode) |
| `app-phone/.../OnboardingViewModel.kt` | Read auth settings from DataStore; resolve config dynamically per auth mode (MANAGED/SELF_HOSTED/DIRECT); support direct Trakt device token exchange for DIRECT mode |
| `app-phone/.../OnboardingScreen.kt` | Add `isReconnect` parameter — shows "Connect to Trakt" title and "Cancel" button instead of app name and "Skip for now" |
| `app-phone/.../PhoneNavGraph.kt` | Pass `isReconnect = true` for Connect route; navigate back to previous screen (Settings) on success instead of Home |
| String resources (EN/DE/FR/ES) | Add `onboarding_reconnect_title` in all 4 languages |
| `app-phone/.../OnboardingViewModelTest.kt` | **NEW** — Tests for all 3 auth modes: configuration validation, device code request, error handling |
| `core/.../TokenProxyServiceFactoryTest.kt` | **NEW** — Tests for factory URL handling |

### Auth mode behavior

| Mode | Client ID source | Token exchange |
|------|-----------------|----------------|
| **MANAGED** | `BuildConfig.TRAKT_CLIENT_ID` | Via `TokenProxyService` (build-time URL) |
| **SELF_HOSTED** | `BuildConfig.TRAKT_CLIENT_ID` | Via `TokenProxyServiceFactory` (user-configured URL) |
| **DIRECT** | User-configured (DataStore) | Direct `TraktApiService.pollDeviceToken()` with client_secret |

## Test plan

- [ ] `./gradlew test` — all unit tests pass
- [ ] `./gradlew assembleDebug` — builds successfully
- [ ] MANAGED mode with BuildConfig values set → device code flow works
- [ ] SELF_HOSTED mode with custom backend URL → device code flow works via custom proxy
- [ ] DIRECT mode with client ID/secret → device code flow works via direct Trakt API
- [ ] Reconnection from Settings shows "Connect to Trakt" heading and "Cancel" button
- [ ] Successful connection from Settings navigates back to Settings
- [ ] Initial onboarding flow (first app launch) still works as before

https://claude.ai/code/session_01KN5e6ZCAYDYV6KrZaLoX1x