### PR TITLE
feat(accessibility): add contentDescriptions to interactive TV UI elements for TalkBack

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -11,6 +11,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -200,17 +203,40 @@ private fun PhoneUnreachableBanner() {
     }
 }
 
+/**
+ * Builds a content description for a show card.
+ *
+ * Pure Kotlin — no Compose context required, making it easy to unit-test.
+ * Format: "Show Title, S01E05" when episode is known, or just "Show Title" otherwise.
+ */
+internal fun showCardContentDescription(
+    showTitle: String,
+    lastSeasonNumber: Int?,
+    lastEpisodeNumber: Int?
+): String = if (lastSeasonNumber != null && lastEpisodeNumber != null) {
+    "$showTitle, S${lastSeasonNumber.toString().padStart(2, '0')}E${lastEpisodeNumber.toString().padStart(2, '0')}"
+} else {
+    showTitle
+}
+
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun ShowCard(entry: TraktWatchedEntry, onClick: () -> Unit) {
     val lastSeason  = entry.seasons.maxByOrNull { it.number }
     val lastEpisode = lastSeason?.episodes?.maxByOrNull { it.number }
 
+    val cardDescription = showCardContentDescription(
+        showTitle         = entry.show.title,
+        lastSeasonNumber  = lastSeason?.number,
+        lastEpisodeNumber = lastEpisode?.number
+    )
+
     Card(
         onClick   = onClick,
         modifier  = Modifier
             .width(180.dp)
-            .aspectRatio(2f / 3f),
+            .aspectRatio(2f / 3f)
+            .semantics { contentDescription = cardDescription },
         shape     = CardDefaults.shape(RoundedCornerShape(12.dp)),
         colors    = CardDefaults.colors(
             containerColor         = MaterialTheme.colorScheme.surface,
@@ -263,16 +289,19 @@ private fun PhoneStatusBadge(count: Int, bestName: String?) {
             .background(MaterialTheme.colorScheme.surface)
     ) {
         Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            modifier = Modifier
+                .padding(horizontal = 12.dp, vertical = 6.dp)
+                .semantics(mergeDescendants = true) {},
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            // Green dot
+            // Green dot — purely decorative; the adjacent text already conveys the status
             Box(
                 modifier = Modifier
                     .size(8.dp)
                     .clip(RoundedCornerShape(4.dp))
                     .background(MaterialTheme.extendedColors.success)
+                    .clearAndSetSemantics {}
             )
             Text(
                 text     = if (bestName != null) bestName else stringResource(R.string.tv_devices_count, count),

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -113,7 +115,7 @@ fun RecapScreen(
                     }
 
                     is RecapUiState.Ready -> {
-                        RecapWebView(html = s.html)
+                        RecapWebView(html = s.html, showTitle = showTitle)
                     }
 
                     is RecapUiState.Fallback -> {
@@ -157,10 +159,11 @@ fun RecapScreen(
 }
 
 @Composable
-private fun RecapWebView(html: String) {
+private fun RecapWebView(html: String, showTitle: String) {
     val bgHex          = MaterialTheme.colorScheme.background.toCssHex()
     val textHex        = MaterialTheme.colorScheme.onBackground.toCssHex()
     val placeholderHex = MaterialTheme.extendedColors.placeholder.toCssHex()
+    val recapLabel     = stringResource(R.string.tv_recap_title) + " " + showTitle
 
     // Wrap HTML in a full page with dark background and slide animation
     val fullHtml = """
@@ -236,6 +239,8 @@ private fun RecapWebView(html: String) {
         update = { webView ->
             webView.loadDataWithBaseURL(null, fullHtml, "text/html", "UTF-8", null)
         },
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier
+            .fillMaxSize()
+            .semantics { contentDescription = recapLabel }
     )
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleOverlay.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleOverlay.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -95,10 +97,13 @@ fun ScrobbleOverlay(
                     }
 
                     // Auto-dismiss countdown bar (material3 LinearProgressIndicator)
+                    val countdownDescription = stringResource(R.string.cd_scrobble_countdown, secondsLeft)
                     LinearProgressIndicator(
                         progress = { secondsLeft / 15f },
-                        modifier = Modifier.fillMaxWidth(),
-                        color    = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .semantics { contentDescription = countdownDescription },
+                        color      = MaterialTheme.colorScheme.primary,
                         trackColor = Color.White.copy(alpha = 0.1f)
                     )
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsScreen.kt
@@ -11,6 +11,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -163,11 +165,15 @@ private fun ServiceRow(
 
             // Priority reorder buttons (only for subscribed services)
             if (isSubscribed) {
+                val moveUpDesc   = stringResource(R.string.cd_service_move_up, service.name)
+                val moveDownDesc = stringResource(R.string.cd_service_move_down, service.name)
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     OutlinedButton(
                         onClick = onMoveUp,
                         enabled = canMoveUp,
-                        modifier = Modifier.size(40.dp),
+                        modifier = Modifier
+                            .size(40.dp)
+                            .semantics { contentDescription = moveUpDesc },
                         contentPadding = PaddingValues(0.dp)
                     ) {
                         Text("\u25B2", fontSize = 14.sp)
@@ -175,7 +181,9 @@ private fun ServiceRow(
                     OutlinedButton(
                         onClick = onMoveDown,
                         enabled = canMoveDown,
-                        modifier = Modifier.size(40.dp),
+                        modifier = Modifier
+                            .size(40.dp)
+                            .semantics { contentDescription = moveDownDesc },
                         contentPadding = PaddingValues(0.dp)
                     ) {
                         Text("\u25BC", fontSize = 14.sp)

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/userselect/UserSelectScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/userselect/UserSelectScreen.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -112,14 +114,19 @@ private fun UserAvatar(
     isSelected: Boolean,
     onClick: () -> Unit
 ) {
-    val borderColor = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent
-    val initials    = user.userName.take(2).uppercase()
+    val borderColor   = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent
+    val initials      = user.userName.take(2).uppercase()
+    val avatarDescription = stringResource(
+        if (isSelected) R.string.cd_user_selected else R.string.cd_user_unselected,
+        user.userName
+    )
 
     Card(
         onClick  = onClick,
         modifier = Modifier
             .size(120.dp)
-            .border(3.dp, borderColor, RoundedCornerShape(16.dp)),
+            .border(3.dp, borderColor, RoundedCornerShape(16.dp))
+            .semantics { contentDescription = avatarDescription },
         shape    = CardDefaults.shape(RoundedCornerShape(16.dp)),
         colors   = CardDefaults.colors(
             containerColor        = MaterialTheme.colorScheme.surface,

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -66,4 +66,11 @@
     <string name="tv_llm_gemma_gpu">Gemma GPU</string>
     <string name="tv_llm_gemma_cpu">Gemma CPU</string>
     <string name="tv_llm_none">Kein LLM</string>
+
+    <!-- Barrierefreiheit -->
+    <string name="cd_user_selected">%1$s, ausgewählt</string>
+    <string name="cd_user_unselected">%1$s, Drücken zum Auswählen</string>
+    <string name="cd_scrobble_countdown">Automatisch bestätigen in %1$d Sekunden</string>
+    <string name="cd_service_move_up">%1$s in der Priorität nach oben verschieben</string>
+    <string name="cd_service_move_down">%1$s in der Priorität nach unten verschieben</string>
 </resources>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -66,4 +66,11 @@
     <string name="tv_llm_gemma_gpu">Gemma GPU</string>
     <string name="tv_llm_gemma_cpu">Gemma CPU</string>
     <string name="tv_llm_none">Sin LLM</string>
+
+    <!-- Accesibilidad -->
+    <string name="cd_user_selected">%1$s, seleccionado</string>
+    <string name="cd_user_unselected">%1$s, pulsar para seleccionar</string>
+    <string name="cd_scrobble_countdown">Confirmación automática en %1$d segundos</string>
+    <string name="cd_service_move_up">Subir %1$s en la prioridad</string>
+    <string name="cd_service_move_down">Bajar %1$s en la prioridad</string>
 </resources>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -66,4 +66,11 @@
     <string name="tv_llm_gemma_gpu">Gemma GPU</string>
     <string name="tv_llm_gemma_cpu">Gemma CPU</string>
     <string name="tv_llm_none">Pas de LLM</string>
+
+    <!-- Accessibilité -->
+    <string name="cd_user_selected">%1$s, sélectionné</string>
+    <string name="cd_user_unselected">%1$s, appuyer pour sélectionner</string>
+    <string name="cd_scrobble_countdown">Confirmation automatique dans %1$d secondes</string>
+    <string name="cd_service_move_up">Monter %1$s dans la priorité</string>
+    <string name="cd_service_move_down">Descendre %1$s dans la priorité</string>
 </resources>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -66,4 +66,11 @@
     <string name="tv_llm_gemma_gpu">Gemma GPU</string>
     <string name="tv_llm_gemma_cpu">Gemma CPU</string>
     <string name="tv_llm_none">No LLM</string>
+
+    <!-- Accessibility content descriptions -->
+    <string name="cd_user_selected">%1$s, selected</string>
+    <string name="cd_user_unselected">%1$s, press to select</string>
+    <string name="cd_scrobble_countdown">Auto-confirm in %1$d seconds</string>
+    <string name="cd_service_move_up">Move %1$s up in priority</string>
+    <string name="cd_service_move_down">Move %1$s down in priority</string>
 </resources>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/accessibility/TvAccessibilityContentDescriptionTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/accessibility/TvAccessibilityContentDescriptionTest.kt
@@ -1,0 +1,76 @@
+package com.justb81.watchbuddy.tv.ui.accessibility
+
+import com.justb81.watchbuddy.tv.ui.home.showCardContentDescription
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("TV accessibility content descriptions")
+class TvAccessibilityContentDescriptionTest {
+
+    @Nested
+    @DisplayName("showCardContentDescription")
+    inner class ShowCardContentDescriptionTest {
+
+        @Test
+        fun `includes show title and S##E## when season and episode are known`() {
+            val result = showCardContentDescription("Breaking Bad", 1, 5)
+            assertTrue(result.contains("Breaking Bad"), "should contain show title")
+            assertTrue(result.contains("S01E05"), "should contain padded season-episode")
+        }
+
+        @Test
+        fun `pads single-digit season and episode numbers with leading zero`() {
+            val result = showCardContentDescription("My Show", 2, 3)
+            assertTrue(result.contains("S02E03"), "single-digit values must be zero-padded")
+        }
+
+        @Test
+        fun `does not pad double-digit season and episode numbers`() {
+            val result = showCardContentDescription("Long Show", 12, 10)
+            assertTrue(result.contains("S12E10"), "double-digit values must not be over-padded")
+        }
+
+        @Test
+        fun `returns only show title when season is null`() {
+            val result = showCardContentDescription("New Show", lastSeasonNumber = null, lastEpisodeNumber = null)
+            assertEquals("New Show", result)
+        }
+
+        @Test
+        fun `returns only show title when episode is null but season is set`() {
+            // Should not include partial info
+            val result = showCardContentDescription("Another Show", lastSeasonNumber = 1, lastEpisodeNumber = null)
+            assertEquals("Another Show", result)
+        }
+
+        @Test
+        fun `returns only show title when season is null but episode is set`() {
+            val result = showCardContentDescription("Edge Case Show", lastSeasonNumber = null, lastEpisodeNumber = 1)
+            assertEquals("Edge Case Show", result)
+        }
+
+        @Test
+        fun `handles show title with special characters`() {
+            val result = showCardContentDescription("It's Always Sunny in Philadelphia", 8, 1)
+            assertTrue(result.contains("It's Always Sunny in Philadelphia"))
+            assertTrue(result.contains("S08E01"))
+        }
+
+        @Test
+        fun `season 10 episode 1 renders as S10E01`() {
+            val result = showCardContentDescription("Friends", 10, 1)
+            assertTrue(result.contains("S10E01"))
+            assertFalse(result.contains("S010"), "season should not have three digits")
+        }
+
+        @Test
+        fun `content description starts with show title`() {
+            val result = showCardContentDescription("The Wire", 3, 7)
+            assertTrue(result.startsWith("The Wire"), "title should come first")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #54 — adds `contentDescription` semantics to interactive and visual-only elements in the TV app so TalkBack users can navigate and understand the UI without relying solely on screen content.

### Elements fixed

| Screen | Element | Problem | Fix |
|--------|---------|---------|-----|
| `TvHomeScreen` | `ShowCard` | No content description; TalkBack had no context about the card | `semantics { contentDescription }` in `"Title, S01E05"` format |
| `TvHomeScreen` | Green dot in `PhoneStatusBadge` | Visual-only status indicator with no accessible label | Marked decorative via `clearAndSetSemantics {}`; enclosing `Row` uses `mergeDescendants = true` so TalkBack reads the adjacent text |
| `RecapScreen` | `RecapWebView` (`AndroidView`) | WebView content is opaque to TalkBack | `AndroidView` receives `contentDescription = "Previously on <show title>"` via `Modifier.semantics` |
| `UserSelectScreen` | `UserAvatar` card | Selection state not communicated | `contentDescription` reflects user name + state: `"alice, selected"` / `"alice, press to select"` |
| `ScrobbleOverlay` | `LinearProgressIndicator` | Countdown progress had no accessible label | `contentDescription = "Auto-confirm in N seconds"` updated live as the counter decrements |
| `StreamingSettingsScreen` | ▲ / ▼ `OutlinedButton` | Icon-only buttons with `▲`/`▼` text — not meaningful to screen readers | Descriptive labels via `cd_service_move_up` / `cd_service_move_down` (e.g., `"Move Netflix up in priority"`) |

### String resources

Five new `cd_*` keys added to all four language files (`values/`, `values-de/`, `values-fr/`, `values-es/`):
- `cd_user_selected`, `cd_user_unselected`
- `cd_scrobble_countdown`
- `cd_service_move_up`, `cd_service_move_down`

### Helper function and tests

`showCardContentDescription(showTitle, lastSeasonNumber, lastEpisodeNumber)` is extracted as an `internal` top-level function in `TvHomeScreen.kt` — pure Kotlin, no Compose context required.

`TvAccessibilityContentDescriptionTest` (JUnit 5) covers:
- Title + episode in `S##E##` format with correct zero-padding
- Single-digit and double-digit season/episode numbers
- Null season or episode → returns title only
- Show titles with special characters
- Correct ordering (title first)

## Test plan

- [ ] CI `build-android.yml` passes (compile + unit tests)
- [ ] `TvAccessibilityContentDescriptionTest` — 9 unit tests all green
- [ ] Manual TalkBack verification on Android TV device/emulator (recommended but not CI-gated)

https://claude.ai/code/session_01Y6fWV4U8kc8RAeT5xp2rcS