### PR TITLE
fix(onboarding): improve NotConfigured state with specific reasons and actionable error UI

### DIFF
--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -104,6 +104,7 @@ dependencies {
     implementation(composeBom)
     implementation(libs.compose.ui)
     implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons.core)
     implementation(libs.compose.ui.tooling.preview)
     debugImplementation(libs.compose.ui.tooling)
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
@@ -36,7 +36,8 @@ fun PhoneNavGraph(
                     navController.navigate(PhoneRoute.Home.route) {
                         popUpTo(PhoneRoute.Onboarding.route) { inclusive = true }
                     }
-                }
+                },
+                onOpenSettings = { navController.navigate(PhoneRoute.Settings.route) }
             )
         }
 
@@ -63,6 +64,7 @@ fun PhoneNavGraph(
             OnboardingScreen(
                 onSuccess = { navController.popBackStack() },
                 onSkip = { navController.popBackStack() },
+                onOpenSettings = { navController.navigate(PhoneRoute.Settings.route) },
                 isReconnect = true
             )
         }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -23,6 +25,7 @@ import com.justb81.watchbuddy.R
 fun OnboardingScreen(
     onSuccess: () -> Unit,
     onSkip: () -> Unit,
+    onOpenSettings: () -> Unit = {},
     isReconnect: Boolean = false,
     viewModel: OnboardingViewModel = hiltViewModel()
 ) {
@@ -110,14 +113,10 @@ fun OnboardingScreen(
                     }
 
                     is OnboardingState.NotConfigured -> {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(
-                                text = stringResource(R.string.onboarding_not_configured),
-                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
-                                textAlign = TextAlign.Center,
-                                style = MaterialTheme.typography.bodyMedium
-                            )
-                        }
+                        NotConfiguredCard(
+                            reason = currentState.reason,
+                            onOpenSettings = onOpenSettings
+                        )
                     }
 
                     else -> {}
