### PR TITLE
test(tmdb): add TTL tests for TmdbCache and HTTP route tests for CompanionHttpServer

### DIFF
--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -153,6 +153,8 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
     testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(libs.ktor.server.test.host)
+    testImplementation(libs.ktor.client.content.negotiation)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.androidx.arch.core.testing)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -25,6 +25,8 @@ import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private const val TAG = "CompanionHttpServer"
+
 /**
  * Local HTTP server running on the phone (port 8765).
  * The TV app discovers this via NSD (mDNS) and calls its endpoints.
@@ -47,124 +49,142 @@ class CompanionHttpServer @Inject constructor(
 ) {
     companion object {
         const val PORT = 8765
-        private const val TAG = "CompanionHttpServer"
     }
 
     private var server: EmbeddedServer<*, *>? = null
 
     fun start() {
         server = embeddedServer(Netty, port = PORT) {
-            install(ContentNegotiation) {
-                json(Json { ignoreUnknownKeys = true })
-            }
-            routing {
-                get("/capability") {
-                    call.respond(capabilityProvider.getCapability())
-                }
-
-                get("/shows") {
-                    tokenRepository.getAccessToken()
-                        ?: return@get call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
-                    try {
-                        val shows = showRepository.getShows()
-                        call.respond(shows)
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Failed to fetch shows", e)
-                        call.respond(HttpStatusCode.InternalServerError, ErrorResponse(e.message ?: "Unknown error"))
-                    }
-                }
-
-                post("/recap/{traktShowId}") {
-                    val showId = call.parameters["traktShowId"]?.toIntOrNull()
-                        ?: return@post call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid show ID"))
-
-                    tokenRepository.getAccessToken()
-                        ?: return@post call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
-
-                    try {
-                        val body = try { call.receive<RecapRequest>() } catch (_: Exception) { RecapRequest() }
-                        val apiKey = body.tmdbApiKey.ifBlank {
-                            settingsRepository.getTmdbApiKey().first()
-                        }
-
-                        if (apiKey.isBlank()) {
-                            return@post call.respond(
-                                HttpStatusCode.PreconditionFailed,
-                                ErrorResponse("TMDB API key not configured")
-                            )
-                        }
-
-                        val tmdbLanguage = LocaleHelper.getTmdbLanguage()
-
-                        val shows = showRepository.getShows()
-                        val watchedEntry = shows.find { it.show.ids.trakt == showId }
-                            ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("Show not found"))
-
-                        val tmdbId = watchedEntry.show.ids.tmdb
-                            ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("No TMDB ID for show"))
-
-                        val tmdbShow = tmdbCache.getShow(tmdbId)
-                            ?: tmdbApiService.getShow(tmdbId, apiKey, language = tmdbLanguage)
-                                .also { tmdbCache.putShow(tmdbId, it) }
-
-                        // Collect watched episode numbers from Trakt data
-                        val watchedEpisodeRefs = watchedEntry.seasons.flatMap { season ->
-                            season.episodes.map { ep -> season.number to ep.number }
-                        }
-
-                        // Load episode details from TMDB for the last 8 watched episodes in parallel
-                        val tmdbEpisodes = coroutineScope {
-                            watchedEpisodeRefs
-                                .takeLast(8)
-                                .map { (season, episode) ->
-                                    async {
-                                        try {
-                                            tmdbCache.getEpisode(tmdbId, season, episode)
-                                                ?: tmdbApiService.getEpisode(tmdbId, season, episode, apiKey, language = tmdbLanguage)
-                                                    .also { tmdbCache.putEpisode(tmdbId, season, episode, it) }
-                                        } catch (e: Exception) {
-                                            Log.w(TAG, "Failed to load TMDB episode S${season}E${episode}", e)
-                                            null
-                                        }
-                                    }
-                                }
-                                .awaitAll()
-                                .filterNotNull()
-                        }
-
-                        if (tmdbEpisodes.isEmpty()) {
-                            return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("No episode data available"))
-                        }
-
-                        // Use last episode as the "target" (next to watch)
-                        val targetEpisode = tmdbEpisodes.last()
-                        val watchedEpisodes = tmdbEpisodes.dropLast(1).ifEmpty { tmdbEpisodes }
-
-                        val html = recapGenerator.generateRecap(
-                            show = tmdbShow,
-                            watchedEpisodes = watchedEpisodes,
-                            targetEpisode = targetEpisode,
-                            apiKey = apiKey
-                        )
-                        call.respond(mapOf("html" to html))
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Recap generation failed for show $showId", e)
-                        call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Recap generation failed: ${e.message}"))
-                    }
-                }
-
-                get("/auth/token") {
-                    val token = tokenRepository.getAccessToken()
-                        ?: return@get call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
-                    call.respond(TokenResponse(accessToken = token))
-                }
-            }
+            configureCompanionRoutes(
+                recapGenerator, capabilityProvider, showRepository,
+                tokenRepository, tmdbApiService, tmdbCache, settingsRepository
+            )
         }.start(wait = false)
     }
 
     fun stop() {
         server?.stop(gracePeriodMillis = 1_000, timeoutMillis = 5_000)
         server = null
+    }
+}
+
+/**
+ * Configures the Ktor application with all companion server routes.
+ * Extracted as a top-level function so it can be tested via [io.ktor.server.testing.testApplication].
+ */
+internal fun Application.configureCompanionRoutes(
+    recapGenerator: RecapGenerator,
+    capabilityProvider: DeviceCapabilityProvider,
+    showRepository: ShowRepository,
+    tokenRepository: TokenRepository,
+    tmdbApiService: TmdbApiService,
+    tmdbCache: TmdbCache,
+    settingsRepository: SettingsRepository
+) {
+    install(ContentNegotiation) {
+        json(Json { ignoreUnknownKeys = true })
+    }
+    routing {
+        get("/capability") {
+            call.respond(capabilityProvider.getCapability())
+        }
+
+        get("/shows") {
+            tokenRepository.getAccessToken()
+                ?: return@get call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
+            try {
+                val shows = showRepository.getShows()
+                call.respond(shows)
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to fetch shows", e)
+                call.respond(HttpStatusCode.InternalServerError, ErrorResponse(e.message ?: "Unknown error"))
+            }
+        }
+
+        post("/recap/{traktShowId}") {
+            val showId = call.parameters["traktShowId"]?.toIntOrNull()
+                ?: return@post call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid show ID"))
+
+            tokenRepository.getAccessToken()
+                ?: return@post call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
+
+            try {
+                val body = try { call.receive<RecapRequest>() } catch (_: Exception) { RecapRequest() }
+                val apiKey = body.tmdbApiKey.ifBlank {
+                    settingsRepository.getTmdbApiKey().first()
+                }
+
+                if (apiKey.isBlank()) {
+                    return@post call.respond(
+                        HttpStatusCode.PreconditionFailed,
+                        ErrorResponse("TMDB API key not configured")
+                    )
+                }
+
+                val tmdbLanguage = LocaleHelper.getTmdbLanguage()
+
+                val shows = showRepository.getShows()
+                val watchedEntry = shows.find { it.show.ids.trakt == showId }
+                    ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("Show not found"))
+
+                val tmdbId = watchedEntry.show.ids.tmdb
+                    ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("No TMDB ID for show"))
+
+                val tmdbShow = tmdbCache.getShow(tmdbId)
+                    ?: tmdbApiService.getShow(tmdbId, apiKey, language = tmdbLanguage)
+                        .also { tmdbCache.putShow(tmdbId, it) }
+
+                // Collect watched episode numbers from Trakt data
+                val watchedEpisodeRefs = watchedEntry.seasons.flatMap { season ->
+                    season.episodes.map { ep -> season.number to ep.number }
+                }
+
+                // Load episode details from TMDB for the last 8 watched episodes in parallel
+                val tmdbEpisodes = coroutineScope {
+                    watchedEpisodeRefs
+                        .takeLast(8)
+                        .map { (season, episode) ->
+                            async {
+                                try {
+                                    tmdbCache.getEpisode(tmdbId, season, episode)
+                                        ?: tmdbApiService.getEpisode(tmdbId, season, episode, apiKey, language = tmdbLanguage)
+                                            .also { tmdbCache.putEpisode(tmdbId, season, episode, it) }
+                                } catch (e: Exception) {
+                                    Log.w(TAG, "Failed to load TMDB episode S${season}E${episode}", e)
+                                    null
+                                }
+                            }
+                        }
+                        .awaitAll()
+                        .filterNotNull()
+                }
+
+                if (tmdbEpisodes.isEmpty()) {
+                    return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("No episode data available"))
+                }
+
+                // Use last episode as the "target" (next to watch)
+                val targetEpisode = tmdbEpisodes.last()
+                val watchedEpisodes = tmdbEpisodes.dropLast(1).ifEmpty { tmdbEpisodes }
+
+                val html = recapGenerator.generateRecap(
+                    show = tmdbShow,
+                    watchedEpisodes = watchedEpisodes,
+                    targetEpisode = targetEpisode,
+                    apiKey = apiKey
+                )
+                call.respond(mapOf("html" to html))
+            } catch (e: Exception) {
+                Log.e(TAG, "Recap generation failed for show $showId", e)
+                call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Recap generation failed: ${e.message}"))
+            }
+        }
+
+        get("/auth/token") {
+            val token = tokenRepository.getAccessToken()
+                ?: return@get call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
+            call.respond(TokenResponse(accessToken = token))
+        }
     }
 }
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -1,0 +1,448 @@
+package com.justb81.watchbuddy.phone.server
+
+import com.justb81.watchbuddy.core.model.LlmBackend
+import com.justb81.watchbuddy.core.model.DeviceCapability
+import com.justb81.watchbuddy.core.model.TmdbEpisode
+import com.justb81.watchbuddy.core.model.TmdbShow
+import com.justb81.watchbuddy.core.model.TraktIds
+import com.justb81.watchbuddy.core.model.TraktShow
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.model.TraktWatchedEpisode
+import com.justb81.watchbuddy.core.model.TraktWatchedSeason
+import com.justb81.watchbuddy.core.tmdb.TmdbApiService
+import com.justb81.watchbuddy.core.tmdb.TmdbCache
+import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.llm.RecapGenerator
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import io.mockk.*
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("CompanionHttpServer routes")
+class CompanionHttpServerTest {
+
+    // ── Mocked dependencies ───────────────────────────────────────────────────
+
+    private val recapGenerator: RecapGenerator = mockk()
+    private val capabilityProvider: DeviceCapabilityProvider = mockk()
+    private val showRepository: ShowRepository = mockk()
+    private val tokenRepository: TokenRepository = mockk()
+    private val tmdbApiService: TmdbApiService = mockk()
+    private val tmdbCache = TmdbCache()
+    private val settingsRepository: SettingsRepository = mockk()
+
+    // ── Shared test fixtures ──────────────────────────────────────────────────
+
+    private val capability = DeviceCapability(
+        deviceId = "dev-1",
+        userName = "alice",
+        deviceName = "Pixel 9",
+        llmBackend = LlmBackend.LITERT,
+        modelQuality = 75,
+        freeRamMb = 4096,
+        isAvailable = true,
+        tmdbConfigured = true
+    )
+
+    private val tmdbShow = TmdbShow(100, "Breaking Bad", "A chemistry teacher turns to crime.")
+
+    /** TraktWatchedEntry whose trakt ID = 1 and TMDB ID = 100, with 3 watched episodes. */
+    private val watchedEntry = TraktWatchedEntry(
+        show = TraktShow("Breaking Bad", 2008, TraktIds(trakt = 1, tmdb = 100)),
+        seasons = listOf(
+            TraktWatchedSeason(1, listOf(TraktWatchedEpisode(1), TraktWatchedEpisode(2))),
+            TraktWatchedSeason(2, listOf(TraktWatchedEpisode(1)))
+        )
+    )
+
+    private val ep1 = TmdbEpisode(1, "Pilot", "First episode.", "/s1e1.jpg", 1, 1)
+    private val ep2 = TmdbEpisode(2, "Cat's in the Bag", null, null, 1, 2)
+    private val ep3 = TmdbEpisode(3, "Seven Thirty-Seven", null, null, 2, 1)
+
+    @BeforeEach
+    fun setUp() {
+        clearAllMocks()
+        tmdbCache.clear()
+    }
+
+    // ── Helper: configure test application with all mocked dependencies ───────
+
+    private fun testApp(block: suspend ApplicationTestBuilder.() -> Unit) = testApplication {
+        application {
+            configureCompanionRoutes(
+                recapGenerator, capabilityProvider, showRepository,
+                tokenRepository, tmdbApiService, tmdbCache, settingsRepository
+            )
+        }
+        block()
+    }
+
+    // ── GET /capability ───────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("GET /capability")
+    inner class CapabilityEndpoint {
+
+        @Test
+        fun `returns 200 with capability JSON`() = testApp {
+            coEvery { capabilityProvider.getCapability() } returns capability
+
+            val response = client.get("/capability")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertTrue(body.contains("\"userName\":\"alice\""))
+            assertTrue(body.contains("\"modelQuality\":75"))
+        }
+    }
+
+    // ── GET /shows ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("GET /shows")
+    inner class ShowsEndpoint {
+
+        @Test
+        fun `returns 401 when no access token`() = testApp {
+            every { tokenRepository.getAccessToken() } returns null
+
+            val response = client.get("/shows")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+        @Test
+        fun `returns 200 with shows list when authenticated`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "test-token"
+            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+
+            val response = client.get("/shows")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("Breaking Bad"))
+        }
+
+        @Test
+        fun `returns 200 with empty list when no shows`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "test-token"
+            coEvery { showRepository.getShows() } returns emptyList()
+
+            val response = client.get("/shows")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("[]", response.bodyAsText())
+        }
+
+        @Test
+        fun `returns 500 when show repository throws`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "test-token"
+            coEvery { showRepository.getShows() } throws RuntimeException("Trakt API down")
+
+            val response = client.get("/shows")
+
+            assertEquals(HttpStatusCode.InternalServerError, response.status)
+            assertTrue(response.bodyAsText().contains("Trakt API down"))
+        }
+    }
+
+    // ── POST /recap/{traktShowId} ─────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("POST /recap/{traktShowId}")
+    inner class RecapEndpoint {
+
+        private fun stubSuccessfulEpisodes(apiKey: String = "api-key") {
+            coEvery { tmdbApiService.getEpisode(100, 1, 1, apiKey, any()) } returns ep1
+            coEvery { tmdbApiService.getEpisode(100, 1, 2, apiKey, any()) } returns ep2
+            coEvery { tmdbApiService.getEpisode(100, 2, 1, apiKey, any()) } returns ep3
+        }
+
+        @Test
+        fun `returns 400 for non-numeric show ID`() = testApp {
+            val response = client.post("/recap/not-a-number")
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+        @Test
+        fun `returns 401 when no access token`() = testApp {
+            every { tokenRepository.getAccessToken() } returns null
+
+            val response = client.post("/recap/1")
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+        @Test
+        fun `returns 412 when TMDB key absent from body and settings`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            every { settingsRepository.getTmdbApiKey() } returns flowOf("")
+
+            val response = client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":""}""")
+            }
+
+            assertEquals(HttpStatusCode.PreconditionFailed, response.status)
+        }
+
+        @Test
+        fun `returns 404 when show not in watched list`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            coEvery { showRepository.getShows() } returns emptyList()
+
+            val response = client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":"api-key"}""")
+            }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+        @Test
+        fun `returns 404 when show has no TMDB ID`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            val noTmdbEntry = TraktWatchedEntry(
+                show = TraktShow("No TMDB Show", 2020, TraktIds(trakt = 1, tmdb = null)),
+                seasons = listOf(TraktWatchedSeason(1, listOf(TraktWatchedEpisode(1))))
+            )
+            coEvery { showRepository.getShows() } returns listOf(noTmdbEntry)
+
+            val response = client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":"api-key"}""")
+            }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+        @Test
+        fun `returns 200 on successful recap generation`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
+            stubSuccessfulEpisodes()
+            coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } returns "<div>Recap HTML</div>"
+
+            val response = client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":"api-key"}""")
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("Recap HTML"))
+        }
+
+        @Test
+        fun `uses show from cache — does not call TMDB getShow`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            tmdbCache.putShow(100, tmdbShow)
+            stubSuccessfulEpisodes()
+            coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } returns "<div>ok</div>"
+
+            val response = client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":"api-key"}""")
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            coVerify(exactly = 0) { tmdbApiService.getShow(any(), any(), any()) }
+        }
+
+        @Test
+        fun `fetches show from TMDB on cache miss and stores it in cache`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
+            stubSuccessfulEpisodes()
+            coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } returns "<div>ok</div>"
+
+            client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":"api-key"}""")
+            }
+
+            coVerify(exactly = 1) { tmdbApiService.getShow(100, "api-key", any()) }
+            assertNotNull(tmdbCache.getShow(100))
+            assertEquals("Breaking Bad", tmdbCache.getShow(100)!!.name)
+        }
+
+        @Test
+        fun `uses episode cache on hit — does not call TMDB getEpisode`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
+            // Pre-populate episode cache
+            tmdbCache.putEpisode(100, 1, 1, ep1)
+            tmdbCache.putEpisode(100, 1, 2, ep2)
+            tmdbCache.putEpisode(100, 2, 1, ep3)
+            coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } returns "<div>ok</div>"
+
+            val response = client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":"api-key"}""")
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            coVerify(exactly = 0) { tmdbApiService.getEpisode(any(), any(), any(), any(), any()) }
+        }
+
+        @Test
+        fun `fetches episodes from TMDB on cache miss and stores them in cache`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
+            stubSuccessfulEpisodes()
+            coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } returns "<div>ok</div>"
+
+            client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":"api-key"}""")
+            }
+
+            // All 3 episodes fetched from API
+            coVerify(exactly = 1) { tmdbApiService.getEpisode(100, 1, 1, "api-key", any()) }
+            coVerify(exactly = 1) { tmdbApiService.getEpisode(100, 1, 2, "api-key", any()) }
+            coVerify(exactly = 1) { tmdbApiService.getEpisode(100, 2, 1, "api-key", any()) }
+            // All 3 episodes now in cache
+            assertNotNull(tmdbCache.getEpisode(100, 1, 1))
+            assertNotNull(tmdbCache.getEpisode(100, 1, 2))
+            assertNotNull(tmdbCache.getEpisode(100, 2, 1))
+        }
+
+        @Test
+        fun `returns 200 when one episode fails but others succeed`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
+            coEvery { tmdbApiService.getEpisode(100, 1, 1, "api-key", any()) } returns ep1
+            coEvery { tmdbApiService.getEpisode(100, 1, 2, "api-key", any()) } throws RuntimeException("Network error")
+            coEvery { tmdbApiService.getEpisode(100, 2, 1, "api-key", any()) } returns ep3
+            coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } returns "<div>ok</div>"
+
+            val response = client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":"api-key"}""")
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+        }
+
+        @Test
+        fun `returns 404 when all episodes fail to load`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
+            coEvery { tmdbApiService.getEpisode(any(), any(), any(), any(), any()) } throws RuntimeException("All fail")
+
+            val response = client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":"api-key"}""")
+            }
+
+            assertEquals(HttpStatusCode.NotFound, response.status)
+        }
+
+        @Test
+        fun `returns 503 when recap generation throws`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
+            stubSuccessfulEpisodes()
+            coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } throws RuntimeException("LLM crashed")
+
+            val response = client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":"api-key"}""")
+            }
+
+            assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+        }
+
+        @Test
+        fun `uses TMDB key from settings when body key is blank`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            every { settingsRepository.getTmdbApiKey() } returns flowOf("settings-key")
+            coEvery { tmdbApiService.getShow(100, "settings-key", any()) } returns tmdbShow
+            coEvery { tmdbApiService.getEpisode(100, 1, 1, "settings-key", any()) } returns ep1
+            coEvery { tmdbApiService.getEpisode(100, 1, 2, "settings-key", any()) } returns ep2
+            coEvery { tmdbApiService.getEpisode(100, 2, 1, "settings-key", any()) } returns ep3
+            coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } returns "<div>ok</div>"
+
+            // Send no body → key must come from settings
+            val response = client.post("/recap/1")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            coVerify { tmdbApiService.getShow(100, "settings-key", any()) }
+        }
+
+        @Test
+        fun `limits episode fetches to the last 8 watched episodes`() = testApp {
+            // Build an entry with 10 watched episodes across seasons
+            val manyEpisodeEntry = TraktWatchedEntry(
+                show = TraktShow("Long Show", 2010, TraktIds(trakt = 1, tmdb = 100)),
+                seasons = listOf(
+                    TraktWatchedSeason(1, (1..5).map { TraktWatchedEpisode(it) }),
+                    TraktWatchedSeason(2, (1..5).map { TraktWatchedEpisode(it) })
+                )
+            )
+            every { tokenRepository.getAccessToken() } returns "token"
+            coEvery { showRepository.getShows() } returns listOf(manyEpisodeEntry)
+            coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
+            // Only stub the last 8 episodes (S1E3..S1E5, S2E1..S2E5)
+            coEvery { tmdbApiService.getEpisode(100, 1, 3, "api-key", any()) } returns TmdbEpisode(3, "S1E3", null, null, 1, 3)
+            coEvery { tmdbApiService.getEpisode(100, 1, 4, "api-key", any()) } returns TmdbEpisode(4, "S1E4", null, null, 1, 4)
+            coEvery { tmdbApiService.getEpisode(100, 1, 5, "api-key", any()) } returns TmdbEpisode(5, "S1E5", null, null, 1, 5)
+            coEvery { tmdbApiService.getEpisode(100, 2, 1, "api-key", any()) } returns TmdbEpisode(6, "S2E1", null, null, 2, 1)
+            coEvery { tmdbApiService.getEpisode(100, 2, 2, "api-key", any()) } returns TmdbEpisode(7, "S2E2", null, null, 2, 2)
+            coEvery { tmdbApiService.getEpisode(100, 2, 3, "api-key", any()) } returns TmdbEpisode(8, "S2E3", null, null, 2, 3)
+            coEvery { tmdbApiService.getEpisode(100, 2, 4, "api-key", any()) } returns TmdbEpisode(9, "S2E4", null, null, 2, 4)
+            coEvery { tmdbApiService.getEpisode(100, 2, 5, "api-key", any()) } returns TmdbEpisode(10, "S2E5", null, null, 2, 5)
+            coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } returns "<div>ok</div>"
+
+            val response = client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":"api-key"}""")
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            // First 2 episodes (S1E1, S1E2) should NOT be fetched
+            coVerify(exactly = 0) { tmdbApiService.getEpisode(100, 1, 1, any(), any()) }
+            coVerify(exactly = 0) { tmdbApiService.getEpisode(100, 1, 2, any(), any()) }
+        }
+    }
+
+    // ── GET /auth/token ───────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("GET /auth/token")
+    inner class AuthTokenEndpoint {
+
+        @Test
+        fun `returns 401 when no access token`() = testApp {
+            every { tokenRepository.getAccessToken() } returns null
+
+            val response = client.get("/auth/token")
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+        @Test
+        fun `returns 200 with access token`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "my-secret-token"
+
+            val response = client.get("/auth/token")
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("my-secret-token"))
+        }
+    }
+}

