### PR TITLE
fix(tv): surface actionable error messages when companion phone is unreachable

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.tv.discovery
 import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
+import android.util.Log
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -29,6 +30,7 @@ class PhoneDiscoveryManager @Inject constructor(
     companion object {
         const val SERVICE_TYPE = "_watchbuddy._tcp."
         const val CAPABILITY_PATH = "/capability"
+        private const val TAG = "PhoneDiscoveryManager"
     }
 
     private val _discoveredPhones = MutableStateFlow<List<DiscoveredPhone>>(emptyList())
@@ -95,7 +97,7 @@ class PhoneDiscoveryManager @Inject constructor(
                 .filter { it.serviceInfo.serviceName != serviceInfo.serviceName } + phone)
                 .sortedByDescending { it.score }
         } catch (e: Exception) {
-            // Phone unreachable — ignore
+            Log.w(TAG, "Phone discovered at $url but capability fetch failed: ${e.message}")
         }
     }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -102,6 +102,10 @@ fun TvHomeScreen(
                     NoPhoneConnectedState(onRetry = { viewModel.loadShows() })
                 }
 
+                uiState.phoneApiError && uiState.shows.isEmpty() -> {
+                    PhoneUnreachableState(onRetry = { viewModel.loadShows() })
+                }
+
                 uiState.shows.isEmpty() -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Text(
@@ -113,18 +117,23 @@ fun TvHomeScreen(
                 }
 
                 else -> {
-                    LazyVerticalGrid(
-                        columns            = GridCells.Adaptive(minSize = 180.dp),
-                        contentPadding     = PaddingValues(horizontal = 48.dp, vertical = 16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp),
-                        verticalArrangement   = Arrangement.spacedBy(16.dp),
-                        modifier           = Modifier.fillMaxSize()
-                    ) {
-                        items(uiState.shows, key = { it.show.ids.trakt ?: it.show.title }) { entry ->
-                            ShowCard(
-                                entry    = entry,
-                                onClick  = { onShowClick(entry) }
-                            )
+                    Column(Modifier.fillMaxSize()) {
+                        if (uiState.phoneApiError) {
+                            PhoneUnreachableBanner()
+                        }
+                        LazyVerticalGrid(
+                            columns               = GridCells.Adaptive(minSize = 180.dp),
+                            contentPadding        = PaddingValues(horizontal = 48.dp, vertical = 16.dp),
+                            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                            verticalArrangement   = Arrangement.spacedBy(16.dp),
+                            modifier              = Modifier.weight(1f).fillMaxWidth()
+                        ) {
+                            items(uiState.shows, key = { it.show.ids.trakt ?: it.show.title }) { entry ->
+                                ShowCard(
+                                    entry   = entry,
+                                    onClick = { onShowClick(entry) }
+                                )
+                            }
                         }
                     }
                 }
@@ -151,6 +160,43 @@ private fun NoPhoneConnectedState(onRetry: () -> Unit) {
                 Text(stringResource(R.string.tv_retry))
             }
         }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun PhoneUnreachableState(onRetry: () -> Unit) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Text(
+                text     = stringResource(R.string.tv_error_phone_unreachable_no_cache),
+                fontSize = 18.sp,
+                color    = MaterialTheme.colorScheme.error.copy(alpha = 0.8f),
+                modifier = Modifier.padding(bottom = 24.dp)
+            )
+            Button(
+                onClick = onRetry,
+                scale   = ButtonDefaults.scale(scale = 1f)
+            ) {
+                Text(stringResource(R.string.tv_retry))
+            }
+        }
+    }
+}
+
+@Composable
+private fun PhoneUnreachableBanner() {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(MaterialTheme.colorScheme.errorContainer)
+            .padding(horizontal = 48.dp, vertical = 8.dp)
+    ) {
+        Text(
+            text     = stringResource(R.string.tv_error_phone_unreachable),
+            fontSize = 13.sp,
+            color    = MaterialTheme.colorScheme.onErrorContainer
+        )
     }
 }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -20,6 +20,8 @@ data class TvHomeUiState(
     val bestPhoneName: String? = null,
     val bestPhoneBackend: String? = null,
     val noPhoneConnected: Boolean = false,
+    /** True when a phone was discovered via NSD but its API call failed (distinct from noPhoneConnected). */
+    val phoneApiError: Boolean = false,
     val error: String? = null
 )
 