@@ -133,6 +132,52 @@ fun OnboardingScreen(
                     color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun NotConfiguredCard(
+    reason: NotConfiguredReason,
+    onOpenSettings: () -> Unit
+) {
+    val messageRes = when (reason) {
+        NotConfiguredReason.MANAGED_MISSING_CLIENT_ID ->
+            R.string.onboarding_not_configured_managed_no_client_id
+        NotConfiguredReason.MANAGED_MISSING_BACKEND ->
+            R.string.onboarding_not_configured_managed_no_backend
+        NotConfiguredReason.SELF_HOSTED_MISSING_URL ->
+            R.string.onboarding_not_configured_self_hosted_no_url
+        NotConfiguredReason.SELF_HOSTED_MISSING_CLIENT_ID ->
+            R.string.onboarding_not_configured_self_hosted_no_id
+        NotConfiguredReason.DIRECT_MISSING_CREDENTIALS ->
+            R.string.onboarding_not_configured_direct_no_credentials
+    }
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        Icon(
+            imageVector = Icons.Default.Warning,
+            contentDescription = null,
+            tint = MaterialTheme.colorScheme.error,
+            modifier = Modifier.size(40.dp)
+        )
+        Text(
+            text = stringResource(messageRes),
+            color = MaterialTheme.colorScheme.error,
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Spacer(Modifier.height(4.dp))
+        Button(
+            onClick = onOpenSettings,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.errorContainer,
+                contentColor = MaterialTheme.colorScheme.onErrorContainer
+            )
+        ) {
+            Text(stringResource(R.string.onboarding_open_settings))
         }
     }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
@@ -23,8 +23,22 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import javax.inject.Inject
 import javax.inject.Named
+
+enum class NotConfiguredReason {
+    /** MANAGED mode: the build-time TRAKT_CLIENT_ID is empty. */
+    MANAGED_MISSING_CLIENT_ID,
+    /** MANAGED mode: the compiled-in token proxy is not available. */
+    MANAGED_MISSING_BACKEND,
+    /** SELF_HOSTED mode: the user has not entered a backend URL. */
+    SELF_HOSTED_MISSING_URL,
+    /** SELF_HOSTED mode: the build-time TRAKT_CLIENT_ID is empty. */
+    SELF_HOSTED_MISSING_CLIENT_ID,
+    /** DIRECT mode: either the Client ID or Client Secret is missing. */
+    DIRECT_MISSING_CREDENTIALS,
+}
 
 sealed class OnboardingState {
     object Idle : OnboardingState()
@@ -38,7 +52,7 @@ sealed class OnboardingState {
     object Polling : OnboardingState()
     data class Success(val username: String) : OnboardingState()
     data class Error(val message: String) : OnboardingState()
-    object NotConfigured : OnboardingState()
+    data class NotConfigured(val reason: NotConfiguredReason) : OnboardingState()
 }
 
 @HiltViewModel
@@ -60,18 +74,30 @@ class OnboardingViewModel @Inject constructor(
 
     /**
      * Resolves the effective client ID based on the current auth mode.
-     * Returns null if the required configuration for the active mode is missing.
+     * Returns a [Pair] of (clientId, reason): if clientId is non-null the config is complete;
+     * if null, reason describes why it is missing.
      */
-    private fun resolveClientId(authMode: AuthMode, backendUrl: String, directClientId: String): String? {
-        return when (authMode) {
-            AuthMode.MANAGED -> buildConfigClientId.takeIf {
-                it.isNotBlank() && tokenProxy != null
-            }
-            AuthMode.SELF_HOSTED -> buildConfigClientId.takeIf {
-                it.isNotBlank() && backendUrl.isNotBlank()
-            }
-            AuthMode.DIRECT -> directClientId.takeIf {
-                it.isNotBlank() && settingsRepository.getClientSecret().isNotBlank()
+    private fun resolveClientId(
+        authMode: AuthMode,
+        backendUrl: String,
+        directClientId: String
+    ): Pair<String?, NotConfiguredReason?> = when (authMode) {
+        AuthMode.MANAGED -> when {
+            buildConfigClientId.isBlank() -> null to NotConfiguredReason.MANAGED_MISSING_CLIENT_ID
+            tokenProxy == null -> null to NotConfiguredReason.MANAGED_MISSING_BACKEND
+            else -> buildConfigClientId to null
+        }
+        AuthMode.SELF_HOSTED -> when {
+            backendUrl.isBlank() -> null to NotConfiguredReason.SELF_HOSTED_MISSING_URL
+            buildConfigClientId.isBlank() -> null to NotConfiguredReason.SELF_HOSTED_MISSING_CLIENT_ID
+            else -> buildConfigClientId to null
+        }
+        AuthMode.DIRECT -> {
+            val secret = settingsRepository.getClientSecret()
+            if (directClientId.isBlank() || secret.isBlank()) {
+                null to NotConfiguredReason.DIRECT_MISSING_CREDENTIALS
+            } else {
+                directClientId to null
             }
         }
     }
@@ -81,11 +107,11 @@ class OnboardingViewModel @Inject constructor(
             _state.value = OnboardingState.LoadingCode
             try {
                 val settings = settingsRepository.settings.first()
-                val clientId = resolveClientId(
+                val (clientId, reason) = resolveClientId(
                     settings.authMode, settings.backendUrl, settings.directClientId
                 )
                 if (clientId == null) {
-                    _state.value = OnboardingState.NotConfigured
+                    _state.value = OnboardingState.NotConfigured(reason!!)
                     return@launch
                 }
 
@@ -131,6 +157,7 @@ class OnboardingViewModel @Inject constructor(
         pollingJob?.cancel()
         pollingJob = viewModelScope.launch {
             var attempts = 0
+            var consecutiveNetworkFailures = 0
             val maxAttempts = response.expires_in / response.interval
             while (isActive && attempts < maxAttempts) {
                 delay(response.interval * 1_000L)
@@ -181,8 +208,24 @@ class OnboardingViewModel @Inject constructor(
                     countdownJob?.cancel()
                     _state.value = OnboardingState.Success(profile.username)
                     return@launch
-                } catch (_: Exception) {
-                    // HTTP 400 = PIN not yet confirmed, 410 = expired — keep polling
+                } catch (e: Exception) {
+                    // HTTP 400 = PIN not yet confirmed — this is expected, keep polling.
+                    // Any other exception (network error, HTTP 410/418/429, etc.) counts as a failure.
+                    val isPinPending = e is HttpException && e.code() == 400
+                    if (isPinPending) {
+                        consecutiveNetworkFailures = 0
+                    } else {
+                        consecutiveNetworkFailures++
+                        if (consecutiveNetworkFailures >= 3) {
+                            countdownJob?.cancel()
+                            _state.value = OnboardingState.Error(
+                                getApplication<Application>().getString(
+                                    R.string.onboarding_error_polling_network
+                                )
+                            )
+                            return@launch
+                        }
+                    }
                 }
                 attempts++
             }

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -17,6 +17,13 @@
     <string name="onboarding_error_loading_code">Fehler beim Laden des Codes: %1$s</string>
     <string name="onboarding_code_expired">Code abgelaufen. Bitte erneut versuchen.</string>
     <string name="onboarding_not_configured">Trakt ist noch nicht konfiguriert. Du kannst deine Zugangsdaten in den Einstellungen einrichten.</string>
+    <string name="onboarding_not_configured_managed_no_client_id">Dieses Build enthält keine Trakt-Client-ID. Öffne Einstellungen → Erweitert und wähle \"Eigene Zugangsdaten\".</string>
+    <string name="onboarding_not_configured_managed_no_backend">Das Token-Backend ist nicht konfiguriert. Öffne Einstellungen → Erweitert, um den Authentifizierungsmodus zu wechseln.</string>
+    <string name="onboarding_not_configured_self_hosted_no_url">Backend-URL nicht gesetzt. Trage deine Proxy-Server-URL in Einstellungen → Erweitert ein.</string>
+    <string name="onboarding_not_configured_self_hosted_no_id">Dieses Build enthält keine Trakt-Client-ID. Konfiguriere sie in Einstellungen → Erweitert.</string>
+    <string name="onboarding_not_configured_direct_no_credentials">Gib deine Trakt-Client-ID und dein Client-Secret in Einstellungen → Erweitert ein.</string>
+    <string name="onboarding_open_settings">Einstellungen öffnen</string>
+    <string name="onboarding_error_polling_network">Verbindung während der Autorisierung verloren. Bitte überprüfe deine Internetverbindung und versuche es erneut.</string>
     <string name="onboarding_skip">Jetzt überspringen</string>
     <string name="onboarding_reconnect_title">Mit Trakt verbinden</string>
 

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -17,6 +17,13 @@
     <string name="onboarding_error_loading_code">Error al cargar el código: %1$s</string>
     <string name="onboarding_code_expired">Código expirado. Por favor, inténtalo de nuevo.</string>
     <string name="onboarding_not_configured">Trakt aún no está configurado. Puedes configurar tus credenciales en los ajustes.</string>
+    <string name="onboarding_not_configured_managed_no_client_id">Este build no tiene Client ID de Trakt. Abre Ajustes → Avanzado y selecciona \"Propias credenciales\".</string>
+    <string name="onboarding_not_configured_managed_no_backend">El backend de tokens no está configurado. Abre Ajustes → Avanzado para cambiar el modo de autenticación.</string>
+    <string name="onboarding_not_configured_self_hosted_no_url">URL del backend no configurada. Introduce la URL de tu servidor proxy en Ajustes → Avanzado.</string>
+    <string name="onboarding_not_configured_self_hosted_no_id">Este build no tiene Client ID de Trakt. Configúralo en Ajustes → Avanzado.</string>
+    <string name="onboarding_not_configured_direct_no_credentials">Introduce tu Client ID y Client Secret de Trakt en Ajustes → Avanzado.</string>
+    <string name="onboarding_open_settings">Abrir ajustes</string>
+    <string name="onboarding_error_polling_network">Se perdió la conexión durante la autorización. Comprueba tu conexión a internet e inténtalo de nuevo.</string>
     <string name="onboarding_skip">Omitir por ahora</string>
     <string name="onboarding_reconnect_title">Conectar con Trakt</string>
 

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -17,6 +17,13 @@
     <string name="onboarding_error_loading_code">Erreur lors du chargement du code : %1$s</string>
     <string name="onboarding_code_expired">Code expiré. Veuillez réessayer.</string>
     <string name="onboarding_not_configured">Trakt n\'est pas encore configuré. Vous pouvez configurer vos identifiants dans les paramètres.</string>
+    <string name="onboarding_not_configured_managed_no_client_id">Ce build ne contient pas de Client ID Trakt. Ouvrez Paramètres → Avancé et choisissez \"Propres identifiants\".</string>
+    <string name="onboarding_not_configured_managed_no_backend">Le backend de jetons n\'est pas configuré. Ouvrez Paramètres → Avancé pour changer de mode d\'authentification.</string>
+    <string name="onboarding_not_configured_self_hosted_no_url">URL du backend non définie. Entrez l\'URL de votre serveur proxy dans Paramètres → Avancé.</string>
+    <string name="onboarding_not_configured_self_hosted_no_id">Ce build ne contient pas de Client ID Trakt. Configurez-le dans Paramètres → Avancé.</string>
+    <string name="onboarding_not_configured_direct_no_credentials">Entrez votre Client ID et Client Secret Trakt dans Paramètres → Avancé.</string>
+    <string name="onboarding_open_settings">Ouvrir les paramètres</string>
+    <string name="onboarding_error_polling_network">Connexion perdue pendant l\'autorisation. Vérifiez votre connexion internet et réessayez.</string>
     <string name="onboarding_skip">Ignorer pour le moment</string>
     <string name="onboarding_reconnect_title">Se connecter à Trakt</string>
 

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -17,6 +17,13 @@
     <string name="onboarding_error_loading_code">Error loading code: %1$s</string>
     <string name="onboarding_code_expired">Code expired. Please try again.</string>
     <string name="onboarding_not_configured">Trakt is not configured yet. You can set up your credentials in Settings.</string>
+    <string name="onboarding_not_configured_managed_no_client_id">This build has no Trakt Client ID. Open Settings → Advanced and switch to \"Own credentials\".</string>
+    <string name="onboarding_not_configured_managed_no_backend">Token backend is not configured. Open Settings → Advanced to switch authentication mode.</string>
+    <string name="onboarding_not_configured_self_hosted_no_url">Backend URL not set. Enter your proxy server URL in Settings → Advanced.</string>
+    <string name="onboarding_not_configured_self_hosted_no_id">This build has no Trakt Client ID. Configure it in Settings → Advanced.</string>
+    <string name="onboarding_not_configured_direct_no_credentials">Enter your Trakt Client ID and Client Secret in Settings → Advanced.</string>
+    <string name="onboarding_open_settings">Open Settings</string>
+    <string name="onboarding_error_polling_network">Lost connection while waiting for authorization. Please check your internet connection and try again.</string>
     <string name="onboarding_skip">Skip for now</string>
     <string name="onboarding_reconnect_title">Connect to Trakt</string>
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelTest.kt
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import okhttp3.ResponseBody.Companion.toResponseBody
+import retrofit2.HttpException
+import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @DisplayName("OnboardingViewModel")
@@ -80,25 +83,35 @@ class OnboardingViewModelTest {
     inner class ManagedMode {
 
         @Test
-        fun `shows NotConfigured when client ID is blank`() = runTest {
+        fun `shows NotConfigured with MANAGED_MISSING_CLIENT_ID when client ID is blank`() = runTest {
             every { settingsRepository.settings } returns flowOf(
                 AppSettings(authMode = AuthMode.MANAGED)
             )
             val vm = createViewModel(buildClientId = "")
             vm.requestDeviceCode()
             advanceUntilIdle()
-            assertEquals(OnboardingState.NotConfigured, vm.state.value)
+            val state = vm.state.value
+            assertTrue(state is OnboardingState.NotConfigured)
+            assertEquals(
+                NotConfiguredReason.MANAGED_MISSING_CLIENT_ID,
+                (state as OnboardingState.NotConfigured).reason
+            )
         }
 
         @Test
-        fun `shows NotConfigured when token proxy is null`() = runTest {
+        fun `shows NotConfigured with MANAGED_MISSING_BACKEND when token proxy is null`() = runTest {
             every { settingsRepository.settings } returns flowOf(
                 AppSettings(authMode = AuthMode.MANAGED)
             )
             val vm = createViewModel(proxy = null)
             vm.requestDeviceCode()
             advanceUntilIdle()
-            assertEquals(OnboardingState.NotConfigured, vm.state.value)
+            val state = vm.state.value
+            assertTrue(state is OnboardingState.NotConfigured)
+            assertEquals(
+                NotConfiguredReason.MANAGED_MISSING_BACKEND,
+                (state as OnboardingState.NotConfigured).reason
+            )
         }
 
         @Test
@@ -124,25 +137,35 @@ class OnboardingViewModelTest {
     inner class SelfHostedMode {
 
         @Test
-        fun `shows NotConfigured when backend URL is blank`() = runTest {
+        fun `shows NotConfigured with SELF_HOSTED_MISSING_URL when backend URL is blank`() = runTest {
             every { settingsRepository.settings } returns flowOf(
                 AppSettings(authMode = AuthMode.SELF_HOSTED, backendUrl = "")
             )
             val vm = createViewModel()
             vm.requestDeviceCode()
             advanceUntilIdle()
-            assertEquals(OnboardingState.NotConfigured, vm.state.value)
+            val state = vm.state.value
+            assertTrue(state is OnboardingState.NotConfigured)
+            assertEquals(
+                NotConfiguredReason.SELF_HOSTED_MISSING_URL,
+                (state as OnboardingState.NotConfigured).reason
+            )
         }
 
         @Test
-        fun `shows NotConfigured when client ID is blank`() = runTest {
+        fun `shows NotConfigured with SELF_HOSTED_MISSING_CLIENT_ID when client ID is blank`() = runTest {
             every { settingsRepository.settings } returns flowOf(
                 AppSettings(authMode = AuthMode.SELF_HOSTED, backendUrl = CUSTOM_BACKEND_URL)
             )
             val vm = createViewModel(buildClientId = "")
             vm.requestDeviceCode()
             advanceUntilIdle()
-            assertEquals(OnboardingState.NotConfigured, vm.state.value)
+            val state = vm.state.value
+            assertTrue(state is OnboardingState.NotConfigured)
+            assertEquals(
+                NotConfiguredReason.SELF_HOSTED_MISSING_CLIENT_ID,
+                (state as OnboardingState.NotConfigured).reason
+            )
         }
 
         @Test
@@ -165,7 +188,7 @@ class OnboardingViewModelTest {
     inner class DirectMode {
 
         @Test
-        fun `shows NotConfigured when direct client ID is blank`() = runTest {
+        fun `shows NotConfigured with DIRECT_MISSING_CREDENTIALS when direct client ID is blank`() = runTest {
             every { settingsRepository.settings } returns flowOf(
                 AppSettings(authMode = AuthMode.DIRECT, directClientId = "")
             )
@@ -174,11 +197,16 @@ class OnboardingViewModelTest {
             val vm = createViewModel()
             vm.requestDeviceCode()
             advanceUntilIdle()
-            assertEquals(OnboardingState.NotConfigured, vm.state.value)
+            val state = vm.state.value
+            assertTrue(state is OnboardingState.NotConfigured)
+            assertEquals(
+                NotConfiguredReason.DIRECT_MISSING_CREDENTIALS,
+                (state as OnboardingState.NotConfigured).reason
+            )
         }
 
         @Test
-        fun `shows NotConfigured when client secret is blank`() = runTest {
+        fun `shows NotConfigured with DIRECT_MISSING_CREDENTIALS when client secret is blank`() = runTest {
             every { settingsRepository.settings } returns flowOf(
                 AppSettings(authMode = AuthMode.DIRECT, directClientId = DIRECT_CLIENT_ID)
             )
@@ -187,7 +215,12 @@ class OnboardingViewModelTest {
             val vm = createViewModel()
             vm.requestDeviceCode()
             advanceUntilIdle()
-            assertEquals(OnboardingState.NotConfigured, vm.state.value)
+            val state = vm.state.value
+            assertTrue(state is OnboardingState.NotConfigured)
+            assertEquals(
+                NotConfiguredReason.DIRECT_MISSING_CREDENTIALS,
+                (state as OnboardingState.NotConfigured).reason
+            )
         }
 
         @Test
@@ -234,6 +267,92 @@ class OnboardingViewModelTest {
             advanceUntilIdle()
 
             assertTrue(vm.state.value is OnboardingState.Error)
+        }
+    }
+
+    @Nested
+    @DisplayName("Polling error handling")
+    inner class PollingErrorHandling {
+
+        private val proxyTokenResponse = ProxyTokenResponse(
+            access_token = "acc",
+            refresh_token = "ref",
+            expires_in = 7776000,
+            token_type = "Bearer",
+            scope = "public"
+        )
+
+        @Test
+        fun `shows Error after 3 consecutive network failures during polling`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+            // First call succeeds to get to polling phase; subsequent calls throw network errors
+            coEvery { tokenProxy.exchangeDeviceCode(any()) } throws RuntimeException("Connection refused")
+            every { application.getString(any<Int>()) } returns "Network error"
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            assertTrue(vm.state.value is OnboardingState.Error)
+        }
+
+        @Test
+        fun `continues polling when HTTP 400 is returned (PIN pending)`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+
+            var callCount = 0
+            coEvery { tokenProxy.exchangeDeviceCode(any()) } answers {
+                callCount++
+                if (callCount < 3) {
+                    // HTTP 400 = pending
+                    throw HttpException(Response.error<Any>(400, "".toResponseBody()))
+                } else {
+                    proxyTokenResponse
+                }
+            }
+            coEvery { traktApi.getProfile(any()) } returns TraktUserProfile(username = "user1")
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            // After the third attempt succeeds, state should be Success
+            assertTrue(vm.state.value is OnboardingState.Success)
+        }
+
+        @Test
+        fun `resets consecutive failure count after a successful HTTP 400 response`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+
+            var callCount = 0
+            coEvery { tokenProxy.exchangeDeviceCode(any()) } answers {
+                callCount++
+                when (callCount) {
+                    1 -> throw RuntimeException("network blip")  // counts as 1
+                    2 -> throw HttpException(Response.error<Any>(400, "".toResponseBody())) // resets to 0
+                    3 -> throw RuntimeException("network blip")  // counts as 1 again
+                    4 -> throw RuntimeException("network blip")  // counts as 2
+                    5 -> proxyTokenResponse                       // succeeds before reaching 3
+                    else -> proxyTokenResponse
+                }
+            }
+            coEvery { traktApi.getProfile(any()) } returns TraktUserProfile(username = "user1")
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            // Should succeed because the HTTP 400 reset the failure counter before we hit 3
+            assertTrue(vm.state.value is OnboardingState.Success)
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ compose-ui = { group = "androidx.compose.ui", name = "ui" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 
 # Compose for TV
 compose-tv-material = { group = "androidx.tv", name = "tv-material", version.ref = "compose-tv" }


### PR DESCRIPTION
## Summary

Fixes #111, partially addresses #110.

### Problem

When Trakt is not configured (missing Client ID, backend URL, or direct credentials), the onboarding screen showed a subdued generic text that looked like normal body text — users couldn't tell it was an error, didn't know why it happened, and had no way to fix it from the screen.

Additionally, the polling catch-all silently swallowed all exceptions including network errors, so a backend going down mid-authorization was invisible to the user (they'd see the countdown run to zero).

### Changes

**`OnboardingViewModel.kt`**
- Added `NotConfiguredReason` enum with 5 values covering every misconfiguration path across all 3 auth modes (MANAGED/SELF_HOSTED/DIRECT)
- Changed `OnboardingState.NotConfigured` from a singleton `object` to `data class(reason: NotConfiguredReason)` so the UI knows exactly what's missing
- `resolveClientId()` now returns `Pair<String?, NotConfiguredReason?>` — the reason is always populated when config is absent
- `startPolling()`: only HTTP 400 (PIN pending) is silently ignored; any other exception (network error, HTTP 410/418/429) increments a consecutive-failure counter; after 3 consecutive non-400 failures the countdown is cancelled and a clear network-error message is shown

**`OnboardingScreen.kt`**
- Added `onOpenSettings: () -> Unit = {}` callback parameter
- New `NotConfiguredCard` composable: warning icon (error colour), reason-specific message, "Open Settings" button styled with `errorContainer` colours
- The old subdued grey text is replaced by this prominent, actionable card

**`PhoneNavGraph.kt`**
- Both the initial onboarding and the reconnect (`Connect`) destinations now pass `onOpenSettings = { navController.navigate(PhoneRoute.Settings.route) }`

**String resources (EN / DE / FR / ES)**
- `onboarding_not_configured_managed_no_client_id`
- `onboarding_not_configured_managed_no_backend`
- `onboarding_not_configured_self_hosted_no_url`
- `onboarding_not_configured_self_hosted_no_id`
- `onboarding_not_configured_direct_no_credentials`
- `onboarding_open_settings`
- `onboarding_error_polling_network`

**`build.gradle.kts` / `libs.versions.toml`**
- Added `compose-material-icons-core` (BOM-managed) to app-phone — required for `Icons.Default.Warning`

## Test plan

- [ ] `OnboardingViewModelTest` — existing `NotConfigured` tests updated to assert specific `NotConfiguredReason` values for each auth mode
- [ ] New `PollingErrorHandling` nested test class:
  - `shows Error after 3 consecutive network failures during polling`
  - `continues polling when HTTP 400 is returned (PIN pending)`
  - `resets consecutive failure count after a successful HTTP 400 response`

https://claude.ai/code/session_01PZdB8JMLder2HjPwBe34Sb