### PR TITLE
feat(backend): add debug request logging toggled via DEBUG_MODE env var

### DIFF
--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import request from 'supertest';
 import { createApp } from '../app.js';
 
@@ -337,5 +337,76 @@ describe('Unknown routes', () => {
     const app = buildApp(mockFetch(200, {}));
     const res = await request(app).get('/does-not-exist');
     expect(res.status).toBe(404);
+  });
+});
+
+// ── Debug logging ───────────────────────────────────────────────────────────
+
+describe('Debug logging (debug: true)', () => {
+  let debugSpy;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+  });
+
+  it('logs a debug line for GET /health when debug is enabled', async () => {
+    const app = buildApp(mockFetch(200, {}), { debug: true });
+    await request(app).get('/health');
+    expect(debugSpy).toHaveBeenCalledOnce();
+    expect(debugSpy.mock.calls[0][0]).toMatch(/\[DEBUG\].*GET.*\/health.*200/);
+  });
+
+  it('log line includes method, path, status, and timing', async () => {
+    const app = buildApp(mockFetch(200, {}), { debug: true });
+    await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
+    expect(debugSpy).toHaveBeenCalledOnce();
+    const msg = debugSpy.mock.calls[0][0];
+    expect(msg).toMatch(/\[DEBUG\]/);
+    expect(msg).toMatch(/POST/);
+    expect(msg).toMatch(/\/trakt\/token/);
+    expect(msg).toMatch(/200/);
+    expect(msg).toMatch(/\d+ms/);
+  });
+
+  it('logs debug line even when the endpoint returns an error status', async () => {
+    const app = buildApp(mockFetch(400, { error: 'invalid_grant' }), { debug: true });
+    await request(app).post('/trakt/token').send({ code: 'bad-code' });
+    expect(debugSpy).toHaveBeenCalledOnce();
+    expect(debugSpy.mock.calls[0][0]).toMatch(/400/);
+  });
+
+  it('logs one line per request for multiple requests', async () => {
+    const app = buildApp(mockFetch(200, {}), { debug: true });
+    await request(app).get('/health');
+    await request(app).get('/health');
+    expect(debugSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Debug logging (debug: false / default)', () => {
+  let debugSpy;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+  });
+
+  it('does not log any debug output when debug is disabled (explicit false)', async () => {
+    const app = buildApp(mockFetch(200, {}), { debug: false });
+    await request(app).get('/health');
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not log any debug output when debug option is omitted', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    await request(app).get('/health');
+    expect(debugSpy).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -35,6 +35,7 @@ function validateField(value, fieldName) {
  * @param {string} [config.traktApi]   - Trakt API base URL (default: https://api.trakt.tv)
  * @param {Function} [config.fetchFn]  - fetch implementation (default: global fetch)
  * @param {number} [config.fetchTimeoutMs] - Upstream fetch timeout in ms (default: 15000)
+ * @param {boolean} [config.debug]     - Enable request debug logging (default: false)
  * @returns {import('express').Express}
  */
 export function createApp(config) {
@@ -44,6 +45,7 @@ export function createApp(config) {
     traktApi = 'https://api.trakt.tv',
     fetchFn = fetch,
     fetchTimeoutMs = 15_000,
+    debug = false,
   } = config;
 
   async function fetchWithTimeout(url, options) {
@@ -59,6 +61,20 @@ export function createApp(config) {
   const app = express();
   app.use(helmet());
   app.use(express.json());
+
+  if (debug) {
+    app.use((req, res, next) => {
+      const start = Date.now();
+      const ip = req.ip ?? req.socket?.remoteAddress ?? 'unknown';
+      res.on('finish', () => {
+        const ms = Date.now() - start;
+        console.debug(
+          `[DEBUG] ${new Date().toISOString()} ${req.method} ${req.path} from ${ip} \u2192 ${res.statusCode} (${ms}ms)`,
+        );
+      });
+      next();
+    });
+  }
 
   // Rate limiting — Trakt allows 1000 calls/5min per app
   const limiter = rateLimit({

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -17,18 +17,24 @@
 import 'dotenv/config';
 import { createApp } from './app.js';
 
-const { TRAKT_CLIENT_ID, TRAKT_CLIENT_SECRET, PORT = 3000 } = process.env;
+const { TRAKT_CLIENT_ID, TRAKT_CLIENT_SECRET, PORT = 3000, DEBUG_MODE } = process.env;
 
 if (!TRAKT_CLIENT_ID || !TRAKT_CLIENT_SECRET) {
   console.error('ERROR: TRAKT_CLIENT_ID and TRAKT_CLIENT_SECRET must be set in .env');
   process.exit(1);
 }
 
+const debug = DEBUG_MODE === 'true';
+
 const app = createApp({
   clientId: TRAKT_CLIENT_ID,
   clientSecret: TRAKT_CLIENT_SECRET,
+  debug,
 });
 
 app.listen(PORT, () => {
   console.log(`WatchBuddy token proxy running on port ${PORT}`);
+  if (debug) {
+    console.log('Debug mode enabled — request logging is active');
+  }
 });


### PR DESCRIPTION
## Summary

Closes #106

- Adds a debug request-logging middleware to the Express backend
- When `DEBUG_MODE=true`, every inbound request is logged after the response is sent:
  ```
  [DEBUG] 2026-04-14T10:00:00.000Z POST /trakt/token from ::1 → 200 (42ms)
  ```
  Each log line includes: ISO timestamp, HTTP method, path, client IP, response status, and duration.
- Uses `console.debug` so output is distinguishable from error logs
- No output at all when `DEBUG_MODE` is unset or any value other than `"true"`

## Usage

```bash
# Enable via environment variable
DEBUG_MODE=true node src/index.js

# Or in .env
DEBUG_MODE=true
```

## Changed files

| File | Change |
|------|--------|
| `backend/src/app.js` | Accept `debug` boolean in `createApp` config; register logging middleware when enabled |
| `backend/src/index.js` | Read `DEBUG_MODE` env var; pass `debug` to `createApp`; log startup message when active |
| `backend/src/__tests__/app.test.js` | 6 new test cases verifying logging fires with `debug: true` and is silent with `debug: false` |

## Test plan

- [x] All 30 backend tests pass (`npm test`)
- [x] New tests verify log format contains method, path, status, and timing
- [x] New tests verify no `console.debug` calls when `debug` is `false` or omitted

https://claude.ai/code/session_018MZFkdecxYJc7S4ZYzrHiL