@@ -74,9 +76,12 @@ class TvHomeViewModel @Inject constructor(
     }
 
     private suspend fun loadShows(selectedUserIds: Set<String>) {
-        _uiState.update { it.copy(isLoading = true, error = null, noPhoneConnected = false) }
+        _uiState.update { it.copy(isLoading = true, error = null, noPhoneConnected = false, phoneApiError = false) }
+
+        // Determine best phone before entering the try block so it is accessible in the catch.
+        val bestPhone = phoneDiscovery.getBestPhone()
+
         try {
-            val bestPhone = phoneDiscovery.getBestPhone()
             if (bestPhone != null) {
                 val api = phoneApiClientFactory.createClient(bestPhone.baseUrl)
                 val shows = api.getShows()
@@ -93,11 +98,23 @@ class TvHomeViewModel @Inject constructor(
                 }
             }
         } catch (e: Exception) {
+            // A phone was found (bestPhone != null) but its API call failed — this is different from
+            // "no phone connected". Show phoneApiError so the UI can display the correct message.
+            val phoneFound = bestPhone != null
             val cached = getCachedShows()
             if (cached != null) {
-                _uiState.update { it.copy(isLoading = false, shows = cached, error = e.message) }
+                _uiState.update {
+                    it.copy(isLoading = false, shows = cached, phoneApiError = phoneFound, error = e.message)
+                }
             } else {
-                _uiState.update { it.copy(isLoading = false, error = e.message, noPhoneConnected = true) }
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        phoneApiError = phoneFound,
+                        noPhoneConnected = !phoneFound,
+                        error = e.message
+                    )
+                }
             }
         }
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapScreen.kt
@@ -126,7 +126,10 @@ fun RecapScreen(
                             verticalArrangement = Arrangement.spacedBy(12.dp)
                         ) {
                             Text(
-                                text     = stringResource(R.string.tv_recap_fallback),
+                                text     = stringResource(
+                                    if (s.allPhonesFailed) R.string.tv_recap_fallback_phones_failed
+                                    else R.string.tv_recap_fallback
+                                ),
                                 fontSize = 12.sp,
                                 color    = Color.White.copy(alpha = 0.4f)
                             )

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModel.kt
@@ -25,7 +25,11 @@ sealed class RecapUiState {
     object Idle : RecapUiState()
     data class Generating(val deviceName: String) : RecapUiState()
     data class Ready(val html: String) : RecapUiState()
-    data class Fallback(val synopsis: String) : RecapUiState()
+    data class Fallback(
+        val synopsis: String,
+        /** True when phones were tried but all failed; false when no phones were available at all. */
+        val allPhonesFailed: Boolean = false
+    ) : RecapUiState()
     data class Error(val message: String) : RecapUiState()
 }
 
@@ -82,8 +86,8 @@ class RecapViewModel @Inject constructor(
                 }
             }
 
-            // All phones failed
-            _state.value = RecapUiState.Fallback(fallbackSynopsis)
+            // All phones were tried but all failed — distinguish from the "no phones" early return above.
+            _state.value = RecapUiState.Fallback(fallbackSynopsis, allPhonesFailed = true)
         }
     }
 

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -37,8 +37,13 @@
     <string name="tv_recap_generating_on">Recap wird auf %1$s generiert…</string>
     <string name="tv_recap_error">Recap konnte nicht geladen werden.</string>
     <string name="tv_recap_fallback">Keine KI-Zusammenfassung verfügbar.\nKurzbeschreibung aus TMDB:</string>
+    <string name="tv_recap_fallback_phones_failed">Recap nicht verfügbar – Begleit-App nicht erreichbar.\nBeschreibung aus TMDB:</string>
     <string name="tv_recap_close">Schließen</string>
     <string name="tv_recap_watch_now">Jetzt ansehen</string>
+
+    <!-- Error states -->
+    <string name="tv_error_phone_unreachable">Begleit-App nicht erreichbar. Zwischengespeicherte Daten werden angezeigt.</string>
+    <string name="tv_error_phone_unreachable_no_cache">Begleit-App nicht erreichbar. Stelle sicher, dass WatchBuddy auf deinem Handy läuft.</string>
 
     <!-- Streaming settings -->
     <string name="tv_streaming_settings_button">Dienste</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -37,8 +37,13 @@
     <string name="tv_recap_generating_on">Generando resumen en %1$s…</string>
     <string name="tv_recap_error">No se pudo cargar el resumen.</string>
     <string name="tv_recap_fallback">No hay resumen IA disponible.\nDescripción breve de TMDB:</string>
