### PR TITLE
fix(scrobble): scrobble to Trakt for all connected users, not just the best phone

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,10 +170,10 @@ The TV ranks connected phones by LLM quality and uses the best one. Failover cha
 
 ## Important Patterns
 
-- **Scrobbling:** `MediaSessionScrobbler` listens to active media sessions on the TV, extracts package name + title, fuzzy-matches against Trakt watchlist. Auto-scrobbles if confidence ≥ 95%, shows overlay confirmation between 70–95%, ignores below 70%.
+- **Scrobbling:** `MediaSessionScrobbler` listens to active media sessions on the TV, extracts package name + title, fuzzy-matches against Trakt watchlist. Auto-scrobbles if confidence ≥ 95%, shows overlay confirmation between 70–95%, ignores below 70%. When multiple phones are connected, scrobbling fires in parallel for **every** connected user via `TvTokenCache.getAllTokens()` — each user's Trakt account is updated independently and a failure for one user does not block the others.
 - **LLM selection:** `LlmOrchestrator` checks AICore first, then falls back to LiteRT-LM with a Gemma 4 model (E4B or E2B) sized to available RAM.
 - **Auth modes:** Managed backend (default), self-hosted proxy, or direct Trakt credentials.
-- **Multi-user:** Multiple phones can connect to one TV simultaneously; shared watch mode avoids recap spoilers.
+- **Multi-user:** Multiple phones can connect to one TV simultaneously; scrobbling records the episode for each connected user independently; shared watch mode avoids recap spoilers.
 
 ## Documentation Maintenance
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
@@ -206,70 +206,88 @@ class MediaSessionScrobbler @Inject constructor(
 
     /**
      * Sends a scrobble/start to Trakt for the given candidate.
+     * Scrobbles for every connected phone so all users watching together have
+     * the episode recorded on their own Trakt accounts.
      * Called automatically for high-confidence matches or via [ScrobbleViewModel] after user confirmation.
      */
     suspend fun autoScrobble(candidate: ScrobbleCandidate) {
-        val token = tvTokenCache.getToken()
-        if (token == null) {
-            Log.w(TAG, "No access token available — scrobble skipped")
+        val tokens = tvTokenCache.getAllTokens()
+        if (tokens.isEmpty()) {
+            Log.w(TAG, "No access tokens available — scrobble skipped")
             return
         }
 
         val show = candidate.matchedShow ?: return
         val episode = candidate.matchedEpisode ?: return
 
-        try {
-            traktApi.scrobbleStart(
-                bearer = "Bearer $token",
-                body = ScrobbleBody(
-                    show = show,
-                    episode = episode,
-                    progress = 0f
-                )
-            )
-            currentlyScrobbling = candidate.mediaTitle
-            Log.i(TAG, "Scrobble started: ${show.title} S${episode.season}E${episode.number}")
-        } catch (e: Exception) {
-            Log.e(TAG, "Scrobble start failed", e)
+        coroutineScope {
+            tokens.forEach { (phoneId, token) ->
+                launch {
+                    try {
+                        traktApi.scrobbleStart(
+                            bearer = "Bearer $token",
+                            body = ScrobbleBody(show = show, episode = episode, progress = 0f)
+                        )
+                        Log.i(TAG, "Scrobble started for $phoneId: ${show.title} S${episode.season}E${episode.number}")
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Scrobble start failed for $phoneId", e)
+                    }
+                }
+            }
         }
+        currentlyScrobbling = candidate.mediaTitle
     }
 
     private suspend fun handleScrobblePause(rawTitle: String) {
         if (rawTitle != currentlyScrobbling) return
 
-        val token = tvTokenCache.getToken() ?: return
+        val tokens = tvTokenCache.getAllTokens()
+        if (tokens.isEmpty()) return
         val candidate = matchTitleToTrakt("", rawTitle) ?: return
         val show = candidate.matchedShow ?: return
         val episode = candidate.matchedEpisode ?: return
 
-        try {
-            traktApi.scrobblePause(
-                bearer = "Bearer $token",
-                body = ScrobbleBody(show = show, episode = episode, progress = 50f)
-            )
-            Log.i(TAG, "Scrobble paused: ${show.title}")
-        } catch (e: Exception) {
-            Log.e(TAG, "Scrobble pause failed", e)
+        coroutineScope {
+            tokens.forEach { (phoneId, token) ->
+                launch {
+                    try {
+                        traktApi.scrobblePause(
+                            bearer = "Bearer $token",
+                            body = ScrobbleBody(show = show, episode = episode, progress = 50f)
+                        )
+                        Log.i(TAG, "Scrobble paused for $phoneId: ${show.title}")
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Scrobble pause failed for $phoneId", e)
+                    }
+                }
+            }
         }
     }
 
     private suspend fun handleScrobbleStop(rawTitle: String) {
         if (rawTitle != currentlyScrobbling) return
 
-        val token = tvTokenCache.getToken() ?: return
+        val tokens = tvTokenCache.getAllTokens()
+        if (tokens.isEmpty()) return
         val candidate = matchTitleToTrakt("", rawTitle) ?: return
         val show = candidate.matchedShow ?: return
         val episode = candidate.matchedEpisode ?: return
 
-        try {
-            traktApi.scrobbleStop(
-                bearer = "Bearer $token",
-                body = ScrobbleBody(show = show, episode = episode, progress = 100f)
-            )
-            currentlyScrobbling = null
-            Log.i(TAG, "Scrobble stopped (watched): ${show.title} S${episode.season}E${episode.number}")
-        } catch (e: Exception) {
-            Log.e(TAG, "Scrobble stop failed", e)
+        coroutineScope {
+            tokens.forEach { (phoneId, token) ->
+                launch {
+                    try {
+                        traktApi.scrobbleStop(
+                            bearer = "Bearer $token",
+                            body = ScrobbleBody(show = show, episode = episode, progress = 100f)
+                        )
+                        Log.i(TAG, "Scrobble stopped (watched) for $phoneId: ${show.title} S${episode.season}E${episode.number}")
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Scrobble stop failed for $phoneId", e)
+                    }
+                }
+            }
         }
+        currentlyScrobbling = null
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvTokenCache.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvTokenCache.kt
@@ -3,16 +3,22 @@ package com.justb81.watchbuddy.tv.scrobbler
 import android.util.Log
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
-import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Caches the Trakt access token obtained from the phone companion app.
- * The TV app itself has no Trakt login — it delegates auth to the phone via
+ * Caches the Trakt access tokens obtained from companion phone apps.
+ * The TV app itself has no Trakt login — it delegates auth to phones via
  * the companion HTTP API (GET /auth/token).
  *
- * Token is cached for [CACHE_TTL] to avoid excessive network calls.
+ * Tokens are cached per phone for [CACHE_TTL] to avoid excessive network calls.
+ *
+ * - [getToken] returns the best phone's token (for single-user operations like search).
+ * - [getAllTokens] returns tokens for all available phones (for multi-user scrobbling).
  */
 @Singleton
 class TvTokenCache @Inject constructor(
@@ -21,32 +27,71 @@ class TvTokenCache @Inject constructor(
 ) {
     companion object {
         private const val TAG = "TvTokenCache"
-        private const val CACHE_TTL = 30 * 60 * 1000L // 30 minutes
+        const val CACHE_TTL = 30 * 60 * 1000L // 30 minutes
     }
+
+    /** A token paired with the phone's device ID for identification. */
+    data class PhoneToken(val phoneId: String, val token: String)
 
     private data class CachedEntry(val token: String, val timestamp: Long)
 
-    private val cached = AtomicReference<CachedEntry?>(null)
+    /** Per-phone token cache; key = phone baseUrl. */
+    private val tokenCache = ConcurrentHashMap<String, CachedEntry>()
 
+    /**
+     * Returns the access token for the best available phone.
+     * Used for Trakt API calls that only need a single token (e.g., show search).
+     */
     suspend fun getToken(): String? {
+        val phone = phoneDiscovery.getBestPhone() ?: return null
+        return fetchOrGetCachedToken(phone)
+    }
+
+    /**
+     * Returns access tokens for all currently available phones.
+     * Used for multi-user scrobbling so every connected user's watch history
+     * is recorded independently on their own Trakt account.
+     *
+     * Phones that fail to return a token are silently skipped so one
+     * unreachable device does not block scrobbling for the others.
+     */
+    suspend fun getAllTokens(): List<PhoneToken> {
+        val phones = phoneDiscovery.discoveredPhones.value
+            .filter { it.capability?.isAvailable == true }
+        if (phones.isEmpty()) return emptyList()
+
+        return coroutineScope {
+            phones.map { phone ->
+                async {
+                    fetchOrGetCachedToken(phone)?.let { token ->
+                        PhoneToken(
+                            phoneId = phone.capability?.deviceId ?: phone.baseUrl,
+                            token = token
+                        )
+                    }
+                }
+            }.awaitAll().filterNotNull()
+        }
+    }
+
+    private suspend fun fetchOrGetCachedToken(phone: PhoneDiscoveryManager.DiscoveredPhone): String? {
         val now = System.currentTimeMillis()
-        cached.get()?.let { entry ->
+        tokenCache[phone.baseUrl]?.let { entry ->
             if (now - entry.timestamp < CACHE_TTL) return entry.token
         }
 
-        val phone = phoneDiscovery.getBestPhone() ?: return null
         return try {
             val client = phoneApiClientFactory.createClient(phone.baseUrl)
             val response = client.getAccessToken()
-            cached.set(CachedEntry(response.accessToken, System.currentTimeMillis()))
+            tokenCache[phone.baseUrl] = CachedEntry(response.accessToken, System.currentTimeMillis())
             response.accessToken
         } catch (e: Exception) {
-            Log.w(TAG, "Failed to fetch access token from phone", e)
+            Log.w(TAG, "Failed to fetch token from phone at ${phone.baseUrl}", e)
             null
         }
     }
 
     fun invalidate() {
-        cached.set(null)
+        tokenCache.clear()
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobblerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobblerTest.kt
@@ -33,6 +33,8 @@ class MediaSessionScrobblerTest {
         scrobbler = MediaSessionScrobbler(context, traktApi, tvShowCache, tvTokenCache)
     }
 
+    // ── normalize() ──────────────────────────────────────────────────────────
+
     @Nested
     @DisplayName("normalize()")
     inner class NormalizeTest {
@@ -77,6 +79,8 @@ class MediaSessionScrobblerTest {
             assertEquals("show name 2024", scrobbler.normalize("Show Name (2024)"))
         }
     }
+
+    // ── fuzzyScore() ─────────────────────────────────────────────────────────
 
     @Nested
     @DisplayName("fuzzyScore()")
@@ -145,73 +149,121 @@ class MediaSessionScrobblerTest {
         }
     }
 
+    // ── autoScrobble() ───────────────────────────────────────────────────────
+
     @Nested
     @DisplayName("autoScrobble()")
     inner class AutoScrobbleTest {
 
         private val testShow = TraktShow("Breaking Bad", 2008, TraktIds(trakt = 1))
         private val testEpisode = TraktEpisode(season = 1, number = 1)
+        private val testCandidate = ScrobbleCandidate(
+            "com.netflix", "Breaking Bad S01E01", 0.95f, testShow, testEpisode
+        )
 
-        @Test
-        fun `sends scrobble start to Trakt API`() = runTest {
-            coEvery { tvTokenCache.getToken() } returns "token"
+        private fun mockScrobbleResponse() {
             coEvery { traktApi.scrobbleStart(any(), any()) } returns ScrobbleResponse(
                 id = 1L, action = "start", progress = 0f,
                 show = testShow, episode = testEpisode
             )
+        }
 
-            val candidate = ScrobbleCandidate(
-                "com.netflix", "Breaking Bad S01E01", 0.95f, testShow, testEpisode
+        @Test
+        fun `sends scrobble start to Trakt API for single user`() = runTest {
+            coEvery { tvTokenCache.getAllTokens() } returns listOf(
+                TvTokenCache.PhoneToken("device-1", "token-1")
             )
-            scrobbler.autoScrobble(candidate)
+            mockScrobbleResponse()
+
+            scrobbler.autoScrobble(testCandidate)
 
             coVerify {
                 traktApi.scrobbleStart(
-                    "Bearer token",
+                    "Bearer token-1",
                     match<ScrobbleBody> { it.show == testShow && it.episode == testEpisode && it.progress == 0f }
                 )
             }
         }
 
         @Test
-        fun `skips when no token`() = runTest {
-            coEvery { tvTokenCache.getToken() } returns null
-
-            val candidate = ScrobbleCandidate(
-                "com.netflix", "Test", 0.95f, testShow, testEpisode
+        fun `scrobbles for each connected user when multiple phones present`() = runTest {
+            coEvery { tvTokenCache.getAllTokens() } returns listOf(
+                TvTokenCache.PhoneToken("device-1", "token-1"),
+                TvTokenCache.PhoneToken("device-2", "token-2")
             )
-            scrobbler.autoScrobble(candidate)
+            mockScrobbleResponse()
+
+            scrobbler.autoScrobble(testCandidate)
+
+            coVerify { traktApi.scrobbleStart("Bearer token-1", any()) }
+            coVerify { traktApi.scrobbleStart("Bearer token-2", any()) }
+            coVerify(exactly = 2) { traktApi.scrobbleStart(any(), any()) }
+        }
+
+        @Test
+        fun `skips when no tokens available`() = runTest {
+            coEvery { tvTokenCache.getAllTokens() } returns emptyList()
+
+            scrobbler.autoScrobble(testCandidate)
+
             coVerify(exactly = 0) { traktApi.scrobbleStart(any(), any()) }
         }
 
         @Test
         fun `skips when no matched show`() = runTest {
-            coEvery { tvTokenCache.getToken() } returns "token"
+            coEvery { tvTokenCache.getAllTokens() } returns listOf(
+                TvTokenCache.PhoneToken("device-1", "token-1")
+            )
 
             val candidate = ScrobbleCandidate("pkg", "Title", 0.95f, null, testEpisode)
             scrobbler.autoScrobble(candidate)
+
             coVerify(exactly = 0) { traktApi.scrobbleStart(any(), any()) }
         }
 
         @Test
         fun `skips when no matched episode`() = runTest {
-            coEvery { tvTokenCache.getToken() } returns "token"
+            coEvery { tvTokenCache.getAllTokens() } returns listOf(
+                TvTokenCache.PhoneToken("device-1", "token-1")
+            )
 
             val candidate = ScrobbleCandidate("pkg", "Title", 0.95f, testShow, null)
             scrobbler.autoScrobble(candidate)
+
             coVerify(exactly = 0) { traktApi.scrobbleStart(any(), any()) }
         }
 
         @Test
-        fun `handles API exception gracefully`() = runTest {
-            coEvery { tvTokenCache.getToken() } returns "token"
+        fun `handles API exception for one user without blocking others`() = runTest {
+            coEvery { tvTokenCache.getAllTokens() } returns listOf(
+                TvTokenCache.PhoneToken("device-1", "token-1"),
+                TvTokenCache.PhoneToken("device-2", "token-2")
+            )
+            coEvery { traktApi.scrobbleStart("Bearer token-1", any()) } throws RuntimeException("API Error")
+            coEvery { traktApi.scrobbleStart("Bearer token-2", any()) } returns ScrobbleResponse(
+                id = 2L, action = "start", progress = 0f, show = testShow, episode = testEpisode
+            )
+
+            // Should not throw — failure for one user is isolated
+            scrobbler.autoScrobble(testCandidate)
+
+            coVerify { traktApi.scrobbleStart("Bearer token-1", any()) }
+            coVerify { traktApi.scrobbleStart("Bearer token-2", any()) }
+        }
+
+        @Test
+        fun `handles single API exception gracefully`() = runTest {
+            coEvery { tvTokenCache.getAllTokens() } returns listOf(
+                TvTokenCache.PhoneToken("device-1", "token-1")
+            )
             coEvery { traktApi.scrobbleStart(any(), any()) } throws RuntimeException("API Error")
 
-            val candidate = ScrobbleCandidate("pkg", "Title", 0.95f, testShow, testEpisode)
             // Should not throw
-            scrobbler.autoScrobble(candidate)
+            scrobbler.autoScrobble(testCandidate)
         }
     }
+
+    // ── Levenshtein distance via fuzzyScore ──────────────────────────────────
 
     @Nested
     @DisplayName("Levenshtein distance via fuzzyScore")

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvTokenCacheTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvTokenCacheTest.kt
@@ -1,14 +1,18 @@
 package com.justb81.watchbuddy.tv.scrobbler
 
+import com.justb81.watchbuddy.core.model.DeviceCapability
+import com.justb81.watchbuddy.core.model.LlmBackend
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneApiService
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import com.justb81.watchbuddy.tv.discovery.TokenResponse
 import io.mockk.*
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("TvTokenCache")
@@ -24,67 +28,226 @@ class TvTokenCacheTest {
         tokenCache = TvTokenCache(phoneApiClientFactory, phoneDiscovery)
     }
 
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
     private fun mockBestPhone(baseUrl: String = "http://192.168.1.1:8765/") {
         val phone = mockk<PhoneDiscoveryManager.DiscoveredPhone>()
         every { phone.baseUrl } returns baseUrl
+        every { phone.capability } returns null
         every { phoneDiscovery.getBestPhone() } returns phone
         every { phoneApiClientFactory.createClient(baseUrl) } returns phoneApiService
     }
 
-    @Test
-    fun `getToken fetches from phone on first call`() = runTest {
-        mockBestPhone()
-        coEvery { phoneApiService.getAccessToken() } returns TokenResponse("my-token")
-
-        val token = tokenCache.getToken()
-        assertEquals("my-token", token)
+    private fun createAvailablePhone(
+        baseUrl: String,
+        deviceId: String
+    ): PhoneDiscoveryManager.DiscoveredPhone {
+        val capability = DeviceCapability(
+            deviceId = deviceId,
+            userName = "user-$deviceId",
+            deviceName = "Phone $deviceId",
+            llmBackend = LlmBackend.NONE,
+            modelQuality = 0,
+            freeRamMb = 4000,
+            isAvailable = true
+        )
+        val phone = mockk<PhoneDiscoveryManager.DiscoveredPhone>()
+        every { phone.baseUrl } returns baseUrl
+        every { phone.capability } returns capability
+        return phone
     }
 
-    @Test
-    fun `getToken returns cached token on second call`() = runTest {
-        mockBestPhone()
-        coEvery { phoneApiService.getAccessToken() } returns TokenResponse("cached-token")
-
-        tokenCache.getToken()
-        tokenCache.getToken()
-        // Should only fetch once due to caching
-        coVerify(exactly = 1) { phoneApiService.getAccessToken() }
+    private fun createUnavailablePhone(baseUrl: String): PhoneDiscoveryManager.DiscoveredPhone {
+        val capability = mockk<DeviceCapability>()
+        every { capability.isAvailable } returns false
+        val phone = mockk<PhoneDiscoveryManager.DiscoveredPhone>()
+        every { phone.baseUrl } returns baseUrl
+        every { phone.capability } returns capability
+        return phone
     }
 
-    @Test
-    fun `getToken returns null when no phone discovered`() = runTest {
-        every { phoneDiscovery.getBestPhone() } returns null
+    // ── getToken() ───────────────────────────────────────────────────────────
 
-        val token = tokenCache.getToken()
-        assertNull(token)
+    @Nested
+    @DisplayName("getToken()")
+    inner class GetTokenTest {
+
+        @Test
+        fun `fetches from best phone on first call`() = runTest {
+            mockBestPhone()
+            coEvery { phoneApiService.getAccessToken() } returns TokenResponse("my-token")
+
+            val token = tokenCache.getToken()
+            assertEquals("my-token", token)
+        }
+
+        @Test
+        fun `returns cached token on second call`() = runTest {
+            mockBestPhone()
+            coEvery { phoneApiService.getAccessToken() } returns TokenResponse("cached-token")
+
+            tokenCache.getToken()
+            tokenCache.getToken()
+            // Should only fetch once due to caching
+            coVerify(exactly = 1) { phoneApiService.getAccessToken() }
+        }
+
+        @Test
+        fun `returns null when no phone discovered`() = runTest {
+            every { phoneDiscovery.getBestPhone() } returns null
+
+            val token = tokenCache.getToken()
+            assertNull(token)
+        }
+
+        @Test
+        fun `returns null when API call fails`() = runTest {
+            mockBestPhone()
+            coEvery { phoneApiService.getAccessToken() } throws RuntimeException("Network error")
+
+            val token = tokenCache.getToken()
+            assertNull(token)
+        }
+
+        @Test
+        fun `invalidate forces re-fetch on next call`() = runTest {
+            mockBestPhone()
+            coEvery { phoneApiService.getAccessToken() } returns TokenResponse("token-1")
+
+            tokenCache.getToken()
+            tokenCache.invalidate()
+
+            coEvery { phoneApiService.getAccessToken() } returns TokenResponse("token-2")
+            val token = tokenCache.getToken()
+            assertEquals("token-2", token)
+            coVerify(exactly = 2) { phoneApiService.getAccessToken() }
+        }
+
+        @Test
+        fun `invalidate on empty cache does not crash`() {
+            tokenCache.invalidate()
+        }
     }
 
-    @Test
-    fun `getToken returns null when API call fails`() = runTest {
-        mockBestPhone()
-        coEvery { phoneApiService.getAccessToken() } throws RuntimeException("Network error")
+    // ── getAllTokens() ────────────────────────────────────────────────────────
 
-        val token = tokenCache.getToken()
-        assertNull(token)
-    }
+    @Nested
+    @DisplayName("getAllTokens()")
+    inner class GetAllTokensTest {
 
-    @Test
-    fun `invalidate clears cached token`() = runTest {
-        mockBestPhone()
-        coEvery { phoneApiService.getAccessToken() } returns TokenResponse("token-1")
+        @Test
+        fun `returns token for each available phone`() = runTest {
+            val phone1 = createAvailablePhone("http://192.168.1.1:8765/", "device-1")
+            val phone2 = createAvailablePhone("http://192.168.1.2:8765/", "device-2")
+            val apiService1 = mockk<PhoneApiService>()
+            val apiService2 = mockk<PhoneApiService>()
 
-        tokenCache.getToken()
-        tokenCache.invalidate()
-        // After invalidation, next call should fetch again
-        coEvery { phoneApiService.getAccessToken() } returns TokenResponse("token-2")
-        val token = tokenCache.getToken()
-        assertEquals("token-2", token)
-        coVerify(exactly = 2) { phoneApiService.getAccessToken() }
-    }
+            every { phoneDiscovery.discoveredPhones } returns MutableStateFlow(listOf(phone1, phone2))
+            every { phoneApiClientFactory.createClient("http://192.168.1.1:8765/") } returns apiService1
+            every { phoneApiClientFactory.createClient("http://192.168.1.2:8765/") } returns apiService2
+            coEvery { apiService1.getAccessToken() } returns TokenResponse("token-1")
+            coEvery { apiService2.getAccessToken() } returns TokenResponse("token-2")
 
-    @Test
-    fun `invalidate resets timestamp forcing re-fetch`() {
-        tokenCache.invalidate()
-        // Verify no crash on invalidating empty cache
+            val tokens = tokenCache.getAllTokens()
+
+            assertEquals(2, tokens.size)
+            assertTrue(tokens.any { it.phoneId == "device-1" && it.token == "token-1" })
+            assertTrue(tokens.any { it.phoneId == "device-2" && it.token == "token-2" })
+        }
+
+        @Test
+        fun `returns empty list when no phones discovered`() = runTest {
+            every { phoneDiscovery.discoveredPhones } returns MutableStateFlow(emptyList())
+
+            val tokens = tokenCache.getAllTokens()
+            assertTrue(tokens.isEmpty())
+        }
+
+        @Test
+        fun `skips phones with unavailable capability`() = runTest {
+            val availablePhone = createAvailablePhone("http://192.168.1.1:8765/", "device-1")
+            val unavailablePhone = createUnavailablePhone("http://192.168.1.2:8765/")
+            val apiService1 = mockk<PhoneApiService>()
+
+            every { phoneDiscovery.discoveredPhones } returns MutableStateFlow(
+                listOf(availablePhone, unavailablePhone)
+            )
+            every { phoneApiClientFactory.createClient("http://192.168.1.1:8765/") } returns apiService1
+            coEvery { apiService1.getAccessToken() } returns TokenResponse("token-1")
+
+            val tokens = tokenCache.getAllTokens()
+
+            assertEquals(1, tokens.size)
+            assertEquals("device-1", tokens.first().phoneId)
+        }
+
+        @Test
+        fun `skips phone when API call fails, returns others`() = runTest {
+            val phone1 = createAvailablePhone("http://192.168.1.1:8765/", "device-1")
+            val phone2 = createAvailablePhone("http://192.168.1.2:8765/", "device-2")
+            val apiService1 = mockk<PhoneApiService>()
+            val apiService2 = mockk<PhoneApiService>()
+
+            every { phoneDiscovery.discoveredPhones } returns MutableStateFlow(listOf(phone1, phone2))
+            every { phoneApiClientFactory.createClient("http://192.168.1.1:8765/") } returns apiService1
+            every { phoneApiClientFactory.createClient("http://192.168.1.2:8765/") } returns apiService2
+            coEvery { apiService1.getAccessToken() } throws RuntimeException("Unreachable")
+            coEvery { apiService2.getAccessToken() } returns TokenResponse("token-2")
+
+            val tokens = tokenCache.getAllTokens()
+
+            assertEquals(1, tokens.size)
+            assertEquals("device-2", tokens.first().phoneId)
+        }
+
+        @Test
+        fun `uses cached token for second call to same phone`() = runTest {
+            val phone = createAvailablePhone("http://192.168.1.1:8765/", "device-1")
+            val apiService = mockk<PhoneApiService>()
+
+            every { phoneDiscovery.discoveredPhones } returns MutableStateFlow(listOf(phone))
+            every { phoneApiClientFactory.createClient("http://192.168.1.1:8765/") } returns apiService
+            coEvery { apiService.getAccessToken() } returns TokenResponse("cached-token")
+
+            tokenCache.getAllTokens()
+            tokenCache.getAllTokens()
+
+            coVerify(exactly = 1) { apiService.getAccessToken() }
+        }
+
+        @Test
+        fun `invalidate clears per-phone cache`() = runTest {
+            val phone = createAvailablePhone("http://192.168.1.1:8765/", "device-1")
+            val apiService = mockk<PhoneApiService>()
+
+            every { phoneDiscovery.discoveredPhones } returns MutableStateFlow(listOf(phone))
+            every { phoneApiClientFactory.createClient("http://192.168.1.1:8765/") } returns apiService
+            coEvery { apiService.getAccessToken() } returns TokenResponse("token-v1")
+
+            tokenCache.getAllTokens()
+            tokenCache.invalidate()
+
+            coEvery { apiService.getAccessToken() } returns TokenResponse("token-v2")
+            val tokens = tokenCache.getAllTokens()
+
+            assertEquals("token-v2", tokens.first().token)
+            coVerify(exactly = 2) { apiService.getAccessToken() }
+        }
+
+        @Test
+        fun `uses baseUrl as phoneId when capability is null`() = runTest {
+            val phone = mockk<PhoneDiscoveryManager.DiscoveredPhone>()
+            every { phone.baseUrl } returns "http://192.168.1.1:8765/"
+            every { phone.capability } returns null
+            val apiService = mockk<PhoneApiService>()
+
+            every { phoneDiscovery.discoveredPhones } returns MutableStateFlow(listOf(phone))
+            every { phoneApiClientFactory.createClient("http://192.168.1.1:8765/") } returns apiService
+            coEvery { apiService.getAccessToken() } returns TokenResponse("token")
+
+            // Phone with null capability is filtered out (isAvailable check fails safely)
+            val tokens = tokenCache.getAllTokens()
+            assertTrue(tokens.isEmpty())
+        }
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -97,17 +97,25 @@ Package name + media title extracted
     │
     ▼
 Fuzzy match against local show cache (Levenshtein distance)
-    │ Falls back to Trakt API search if no good cache match
+    │ Falls back to Trakt API search via best phone if no good cache match
     │
-    ├── Confidence ≥ 95% → auto-scrobble (Trakt /scrobble/start)
+    ├── Confidence ≥ 95% → auto-scrobble
+    │                           │
+    │                     For each connected phone:
+    │                       fetch token → Trakt /scrobble/start
+    │                       (parallel, failures isolated per user)
     │
     ├── Confidence 70–95% → ScrobbleOverlay: user confirms or rejects
     │                           │
-    │                      Confirmed → scrobble
-    │                      Rejected → ignore
+    │                      Confirmed → scrobble all connected users (same parallel flow)
+    │                      Rejected  → ignore
     │
     └── Confidence < 70% → ignored
 ```
+
+Multi-user: when multiple phones are connected, each user's watch history is recorded
+independently — one Trakt scrobble call per phone, in parallel. A failure for one user
+does not block the others.
 
 ## Secret Storage Strategy
 

--- a/docs/trakt-flow.md
+++ b/docs/trakt-flow.md
@@ -48,7 +48,7 @@ This document describes the full user journey and technical flow for connecting 
    └──────────────────┘                       └───────────────────┘
 ```
 
-The phone app owns the Trakt connection. The TV app has **no Trakt credentials** — it discovers the phone on the local network, borrows its access token, and uses that token for scrobbling and show lookups.
+The phone app owns the Trakt connection. The TV app has **no Trakt credentials** — it discovers all phones on the local network, borrows each phone's access token, and uses those tokens for scrobbling (one Trakt call per connected user) and show lookups.
 
 ---
 
@@ -186,18 +186,23 @@ Rank phone:  score = modelQuality (0–150) + ramBonus (0–10)
     │  RAM bonus:  ≥6 GB → +10  |  4–6 GB → +6  |  3–4 GB → +3  |  <3 GB → 0
     │
     ▼
-getBestPhone() → highest-scoring phone
+getBestPhone() → highest-scoring phone (used for single-token ops like search)
     │
     ▼
-TvTokenCache.getToken()
-    ├── Check in-memory cache (30-min TTL)
-    └── If expired → GET http://{bestPhone}:8765/auth/token
-                          │
-                          ▼
-                     Response: { "accessToken": "..." }
-                          │
-                          ▼
-                     Cache token in memory with timestamp
+TvTokenCache — per-phone token cache (ConcurrentHashMap, 30-min TTL per phone)
+    │
+    ├── getToken()       → token for best phone only   (Trakt search)
+    └── getAllTokens()   → tokens for ALL available phones  (scrobbling)
+              │
+              └── For each available phone in parallel:
+                    Check per-phone cache (30-min TTL)
+                    If expired → GET http://{phone}:8765/auth/token
+                                      │
+                                      ▼
+                                 Response: { "accessToken": "..." }
+                                      │
+                                      ▼
+                                 Cache token keyed by phone baseUrl
 ```
 
 ### Key Classes
@@ -301,6 +306,7 @@ matchTitleToTrakt() — two-tier fuzzy matching:
     │     If score ≥ 0.70 → use cached match
     │
     └── Tier 2: Trakt API fallback
+          TvTokenCache.getToken() → token from best phone
           GET https://api.trakt.tv/search/show?query={title}&limit=5 (Bearer token)
           If best result score ≥ 0.50 → use API match
     │
@@ -308,21 +314,24 @@ matchTitleToTrakt() — two-tier fuzzy matching:
 Create ScrobbleCandidate { packageName, mediaTitle, confidence, matchedShow, matchedEpisode }
     │
     ├── confidence ≥ 0.95 → autoScrobble()
-    │     POST https://api.trakt.tv/scrobble/start
-    │       Body: { show, episode, progress: 0.0 }
+    │     TvTokenCache.getAllTokens() → tokens for ALL connected phones
+    │     For each phone token (in parallel):
+    │       POST https://api.trakt.tv/scrobble/start
+    │         Body: { show, episode, progress: 0.0 }
+    │       Failure for one user does not block the others
     │
     ├── confidence 0.70–0.95 → emit to pendingConfirmation SharedFlow
     │     │
     │     ▼
     │   ScrobbleViewModel collects → ScrobbleOverlay displayed
     │     │
-    │     ├── User confirms → autoScrobble()
+    │     ├── User confirms → autoScrobble()  (same multi-user flow above)
     │     ├── User dismisses → remembered in session (won't re-show)
     │     └── 15s timeout → auto-confirms
     │
     └── confidence < 0.70 → ignored
 
-Playback state changes:
+Playback state changes (each fires for ALL connected phones in parallel):
     ├── PLAYING  → scrobbleStart()  { progress: 0.0 }
     ├── PAUSED   → scrobblePause()  { progress: 50.0 }
     └── STOPPED  → scrobbleStop()   { progress: 100.0 }  ← marks episode as watched
@@ -332,7 +341,8 @@ Playback state changes:
 
 | Class | Responsibility |
 |-------|----------------|
-| `MediaSessionScrobbler` | Polls media sessions, fuzzy matches, scrobbles to Trakt |
+| `MediaSessionScrobbler` | Polls media sessions, fuzzy matches, scrobbles to Trakt for all connected users |
+| `TvTokenCache` | Per-phone token cache; `getToken()` for best phone, `getAllTokens()` for all phones |
 | `TvShowCache` | In-memory show cache for first-pass matching |
 | `ScrobbleViewModel` | Bridges pending confirmations to the overlay UI |
 | `ScrobbleOverlay` | Composable confirmation overlay (D-pad navigable) |
@@ -444,17 +454,21 @@ fun resolveClientId(authMode, backendUrl, directClientId): String? = when (authM
 ### Token Flow Across Devices
 
 ```
-Phone (owns token)                    TV (borrows token)
-─────────────────                    ──────────────────
-TokenRepository                      TvTokenCache
-  │                                    │
-  │  access_token in Keystore          │  In-memory, 30-min TTL
-  │  refresh_token in Keystore         │
-  │                                    │  On cache miss:
-  │◄───── GET /auth/token ────────────│    GET http://{phone}:8765/auth/token
-  │                                    │
-  ▼                                    ▼
-  Returns current access_token         Caches and uses for Trakt API calls
+Phone A (Alice)  Phone B (Bob)       TV (borrows tokens)
+───────────────  ─────────────       ───────────────────
+TokenRepository  TokenRepository     TvTokenCache
+  │                │                   │
+  │  token in      │  token in         │  Per-phone ConcurrentHashMap
+  │  Keystore      │  Keystore         │  30-min TTL per phone
+  │                │                   │
+  │                │                   │  getToken()    → best phone only (search)
+  │                │                   │  getAllTokens() → all available phones (scrobble)
+  │                │                   │
+  │◄── GET /auth/token ───────────────│   On cache miss per phone:
+  │                │◄── GET /auth/token│     GET http://{phone}:8765/auth/token
+  ▼                ▼                   ▼
+  Alice's token    Bob's token         Both cached and used independently
+                                       for parallel Trakt scrobble calls
 ```
 
 ### Refresh
@@ -518,41 +532,45 @@ The `TraktApiService` and `TokenProxyService` both define refresh endpoints (`PO
   │◄───────────────│                │                │
 ```
 
-### Full Scrobble Sequence
+### Full Scrobble Sequence (multi-user)
 
 ```
- Streaming App    TV Scrobbler     Phone             Trakt API
-  │                │                │                │
-  │  Playing       │                │                │
-  │  media session │                │                │
-  │───────────────►│                │                │
-  │                │  Extract title + package        │
-  │                │                │                │
-  │                │  Fuzzy match (local cache)      │
-  │                │  Score: 0.97 (auto-scrobble)    │
-  │                │                │                │
-  │                │  Need token    │                │
-  │                │  GET /auth/token│               │
-  │                │───────────────►│                │
-  │                │◄───────────────│                │
-  │                │  { accessToken }│               │
-  │                │                │                │
-  │                │  POST /scrobble/start           │
-  │                │  { show, episode, progress: 0 } │
-  │                │────────────────────────────────►│
-  │                │◄────────────────────────────────│
-  │                │                │                │
-  │  Paused        │                │                │
-  │───────────────►│                │                │
-  │                │  POST /scrobble/pause           │
-  │                │  { progress: 50 }               │
-  │                │────────────────────────────────►│
-  │                │                │                │
-  │  Stopped       │                │                │
-  │───────────────►│                │                │
-  │                │  POST /scrobble/stop            │
-  │                │  { progress: 100 }  ← watched  │
-  │                │────────────────────────────────►│
+ Streaming App    TV Scrobbler    Phone A (Alice)   Phone B (Bob)    Trakt API
+  │                │                │                │                │
+  │  Playing       │                │                │                │
+  │  media session │                │                │                │
+  │───────────────►│                │                │                │
+  │                │  Extract title + package        │                │
+  │                │                │                │                │
+  │                │  Fuzzy match (local cache)      │                │
+  │                │  Score: 0.97 → auto-scrobble    │                │
+  │                │                │                │                │
+  │                │  getAllTokens() — fetch from all phones in parallel
+  │                │  GET /auth/token│               │                │
+  │                │───────────────►│                │                │
+  │                │  GET /auth/token│               │                │
+  │                │────────────────────────────────►│                │
+  │                │◄───────────────│                │                │
+  │                │  { Alice token }│               │                │
+  │                │◄────────────────────────────────│                │
+  │                │                │  { Bob token } │                │
+  │                │                │                │                │
+  │                │  POST /scrobble/start (Alice)   │                │
+  │                │  { show, episode, progress: 0 } │                │
+  │                │────────────────────────────────────────────────►│
+  │                │  POST /scrobble/start (Bob) ← parallel          │
+  │                │────────────────────────────────────────────────►│
+  │                │◄────────────────────────────────────────────────│
+  │                │                │                │                │
+  │  Paused        │                │                │                │
+  │───────────────►│                │                │                │
+  │                │  POST /scrobble/pause (Alice + Bob, parallel)   │
+  │                │────────────────────────────────────────────────►│
+  │                │                │                │                │
+  │  Stopped       │                │                │                │
+  │───────────────►│                │                │                │
+  │                │  POST /scrobble/stop (Alice + Bob) ← watched   │
+  │                │────────────────────────────────────────────────►│
 ```
 
 ---
@@ -585,7 +603,7 @@ The `TraktApiService` and `TokenProxyService` both define refresh endpoints (`PO
 | `app-tv/.../discovery/PhoneDiscoveryManager.kt` | NSD listener, phone ranking |
 | `app-tv/.../discovery/PhoneApiService.kt` | Retrofit interface for phone HTTP API |
 | `app-tv/.../discovery/PhoneApiClientFactory.kt` | Per-phone Retrofit client factory |
-| `app-tv/.../scrobbler/TvTokenCache.kt` | In-memory token cache (30-min TTL) |
+| `app-tv/.../scrobbler/TvTokenCache.kt` | Per-phone token cache (ConcurrentHashMap, 30-min TTL); `getAllTokens()` for multi-user scrobbling |
 
 ### TV App — Scrobbling
 


### PR DESCRIPTION
## Summary

Fixes #109.

When multiple phones are connected via NSD (e.g. two users watching TV together), scrobbling previously only recorded the watched episode on the **best-ranked phone's** Trakt account. All other connected users were silently ignored.

- **`TvTokenCache`**: Replaced the single `AtomicReference` cache with a per-phone `ConcurrentHashMap` cache (keyed by `baseUrl`). Added `getAllTokens()` which fetches tokens from all available phones in parallel using `coroutineScope` + `async/awaitAll`. The existing `getToken()` is preserved for single-token use cases (e.g. Trakt show search).
- **`MediaSessionScrobbler`**: `autoScrobble()`, `handleScrobblePause()`, and `handleScrobbleStop()` now call `getAllTokens()` and fire one Trakt API call per user in parallel. A failure for one user's token does not block scrobbling for the others.

## Test plan

- [ ] `TvTokenCacheTest` — new `getAllTokens()` tests cover: returns tokens for all available phones, empty list when no phones, skips unavailable phones, skips phones that fail (returns others), caching per phone, `invalidate()` clears per-phone cache, `null` capability handled safely
- [ ] `MediaSessionScrobblerTest` — `autoScrobble()` tests updated: single-user path, multi-user path (two phones → two Trakt calls), empty token list skips scrobble, API failure for one user does not block the other

https://claude.ai/code/session_01GFZDETdpaGVPuB5JYqHkLG