--- a/core/src/main/java/com/justb81/watchbuddy/core/tmdb/TmdbCache.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/tmdb/TmdbCache.kt
@@ -21,13 +21,16 @@ class TmdbCache @Inject constructor() {
     private val showCache = ConcurrentHashMap<Int, CacheEntry<TmdbShow>>()
     private val episodeCache = ConcurrentHashMap<Triple<Int, Int, Int>, CacheEntry<TmdbEpisode>>()
 
+    /** Overridable time source — defaults to wall-clock time. Override in tests to control TTL behaviour. */
+    internal var timeSource: () -> Long = { System.currentTimeMillis() }
+
     companion object {
         const val TTL_MS = 15 * 60 * 1000L // 15 minutes
     }
 
     fun getShow(id: Int): TmdbShow? {
         val entry = showCache[id] ?: return null
-        return if (System.currentTimeMillis() - entry.timestamp < TTL_MS) {
+        return if (timeSource() - entry.timestamp < TTL_MS) {
             entry.value
         } else {
             showCache.remove(id)
@@ -36,13 +39,13 @@ class TmdbCache @Inject constructor() {
     }
 
     fun putShow(id: Int, show: TmdbShow) {
-        showCache[id] = CacheEntry(System.currentTimeMillis(), show)
+        showCache[id] = CacheEntry(timeSource(), show)
     }
 
     fun getEpisode(seriesId: Int, season: Int, episode: Int): TmdbEpisode? {
         val key = Triple(seriesId, season, episode)
         val entry = episodeCache[key] ?: return null
-        return if (System.currentTimeMillis() - entry.timestamp < TTL_MS) {
+        return if (timeSource() - entry.timestamp < TTL_MS) {
             entry.value
         } else {
             episodeCache.remove(key)
@@ -52,7 +55,7 @@ class TmdbCache @Inject constructor() {
 
     fun putEpisode(seriesId: Int, season: Int, episode: Int, tmdbEpisode: TmdbEpisode) {
         val key = Triple(seriesId, season, episode)
-        episodeCache[key] = CacheEntry(System.currentTimeMillis(), tmdbEpisode)
+        episodeCache[key] = CacheEntry(timeSource(), tmdbEpisode)
     }
 
     fun clear() {

--- a/core/src/test/java/com/justb81/watchbuddy/core/tmdb/TmdbCacheTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/tmdb/TmdbCacheTest.kt
@@ -131,6 +131,97 @@ class TmdbCacheTest {
     }
 
     @Nested
+    @DisplayName("TTL expiry")
+    inner class TtlTest {
+
+        private val baseTime = 1_000_000L
+        private var fakeTime = baseTime
+
+        @BeforeEach
+        fun setUpClock() {
+            fakeTime = baseTime
+            cache.timeSource = { fakeTime }
+        }
+
+        @Test
+        fun `getShow returns entry just before TTL expires`() {
+            cache.putShow(1, TmdbShow(1, "Breaking Bad"))
+            fakeTime = baseTime + TmdbCache.TTL_MS - 1
+            assertNotNull(cache.getShow(1))
+        }
+
+        @Test
+        fun `getShow returns null at TTL boundary`() {
+            cache.putShow(1, TmdbShow(1, "Breaking Bad"))
+            fakeTime = baseTime + TmdbCache.TTL_MS
+            assertNull(cache.getShow(1))
+        }
+
+        @Test
+        fun `getShow returns null after TTL expires`() {
+            cache.putShow(1, TmdbShow(1, "Breaking Bad"))
+            fakeTime = baseTime + TmdbCache.TTL_MS + 1
+            assertNull(cache.getShow(1))
+        }
+
+        @Test
+        fun `getShow removes expired entry from cache`() {
+            cache.putShow(1, TmdbShow(1, "Test"))
+            fakeTime = baseTime + TmdbCache.TTL_MS + 1
+            cache.getShow(1) // triggers eviction
+            // A fresh put at current time should work
+            cache.putShow(1, TmdbShow(1, "Fresh"))
+            assertNotNull(cache.getShow(1))
+        }
+
+        @Test
+        fun `putShow refreshes TTL on overwrite`() {
+            cache.putShow(1, TmdbShow(1, "Original"))
+            // Advance close to expiry, then overwrite
+            fakeTime = baseTime + TmdbCache.TTL_MS - 100
+            cache.putShow(1, TmdbShow(1, "Updated"))
+            // Advance past the original TTL — new entry should still be valid
+            fakeTime = baseTime + TmdbCache.TTL_MS + 1
+            val result = cache.getShow(1)
+            assertNotNull(result)
+            assertEquals("Updated", result!!.name)
+        }
+
+        @Test
+        fun `getEpisode returns entry just before TTL expires`() {
+            cache.putEpisode(100, 1, 1, TmdbEpisode(1, "Pilot", null, null, 1, 1))
+            fakeTime = baseTime + TmdbCache.TTL_MS - 1
+            assertNotNull(cache.getEpisode(100, 1, 1))
+        }
+
+        @Test
+        fun `getEpisode returns null at TTL boundary`() {
+            cache.putEpisode(100, 1, 1, TmdbEpisode(1, "Pilot", null, null, 1, 1))
+            fakeTime = baseTime + TmdbCache.TTL_MS
+            assertNull(cache.getEpisode(100, 1, 1))
+        }
+
+        @Test
+        fun `getEpisode returns null after TTL expires`() {
+            cache.putEpisode(100, 1, 1, TmdbEpisode(1, "Pilot", null, null, 1, 1))
+            fakeTime = baseTime + TmdbCache.TTL_MS + 1
+            assertNull(cache.getEpisode(100, 1, 1))
+        }
+
+        @Test
+        fun `TTL expiry is independent per entry`() {
+            cache.putShow(1, TmdbShow(1, "Show A"))
+            fakeTime = baseTime + 1000
+            cache.putShow(2, TmdbShow(2, "Show B"))
+
+            // Advance past Show A's TTL but not Show B's
+            fakeTime = baseTime + TmdbCache.TTL_MS + 500
+            assertNull(cache.getShow(1))     // Show A expired
+            assertNotNull(cache.getShow(2))  // Show B still valid (its TTL is TTL_MS - 500 ms away)
+        }
+    }
+
+    @Nested
     @DisplayName("clear")
     inner class ClearTest {
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -63,6 +63,8 @@ ktor-server-core = { group = "io.ktor", name = "ktor-server-core", version.ref =
 ktor-server-netty = { group = "io.ktor", name = "ktor-server-netty", version.ref = "ktor" }
 ktor-server-content-negotiation = { group = "io.ktor", name = "ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-serialization-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-server-test-host = { group = "io.ktor", name = "ktor-server-test-host", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 
 # Kotlin Serialization
 kotlinx-serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }


### PR DESCRIPTION
## Summary

Closes #116, #117, #118

The implementations for parallel TMDB episode fetching (#116), removal of unused `TmdbApiService` methods (#117), and in-memory TMDB caching (#118) were already merged. This PR adds the missing test coverage and the small refactor needed to make the server testable.

- **`TmdbCache` — clock injection for TTL tests**: Added an `internal var timeSource: () -> Long` hook (defaults to `System::currentTimeMillis`). Tests override it to simulate time passing without real waits.
- **`TmdbCacheTest` — 9 new TTL tests**: Cover expiry at boundary, just before/after, per-entry independence, and TTL refresh on overwrite for both show and episode caches.
- **`CompanionHttpServer` refactor**: Extracted the Ktor routing setup into a top-level `internal fun Application.configureCompanionRoutes(...)`, callable from `testApplication` without starting a real Netty server.
- **New `CompanionHttpServerTest`**: 20 tests covering all four endpoints:
  - `GET /capability` — returns JSON capability
  - `GET /shows` — auth check, success, empty list, repository error
  - `POST /recap/{id}` — bad ID, auth, missing TMDB key, show not found, no TMDB ID, show cache hit/miss, episode cache hit/miss, partial episode failure, all-episodes-fail, recap generator failure, settings fallback for API key, 8-episode window limit
  - `GET /auth/token` — auth check, returns token
- **New test dependencies**: `ktor-server-test-host`, `ktor-client-content-negotiation`

## Test plan

- [ ] `./gradlew :core:test` — all `TmdbCacheTest` tests pass (including 9 new TTL tests)
- [ ] `./gradlew :app-phone:test` — all `CompanionHttpServerTest` tests pass (20 new tests)
- [ ] `./gradlew assembleDebug` — both APKs build cleanly

https://claude.ai/code/session_01A7TM75UDyw7VdbwMhwivQX