+    <string name="tv_recap_fallback_phones_failed">Resumen no disponible — aplicación compañera inaccesible.\nDescripción de TMDB:</string>
     <string name="tv_recap_close">Cerrar</string>
     <string name="tv_recap_watch_now">Ver ahora</string>
+
+    <!-- Error states -->
+    <string name="tv_error_phone_unreachable">Aplicación compañera inaccesible. Mostrando datos en caché.</string>
+    <string name="tv_error_phone_unreachable_no_cache">Aplicación compañera inaccesible. Asegúrate de que WatchBuddy está en ejecución en tu teléfono.</string>
 
     <!-- Streaming settings -->
     <string name="tv_streaming_settings_button">Servicios</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -37,8 +37,13 @@
     <string name="tv_recap_generating_on">Génération du récap sur %1$s…</string>
     <string name="tv_recap_error">Impossible de charger le récap.</string>
     <string name="tv_recap_fallback">Aucun résumé IA disponible.\nDescription courte de TMDB :</string>
+    <string name="tv_recap_fallback_phones_failed">Récap indisponible — application compagnon inaccessible.\nDescription de TMDB :</string>
     <string name="tv_recap_close">Fermer</string>
     <string name="tv_recap_watch_now">Regarder maintenant</string>
+
+    <!-- Error states -->
+    <string name="tv_error_phone_unreachable">Application compagnon inaccessible. Affichage des données en cache.</string>
+    <string name="tv_error_phone_unreachable_no_cache">Application compagnon inaccessible. Assurez-vous que WatchBuddy est en cours d\'exécution sur votre téléphone.</string>
 
     <!-- Streaming settings -->
     <string name="tv_streaming_settings_button">Services</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -37,8 +37,13 @@
     <string name="tv_recap_generating_on">Generating recap on %1$s…</string>
     <string name="tv_recap_error">Could not load recap.</string>
     <string name="tv_recap_fallback">No AI summary available.\nBrief description from TMDB:</string>
+    <string name="tv_recap_fallback_phones_failed">Recap unavailable — companion app unreachable.\nShowing description from TMDB:</string>
     <string name="tv_recap_close">Close</string>
     <string name="tv_recap_watch_now">Watch now</string>
+
+    <!-- Error states -->
+    <string name="tv_error_phone_unreachable">Companion app unreachable. Showing cached data.</string>
+    <string name="tv_error_phone_unreachable_no_cache">Companion app unreachable. Make sure WatchBuddy is running on your phone.</string>
 
     <!-- Streaming settings -->
     <string name="tv_streaming_settings_button">Services</string>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
