### PR TITLE
fix: TMDB language, API key validation, HTML encoding, parallel fetches (#112 #114 #115 #116)

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/FallbackProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/FallbackProvider.kt
@@ -12,15 +12,21 @@ class FallbackProvider(
 
     override val displayName: String = "TMDB Synopsis Fallback"
 
+    private fun String.escapeHtml(): String =
+        replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+
     override suspend fun generate(prompt: String): String {
         val slides = episodes.takeLast(6).mapIndexed { index, ep ->
             val label = "S${ep.season_number.toString().padStart(2, '0')}" +
                     "E${ep.episode_number.toString().padStart(2, '0')}"
-            val overview = ep.overview ?: "—"
+            val overview = (ep.overview ?: "—").escapeHtml()
             """
             <div class="slide" style="animation-delay:${index * 4}s">
               <img data-tmdb-still="$label" alt="$label">
-              <h3>${ep.name} ($label)</h3>
+              <h3>${ep.name.escapeHtml()} ($label)</h3>
               <p>$overview</p>
             </div>
             """.trimIndent()

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -1,10 +1,14 @@
 package com.justb81.watchbuddy.phone.server
 
 import android.util.Log
+import com.justb81.watchbuddy.core.locale.LocaleHelper
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.llm.RecapGenerator
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import io.ktor.http.*
 import io.ktor.server.application.*
@@ -81,6 +85,15 @@ class CompanionHttpServer @Inject constructor(
                             settingsRepository.getTmdbApiKey().first()
                         }
 
+                        if (apiKey.isBlank()) {
+                            return@post call.respond(
+                                HttpStatusCode.PreconditionFailed,
+                                ErrorResponse("TMDB API key not configured")
+                            )
+                        }
+
+                        val tmdbLanguage = LocaleHelper.getTmdbLanguage()
+
                         val shows = showRepository.getShows()
                         val watchedEntry = shows.find { it.show.ids.trakt == showId }
                             ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("Show not found"))
@@ -88,24 +101,30 @@ class CompanionHttpServer @Inject constructor(
                         val tmdbId = watchedEntry.show.ids.tmdb
                             ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("No TMDB ID for show"))
 
-                        val tmdbShow = tmdbApiService.getShow(tmdbId, apiKey)
+                        val tmdbShow = tmdbApiService.getShow(tmdbId, apiKey, language = tmdbLanguage)
 
                         // Collect watched episode numbers from Trakt data
                         val watchedEpisodeRefs = watchedEntry.seasons.flatMap { season ->
                             season.episodes.map { ep -> season.number to ep.number }
                         }
 
-                        // Load episode details from TMDB for the last 8 watched episodes
-                        val tmdbEpisodes = watchedEpisodeRefs
-                            .takeLast(8)
-                            .mapNotNull { (season, episode) ->
-                                try {
-                                    tmdbApiService.getEpisode(tmdbId, season, episode, apiKey)
-                                } catch (e: Exception) {
-                                    Log.w(TAG, "Failed to load TMDB episode S${season}E${episode}", e)
-                                    null
+                        // Load episode details from TMDB for the last 8 watched episodes in parallel
+                        val tmdbEpisodes = coroutineScope {
+                            watchedEpisodeRefs
+                                .takeLast(8)
+                                .map { (season, episode) ->
+                                    async {
+                                        try {
+                                            tmdbApiService.getEpisode(tmdbId, season, episode, apiKey, language = tmdbLanguage)
+                                        } catch (e: Exception) {
+                                            Log.w(TAG, "Failed to load TMDB episode S${season}E${episode}", e)
+                                            null
+                                        }
+                                    }
                                 }
-                            }
+                                .awaitAll()
+                                .filterNotNull()
+                        }
 
                         if (tmdbEpisodes.isEmpty()) {
                             return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("No episode data available"))

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/FallbackProviderTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/FallbackProviderTest.kt
@@ -89,4 +89,46 @@ class FallbackProviderTest {
         assertTrue(html.contains("animation-delay:4s"))
         assertTrue(html.contains("animation-delay:8s"))
     }
+
+    @Test
+    fun `generate escapes HTML special characters in episode name`() = runTest {
+        val ep = TmdbEpisode(1, "The <Choice> & \"Consequences\"", "Normal overview", null, 1, 1)
+        val html = FallbackProvider(listOf(ep)).generate("unused")
+        assertTrue(html.contains("The &lt;Choice&gt; &amp; &quot;Consequences&quot;"))
+        assertFalse(html.contains("<Choice>"))
+        assertFalse(html.contains("\"Consequences\""))
+    }
+
+    @Test
+    fun `generate escapes HTML special characters in episode overview`() = runTest {
+        val ep = TmdbEpisode(1, "Normal", "<script>alert('xss')</script> & more", null, 1, 1)
+        val html = FallbackProvider(listOf(ep)).generate("unused")
+        assertTrue(html.contains("&lt;script&gt;"))
+        assertTrue(html.contains("&amp; more"))
+        assertFalse(html.contains("<script>"))
+    }
+
+    @Test
+    fun `generate escapes ampersand in episode name`() = runTest {
+        val ep = TmdbEpisode(1, "Fire & Ice", null, null, 1, 1)
+        val html = FallbackProvider(listOf(ep)).generate("unused")
+        assertTrue(html.contains("Fire &amp; Ice"))
+        assertFalse(html.contains("Fire & Ice"))
+    }
+
+    @Test
+    fun `generate escapes less-than and greater-than signs in overview`() = runTest {
+        val ep = TmdbEpisode(1, "Normal", "Rating: 8 > 7 and <10", null, 1, 1)
+        val html = FallbackProvider(listOf(ep)).generate("unused")
+        assertTrue(html.contains("8 &gt; 7"))
+        assertTrue(html.contains("&lt;10"))
+    }
+
+    @Test
+    fun `generate escapes double quotes in episode name`() = runTest {
+        val ep = TmdbEpisode(1, "The \"One\"", null, null, 1, 1)
+        val html = FallbackProvider(listOf(ep)).generate("unused")
+        assertTrue(html.contains("The &quot;One&quot;"))
+        assertFalse(html.contains("The \"One\""))
+    }
 }

--- a/core/src/main/java/com/justb81/watchbuddy/core/locale/LocaleHelper.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/locale/LocaleHelper.kt
@@ -14,4 +14,16 @@ object LocaleHelper {
     fun getLlmResponseLanguage(locale: Locale = Locale.getDefault()): String {
         return locale.getDisplayLanguage(Locale.ENGLISH)
     }
+
+    /**
+     * Returns a TMDB-compatible BCP 47 language tag for the given locale,
+     * e.g. "en-US", "de-DE", "fr-FR". Falls back to "en-US" for empty locales.
+     *
+     * Used to request locale-appropriate show/episode metadata from the TMDB API.
+     */
+    fun getTmdbLanguage(locale: Locale = Locale.getDefault()): String {
+        val language = locale.language.takeIf { it.isNotEmpty() } ?: return "en-US"
+        val country = locale.country.takeIf { it.isNotEmpty() }
+        return if (country != null) "$language-$country" else language
+    }
 }

--- a/core/src/main/java/com/justb81/watchbuddy/core/tmdb/TmdbApiService.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/tmdb/TmdbApiService.kt
@@ -11,14 +11,14 @@ interface TmdbApiService {
     suspend fun searchShow(
         @Query("api_key") apiKey: String,
         @Query("query") query: String,
-        @Query("language") language: String = "de-DE"
+        @Query("language") language: String = "en-US"
     ): TmdbSearchResponse
 
     @GET("tv/{series_id}")
     suspend fun getShow(
         @Path("series_id") id: Int,
         @Query("api_key") apiKey: String,
-        @Query("language") language: String = "de-DE"
+        @Query("language") language: String = "en-US"
     ): TmdbShow
 
     @GET("tv/{series_id}/season/{season_number}/episode/{episode_number}")
@@ -27,7 +27,7 @@ interface TmdbApiService {
         @Path("season_number") seasonNumber: Int,
         @Path("episode_number") episodeNumber: Int,
         @Query("api_key") apiKey: String,
-        @Query("language") language: String = "de-DE"
+        @Query("language") language: String = "en-US"
     ): TmdbEpisode
 
     @GET("tv/{series_id}/season/{season_number}")
@@ -35,7 +35,7 @@ interface TmdbApiService {
         @Path("series_id") seriesId: Int,
         @Path("season_number") seasonNumber: Int,
         @Query("api_key") apiKey: String,
-        @Query("language") language: String = "de-DE"
+        @Query("language") language: String = "en-US"
     ): TmdbSeasonResponse
 }
 

--- a/core/src/test/java/com/justb81/watchbuddy/core/locale/LocaleHelperTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/locale/LocaleHelperTest.kt
@@ -2,6 +2,7 @@ package com.justb81.watchbuddy.core.locale
 
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -26,6 +27,19 @@ class LocaleHelperTest {
             Arguments.of(Locale("pt"), "Portuguese"),
             Arguments.of(Locale("it"), "Italian")
         )
+
+        @JvmStatic
+        fun tmdbLanguageProvider(): Stream<Arguments> = Stream.of(
+            Arguments.of(Locale.US, "en-US"),
+            Arguments.of(Locale.UK, "en-GB"),
+            Arguments.of(Locale.GERMANY, "de-DE"),
+            Arguments.of(Locale.FRANCE, "fr-FR"),
+            Arguments.of(Locale("es", "ES"), "es-ES"),
+            Arguments.of(Locale("ja", "JP"), "ja-JP"),
+            Arguments.of(Locale.ENGLISH, "en"),
+            Arguments.of(Locale.GERMAN, "de"),
+            Arguments.of(Locale("fr"), "fr")
+        )
     }
 
     @ParameterizedTest(name = "{0} -> {1}")
@@ -39,5 +53,42 @@ class LocaleHelperTest {
         val result = LocaleHelper.getLlmResponseLanguage(Locale("xx"))
         assertNotNull(result)
         assertTrue(result.isNotEmpty())
+    }
+
+    @Nested
+    @DisplayName("getTmdbLanguage")
+    inner class GetTmdbLanguageTest {
+
+        @ParameterizedTest(name = "{0} -> {1}")
+        @MethodSource("com.justb81.watchbuddy.core.locale.LocaleHelperTest#tmdbLanguageProvider")
+        fun `returns correct BCP 47 tag for locale`(locale: Locale, expected: String) {
+            assertEquals(expected, LocaleHelper.getTmdbLanguage(locale))
+        }
+
+        @Test
+        fun `returns en-US for empty locale`() {
+            val emptyLocale = Locale("", "")
+            assertEquals("en-US", LocaleHelper.getTmdbLanguage(emptyLocale))
+        }
+
+        @Test
+        fun `result is never blank`() {
+            val result = LocaleHelper.getTmdbLanguage(Locale.US)
+            assertTrue(result.isNotBlank())
+        }
+
+        @Test
+        fun `language and country are separated by hyphen`() {
+            val result = LocaleHelper.getTmdbLanguage(Locale.GERMANY)
+            assertTrue(result.contains("-"))
+            val parts = result.split("-")
+            assertEquals(2, parts.size)
+        }
+
+        @Test
+        fun `language-only locale returns language without hyphen`() {
+            val result = LocaleHelper.getTmdbLanguage(Locale.ENGLISH)
+            assertFalse(result.contains("-"))
+        }
     }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Fixes four open TMDB-related issues in a single batch:

- **fix #112** — TMDB language hardcoded to `de-DE`: All non-German users were receiving German show/episode metadata. `LocaleHelper.getTmdbLanguage()` now resolves the device locale to a BCP 47 tag (e.g. `en-US`, `fr-FR`). `TmdbApiService` defaults changed from `"de-DE"` to `"en-US"`. `CompanionHttpServer` resolves the language once and passes it to every TMDB call.

- **fix #114** — Empty TMDB API key causes cryptic 503: The recap endpoint now validates the API key immediately after resolving it and returns `HTTP 412 PreconditionFailed` with `"TMDB API key not configured"` instead of proceeding with an empty key and surfacing a downstream 401 as a generic service error.

- **fix #115** — `FallbackProvider` injects TMDB text into HTML without entity-encoding: Added a private `String.escapeHtml()` helper (`&`, `<`, `>`, `"`) and applied it to `ep.name` and `ep.overview` before interpolation.

- **perf #116** — TMDB episode fetches are sequential: The up-to-8 `getEpisode()` calls are now issued in parallel via `coroutineScope { list.map { async { … } }.awaitAll() }`, reducing typical recap latency by ~1–2 s.

## Changed files

| File | Change |
|------|--------|
| `core/…/locale/LocaleHelper.kt` | Add `getTmdbLanguage()` |
| `core/…/tmdb/TmdbApiService.kt` | Language defaults `"de-DE"` → `"en-US"` |
| `app-phone/…/server/CompanionHttpServer.kt` | API key guard, locale language, parallel fetches |
| `app-phone/…/llm/FallbackProvider.kt` | `escapeHtml()` applied to episode name & overview |

## Tests

- `LocaleHelperTest`: 9 parameterized cases for `getTmdbLanguage()` (language+country, language-only, empty locale fallback) plus invariant checks.
- `FallbackProviderTest`: 5 new cases verifying that `<`, `>`, `&`, and `"` in episode names and overviews are properly encoded in the generated HTML.

## Test plan

- [ ] Build passes in CI (`build-android.yml`)
- [ ] Unit tests green (`:core:test`, `:app-phone:test`)
- [ ] Recap request with blank API key returns 412, not 503
- [ ] Recap content on a non-German device uses the correct locale language for episode overviews

https://claude.ai/code/session_011uY5rVd4Vd7tGANsLmN5Qn
EOF
)