### PR TITLE
fix(build): sign debug APKs with release keystore to enable seamless upgrades

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -54,10 +54,34 @@ jobs:
           key: config-cache-${{ hashFiles('**/*.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml') }}
           restore-keys: config-cache-
 
+      # Decode release keystore when available so debug APKs are signed with the
+      # same certificate as release APKs.  This prevents INSTALL_FAILED_UPDATE_INCOMPATIBLE
+      # when users upgrade between debug and release builds.
+      - name: Decode Keystore
+        id: keystore
+        run: |
+          if [ -n "${{ secrets.KEYSTORE_BASE64 }}" ]; then
+            echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > /tmp/release.keystore
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run unit tests
         run: ./gradlew test
 
-      - name: Build Phone and TV debug APKs
+      - name: Build Phone and TV debug APKs (signed)
+        if: steps.keystore.outputs.available == 'true'
+        env:
+          VERSION_CODE: ${{ github.run_number }}
+          KEYSTORE_FILE: /tmp/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
+
+      - name: Build Phone and TV debug APKs (unsigned fallback)
+        if: steps.keystore.outputs.available == 'false'
         env:
           VERSION_CODE: ${{ github.run_number }}
         run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,18 +78,24 @@ jobs:
           VERSION_CODE: ${{ github.run_number }}
         run: ./gradlew :app-tv:assembleRelease
 
-      # -- Debug APKs (immer) ---------------------------------------------
-      - name: Build Phone debug APK
+      # -- Debug APKs (always) — signed with release keystore when available -----
+      - name: Build debug APKs (signed)
+        if: steps.keystore.outputs.available == 'true'
         env:
           VERSION_NAME: ${{ needs.release-please.outputs.version }}
           VERSION_CODE: ${{ github.run_number }}
-        run: ./gradlew :app-phone:assembleDebug
+          KEYSTORE_FILE: /tmp/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
 
-      - name: Build TV debug APK
+      - name: Build debug APKs (unsigned fallback)
+        if: steps.keystore.outputs.available == 'false'
         env:
           VERSION_NAME: ${{ needs.release-please.outputs.version }}
           VERSION_CODE: ${{ github.run_number }}
-        run: ./gradlew :app-tv:assembleDebug
+        run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
 
       # -- APKs sammeln und umbenennen -------------------------------------
       - name: Collect APKs

--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -38,8 +38,10 @@ android {
         )
     }
 
-    // CI signing: keystore path + credentials via environment variables
-    val keystoreFile = providers.environmentVariable("KEYSTORE_FILE").orNull
+    // CI signing: keystore path + credentials via environment variables.
+    // takeIf guards against KEYSTORE_FILE being set to an empty string (e.g. when
+    // the secret is absent and the workflow sets the variable to '' as a fallback).
+    val keystoreFile = providers.environmentVariable("KEYSTORE_FILE").orNull?.takeIf { it.isNotBlank() }
     if (keystoreFile != null) {
         signingConfigs {
             create("release") {
@@ -52,6 +54,16 @@ android {
     }
 
     buildTypes {
+        debug {
+            // Use the release keystore for debug builds when available so that debug
+            // and release APKs share the same signing certificate.  Without this,
+            // upgrading from a CI debug APK to a release APK fails with
+            // INSTALL_FAILED_UPDATE_INCOMPATIBLE because each runner generates a
+            // different ephemeral debug.keystore.
+            if (keystoreFile != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
+        }
         release {
             isMinifyEnabled = true
             isShrinkResources = true

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -25,8 +25,10 @@ android {
             .orElse("0.5.1").get() // x-release-please-version
     }
 
-    // CI signing: keystore path + credentials via environment variables
-    val keystoreFile = providers.environmentVariable("KEYSTORE_FILE").orNull
+    // CI signing: keystore path + credentials via environment variables.
+    // takeIf guards against KEYSTORE_FILE being set to an empty string (e.g. when
+    // the secret is absent and the workflow sets the variable to '' as a fallback).
+    val keystoreFile = providers.environmentVariable("KEYSTORE_FILE").orNull?.takeIf { it.isNotBlank() }
     if (keystoreFile != null) {
         signingConfigs {
             create("release") {
@@ -39,6 +41,16 @@ android {
     }
 
     buildTypes {
+        debug {
+            // Use the release keystore for debug builds when available so that debug
+            // and release APKs share the same signing certificate.  Without this,
+            // upgrading from a CI debug APK to a release APK fails with
+            // INSTALL_FAILED_UPDATE_INCOMPATIBLE because each runner generates a
+            // different ephemeral debug.keystore.
+            if (keystoreFile != null) {
+                signingConfig = signingConfigs.getByName("release")
+            }
+        }
         release {
             isMinifyEnabled = true
             isShrinkResources = true


### PR DESCRIPTION
## Summary

Fixes #105 — upgrading an installed APK failed with `INSTALL_FAILED_UPDATE_INCOMPATIBLE` because debug and release APKs were signed with different certificates.

**Root cause:** CI debug APKs (`assembleDebug`) were signed with the runner's ephemeral machine-specific `debug.keystore` (regenerated per run), while release APKs used the project's `KEYSTORE_BASE64` secret. Android treats signing certificate changes as incompatible upgrades, so any attempt to install a release APK over a debug one (or a debug APK from a different run) was rejected.

## Changes

### `app-phone/build.gradle.kts` and `app-tv/build.gradle.kts`
- Added a `debug { }` build type block that applies the release signing config when `KEYSTORE_FILE` is set. When the keystore is not present (local dev, forks), debug builds fall back to the default Android debug key as before.
- Hardened the `keystoreFile` lookup with `takeIf { it.isNotBlank() }` so that an empty-string `KEYSTORE_FILE` env var (which `orNull` would return as non-null) is correctly treated as absent, preventing a Gradle configuration error.

### `.github/workflows/build-android.yml`
- Added a **Decode Keystore** step matching the pattern in `release.yml`.
- Split the single APK build step into two conditional steps: **signed** (when keystore is available) and **unsigned fallback** (when it is not, e.g. fork PRs without secrets).

### `.github/workflows/release.yml`
- The two separate phone/TV debug APK build steps are consolidated into a single **signed** step (passing keystore env vars) and a matching **unsigned fallback** step.
- Debug APKs produced by the release workflow now share the same certificate as release APKs.

## Result

All CI-built APKs — from PR builds and release workflows, debug and release — are signed with the same certificate when `KEYSTORE_BASE64` is configured. Users can install any newer APK over any older APK without uninstalling first.

## Test plan

- [ ] CI `build-android.yml` passes (tests + APK builds)
- [ ] Signed APK build steps run successfully when keystore secret is present
- [ ] Unsigned fallback steps run successfully when keystore secret is absent (fork PR simulation)
- [ ] Manual verification: install debug APK, then release APK — no `INSTALL_FAILED_UPDATE_INCOMPATIBLE`

> **Note:** These changes are entirely in build configuration (Gradle scripts and CI YAML). There is no application Kotlin code to unit-test; correctness is validated by the CI pipeline passing.

https://claude.ai/code/session_011VorugVcbAeRpKochPrvce