@@ -64,6 +64,49 @@ class TvHomeViewModelTest {
         val state = viewModel.uiState.value
         assertFalse(state.isLoading)
         assertTrue(state.noPhoneConnected)
+        assertFalse(state.phoneApiError)
+    }
+
+    @Test
+    fun `loadShows sets phoneApiError (not noPhoneConnected) when phone found but API fails`() = runTest {
+        val phone = mockk<PhoneDiscoveryManager.DiscoveredPhone>()
+        every { phone.baseUrl } returns "http://192.168.1.1:8765/"
+        every { phoneDiscovery.getBestPhone() } returns phone
+        every { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+        coEvery { phoneApiService.getShows() } throws RuntimeException("Connection refused")
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertTrue(state.phoneApiError)
+        assertFalse(state.noPhoneConnected)
+    }
+
+    @Test
+    fun `loadShows shows cached data with phoneApiError when phone found but API fails`() = runTest {
+        val phone = mockk<PhoneDiscoveryManager.DiscoveredPhone>()
+        every { phone.baseUrl } returns "http://192.168.1.1:8765/"
+        every { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+
+        // First call succeeds and populates cache
+        every { phoneDiscovery.getBestPhone() } returns phone
+        coEvery { phoneApiService.getShows() } returns testShows
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        assertEquals(2, viewModel.uiState.value.shows.size)
+
+        // Second call fails — cached shows should be shown with phoneApiError
+        coEvery { phoneApiService.getShows() } throws RuntimeException("Timeout")
+        viewModel.loadShows()
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertFalse(state.isLoading)
+        assertTrue(state.phoneApiError)
+        assertFalse(state.noPhoneConnected)
+        assertEquals(2, state.shows.size)
     }
 
     @Test
@@ -81,6 +124,8 @@ class TvHomeViewModelTest {
         assertEquals(2, state.shows.size)
         assertEquals("Show 1", state.shows[0].show.title)
         assertFalse(state.isLoading)
+        assertFalse(state.phoneApiError)
+        assertFalse(state.noPhoneConnected)
     }
 
     @Test

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModelTest.kt
@@ -43,13 +43,13 @@ class RecapViewModelTest {
     }
 
     @Test
-    fun `requestRecap with no phones returns Fallback`() = runTest {
+    fun `requestRecap with no phones returns Fallback with allPhonesFailed false`() = runTest {
         viewModel.requestRecap(123, "Fallback synopsis text")
         advanceUntilIdle()
 
-        val state = viewModel.state.value
-        assertTrue(state is RecapUiState.Fallback)
-        assertEquals("Fallback synopsis text", (state as RecapUiState.Fallback).synopsis)
+        val state = viewModel.state.value as RecapUiState.Fallback
+        assertEquals("Fallback synopsis text", state.synopsis)
+        assertFalse(state.allPhonesFailed)
     }
 
     @Test
@@ -62,7 +62,7 @@ class RecapViewModelTest {
     }
 
     @Test
-    fun `requestRecap with failing phones returns Fallback`() = runTest {
+    fun `requestRecap with failing phones returns Fallback with allPhonesFailed true`() = runTest {
         val phone = mockk<PhoneDiscoveryManager.DiscoveredPhone>()
         every { phone.capability } returns mockk {
             every { isAvailable } returns true
@@ -85,7 +85,8 @@ class RecapViewModelTest {
         viewModel.requestRecap(123, "Fallback text")
         advanceUntilIdle()
 
-        val state = viewModel.state.value
-        assertTrue(state is RecapUiState.Fallback)
+        val state = viewModel.state.value as RecapUiState.Fallback
+        assertEquals("Fallback text", state.synopsis)
+        assertTrue(state.allPhonesFailed)
     }
 }


### PR DESCRIPTION
## Summary

Fixes #110 (partial — `OnboardingViewModel` polling error handling is already covered by #125).

- **`PhoneDiscoveryManager`**: Replace silent `catch` with `Log.w` when the HTTP capability fetch for a discovered phone fails, so the failure is visible in logcat.

- **`TvHomeViewModel` / `TvHomeUiState`**: Add `phoneApiError: Boolean` to distinguish "phone found via NSD but API call failed" from "no phone discovered at all". Previously both cases collapsed into `noPhoneConnected = true`, causing the misleading "Start WatchBuddy on your phone" message to appear even when the phone IS running but temporarily unreachable. Moves `getBestPhone()` before the `try` block so the `catch` can set the correct flag.

- **`TvHomeScreen`**: Two new composables:
  - `PhoneUnreachableState` — full-screen error with retry button when the phone API fails and there is no cached data.
  - `PhoneUnreachableBanner` — a narrow warning strip rendered above the cached show grid when the phone API fails but cached data is available.

- **`RecapViewModel` / `RecapScreen`**: Add `allPhonesFailed: Boolean` to `RecapUiState.Fallback`. When the failover loop exhausts all available phones, `allPhonesFailed = true`, and `RecapScreen` shows the more specific `tv_recap_fallback_phones_failed` string ("companion app unreachable") instead of the generic "no AI summary" text.

- **String resources**: Added `tv_error_phone_unreachable`, `tv_error_phone_unreachable_no_cache`, and `tv_recap_fallback_phones_failed` in all four supported languages (EN, DE, FR, ES).

## Test plan

- [x] `TvHomeViewModelTest` — 3 new tests:
  - `phoneApiError true when phone found but API fails (no cache)`
  - `phoneApiError true with cached shows when phone API fails`
  - Existing success path asserts `phoneApiError = false` and `noPhoneConnected = false`
- [x] `RecapViewModelTest` — updated tests:
  - `allPhonesFailed = false` when no phones are available (early return path)
  - `allPhonesFailed = true` when phones are tried but all fail

https://claude.ai/code/session_013xQYY1DNzXpNtHcbg6QcvU