### PR TITLE
fix(ci): pass Trakt secrets to Gradle build steps

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -78,12 +78,16 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
+          TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
         run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
 
       - name: Build Phone and TV debug APKs (unsigned fallback)
         if: steps.keystore.outputs.available == 'false'
         env:
           VERSION_CODE: ${{ github.run_number }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
+          TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
         run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
 
       - name: Upload Phone APK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,8 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           VERSION_NAME: ${{ needs.release-please.outputs.version }}
           VERSION_CODE: ${{ github.run_number }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
+          TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
         run: ./gradlew :app-phone:assembleRelease
 
       - name: Build signed TV APK
@@ -76,6 +78,8 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           VERSION_NAME: ${{ needs.release-please.outputs.version }}
           VERSION_CODE: ${{ github.run_number }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
+          TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
         run: ./gradlew :app-tv:assembleRelease
 
       # -- Debug APKs (always) — signed with release keystore when available -----
@@ -88,6 +92,8 @@ jobs:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
+          TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
         run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
 
       - name: Build debug APKs (unsigned fallback)
@@ -95,6 +101,8 @@ jobs:
         env:
           VERSION_NAME: ${{ needs.release-please.outputs.version }}
           VERSION_CODE: ${{ github.run_number }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
+          TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
         run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
 
       # -- APKs sammeln und umbenennen -------------------------------------


### PR DESCRIPTION
## Summary

- `build.gradle.kts` reads `TRAKT_CLIENT_ID` and `TOKEN_BACKEND_URL` from environment variables, but neither CI workflow forwarded these GitHub secrets to the Gradle process
- Both values defaulted to empty strings, silently disabling Trakt login in all CI-built APKs
- Added `TRAKT_CLIENT_ID` and `TOKEN_BACKEND_URL` to every Gradle build step in `build-android.yml` (2 steps) and `release.yml` (4 steps)

Closes #135

## Test plan

- [ ] CI build passes on this PR
- [ ] Download debug APK artifact and verify Trakt login is available (not disabled)
- [ ] Confirm `BuildConfig.TRAKT_CLIENT_ID` is non-empty in the built APK

https://claude.ai/code/session_012886MEm82nB14pTiT2tZCW