### PR TITLE
fix/feat: remove certificate pinning, keep model download alive, add custom model URL

### DIFF
--- a/app-phone/src/main/AndroidManifest.xml
+++ b/app-phone/src/main/AndroidManifest.xml
@@ -65,5 +65,13 @@
             android:exported="false"
             android:foregroundServiceType="dataSync" />
 
+        <!-- WorkManager foreground service — required for long-running downloads on Android 10+.
+             Merges with WorkManager's own SystemForegroundService manifest entry to declare
+             the dataSync foreground service type used by ModelDownloadWorker. -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
+
     </application>
 </manifest>

--- a/app-phone/src/main/java/com/justb81/watchbuddy/WatchBuddyPhoneApp.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/WatchBuddyPhoneApp.kt
@@ -37,5 +37,19 @@ class WatchBuddyPhoneApp : Application(), Configuration.Provider {
             }
             manager.createNotificationChannel(channel)
         }
+        if (manager.getNotificationChannel(MODEL_DOWNLOAD_CHANNEL_ID) == null) {
+            val channel = NotificationChannel(
+                MODEL_DOWNLOAD_CHANNEL_ID,
+                getString(R.string.model_download_channel_name),
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = getString(R.string.model_download_channel_description)
+            }
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+    companion object {
+        const val MODEL_DOWNLOAD_CHANNEL_ID = "model_download"
     }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
@@ -1,41 +1,53 @@
 package com.justb81.watchbuddy.phone.di
 
+import android.content.Context
+import androidx.work.WorkManager
 import com.justb81.watchbuddy.BuildConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Named
 import javax.inject.Singleton
 
 /**
- * App-spezifische Hilt-Bindings.
+ * App-specific Hilt bindings.
  *
- * Stellt die BuildConfig-Werte als benannte Strings in den Hilt-Graph,
- * damit core-Module (NetworkModule) darauf zugreifen können, ohne direkt
- * von app-phone's BuildConfig abhängig zu sein.
+ * Exposes BuildConfig values as named strings in the Hilt graph so that core
+ * modules (NetworkModule) can access them without directly depending on
+ * app-phone's BuildConfig.
  */
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
 
-    /** Trakt Client-ID aus BuildConfig (gesetzt via app-phone/build.gradle.kts). */
+    /** Trakt Client ID from BuildConfig (set via app-phone/build.gradle.kts). */
     @Provides
     @Singleton
     @Named("traktClientId")
     fun provideTraktClientId(): String = BuildConfig.TRAKT_CLIENT_ID
 
     /**
-     * URL des WatchBuddy Token-Proxy-Backends aus BuildConfig.
-     * Leerstring → kein Proxy, Trakt-Login deaktiviert.
+     * URL of the WatchBuddy token proxy backend from BuildConfig.
+     * Empty string → no proxy, Trakt login disabled.
      */
     @Provides
     @Singleton
     fun provideTokenBackendUrl(): String = BuildConfig.TOKEN_BACKEND_URL
 
-    /** Debug-Flag für NetworkModule (steuert HTTP-Logging-Level). */
+    /** Debug flag for NetworkModule (controls HTTP logging level). */
     @Provides
     @Singleton
     @Named("isDebugBuild")
     fun provideIsDebugBuild(): Boolean = BuildConfig.DEBUG
+
+    /**
+     * WorkManager singleton for injection into ViewModels.
+     * Injecting rather than calling getInstance() directly keeps ViewModels testable.
+     */
+    @Provides
+    @Singleton
+    fun provideWorkManager(@ApplicationContext context: Context): WorkManager =
+        WorkManager.getInstance(context)
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorker.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorker.kt
@@ -1,11 +1,18 @@
 package com.justb81.watchbuddy.phone.llm
 
+import android.app.Notification
 import android.content.Context
+import android.content.pm.ServiceInfo
+import android.os.Build
 import android.util.Log
+import androidx.core.app.NotificationCompat
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
+import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.WatchBuddyPhoneApp
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -31,6 +38,8 @@ class ModelDownloadWorker @AssistedInject constructor(
             ?: return Result.failure(workDataOf(KEY_ERROR to "No model URL provided"))
         val modelFileName = inputData.getString(KEY_MODEL_FILENAME) ?: "model.bin"
 
+        setForeground(createForegroundInfo())
+
         val outputDir = settingsRepository.modelDir()
         val outputFile = File(outputDir, modelFileName)
         val tempFile = File(outputDir, "$modelFileName.tmp")
@@ -53,6 +62,23 @@ class ModelDownloadWorker @AssistedInject constructor(
             }
         }
     }
+
+    internal fun createForegroundInfo(): ForegroundInfo {
+        val notification = buildNotification()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            ForegroundInfo(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun buildNotification(): Notification =
+        NotificationCompat.Builder(applicationContext, WatchBuddyPhoneApp.MODEL_DOWNLOAD_CHANNEL_ID)
+            .setContentTitle(applicationContext.getString(R.string.model_download_notification_title))
+            .setContentText(applicationContext.getString(R.string.model_download_notification_text))
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setOngoing(true)
+            .build()
 
     private suspend fun downloadFile(url: String, target: File) = withContext(Dispatchers.IO) {
         val request = Request.Builder().url(url).build()
@@ -106,5 +132,6 @@ class ModelDownloadWorker @AssistedInject constructor(
         private const val TAG = "ModelDownloadWorker"
         private const val MAX_RETRIES = 3
         private const val BUFFER_SIZE = 8 * 1024
+        private const val NOTIFICATION_ID = 2
     }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorker.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorker.kt
@@ -49,6 +49,15 @@ class ModelDownloadWorker @AssistedInject constructor(
             if (!tempFile.renameTo(outputFile)) {
                 throw RuntimeException("Failed to rename downloaded model to final path")
             }
+            // Sanity-check: a real .litertlm model is hundreds of MB; anything smaller
+            // is almost certainly an HTML error page or a corrupt response.
+            if (outputFile.length() < MIN_MODEL_SIZE_BYTES) {
+                val size = outputFile.length()
+                outputFile.delete()
+                return Result.failure(
+                    workDataOf(KEY_ERROR to "Validation: model file too small ($size bytes)")
+                )
+            }
             settingsRepository.setModelReady(true)
             setProgress(workDataOf(KEY_PROGRESS to 100))
             return Result.success(workDataOf(KEY_PROGRESS to 100))
@@ -133,5 +142,6 @@ class ModelDownloadWorker @AssistedInject constructor(
         private const val MAX_RETRIES = 3
         private const val BUFFER_SIZE = 8 * 1024
         private const val NOTIFICATION_ID = 2
+        private const val MIN_MODEL_SIZE_BYTES = 1_048_576L // 1 MB
     }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/AppSettings.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/AppSettings.kt
@@ -7,6 +7,6 @@ data class AppSettings(
     val backendUrl: String = "",
     val directClientId: String = "",
     val companionEnabled: Boolean = false,
-    val modelBaseUrl: String = "",
+    val modelDownloadUrl: String = "",
     val tmdbApiKey: String = ""
 )

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
@@ -35,7 +35,7 @@ class SettingsRepository @Inject constructor(
         val BACKEND_URL = stringPreferencesKey("backend_url")
         val DIRECT_CLIENT_ID = stringPreferencesKey("direct_client_id")
         val COMPANION_ENABLED = booleanPreferencesKey("companion_enabled")
-        val MODEL_BASE_URL = stringPreferencesKey("model_base_url")
+        val MODEL_DOWNLOAD_URL = stringPreferencesKey("model_download_url")
         val MODEL_READY = booleanPreferencesKey("model_ready")
         val TMDB_API_KEY = stringPreferencesKey("tmdb_api_key")
     }
@@ -61,7 +61,7 @@ class SettingsRepository @Inject constructor(
             backendUrl = prefs[Keys.BACKEND_URL] ?: "",
             directClientId = prefs[Keys.DIRECT_CLIENT_ID] ?: "",
             companionEnabled = prefs[Keys.COMPANION_ENABLED] ?: false,
-            modelBaseUrl = prefs[Keys.MODEL_BASE_URL] ?: "",
+            modelDownloadUrl = prefs[Keys.MODEL_DOWNLOAD_URL] ?: "",
             tmdbApiKey = prefs[Keys.TMDB_API_KEY] ?: ""
         )
     }
@@ -72,7 +72,7 @@ class SettingsRepository @Inject constructor(
             prefs[Keys.BACKEND_URL] = settings.backendUrl
             prefs[Keys.DIRECT_CLIENT_ID] = settings.directClientId
             prefs[Keys.COMPANION_ENABLED] = settings.companionEnabled
-            prefs[Keys.MODEL_BASE_URL] = settings.modelBaseUrl
+            prefs[Keys.MODEL_DOWNLOAD_URL] = settings.modelDownloadUrl
             prefs[Keys.TMDB_API_KEY] = settings.tmdbApiKey
         }
     }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -220,6 +220,20 @@ fun SettingsScreen(
                             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
                         )
                     }
+                    uiState.llmValidationFailed -> {
+                        Text(
+                            text     = stringResource(R.string.settings_llm_validation_failed),
+                            style    = MaterialTheme.typography.bodySmall,
+                            color    = MaterialTheme.colorScheme.error,
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                        )
+                        TextButton(
+                            onClick  = { viewModel.downloadModel() },
+                            modifier = Modifier.padding(horizontal = 8.dp)
+                        ) {
+                            Text(stringResource(R.string.settings_llm_download))
+                        }
+                    }
                     uiState.llmModelName != null -> {
                         TextButton(
                             onClick  = { viewModel.downloadModel() },
@@ -365,11 +379,15 @@ private fun AdvancedAuthSettings(uiState: SettingsUiState, viewModel: SettingsVi
         )
         Spacer(Modifier.height(4.dp))
         OutlinedTextField(
-            value         = uiState.modelBaseUrl,
-            onValueChange = viewModel::setModelBaseUrl,
+            value         = uiState.modelDownloadUrl,
+            onValueChange = viewModel::setModelDownloadUrl,
             label         = { Text(stringResource(R.string.settings_model_url)) },
             modifier      = Modifier.fillMaxWidth(),
-            singleLine    = true
+            singleLine    = true,
+            isError       = uiState.modelDownloadUrlError,
+            supportingText = if (uiState.modelDownloadUrlError) {
+                { Text(stringResource(R.string.settings_model_url_invalid)) }
+            } else null
         )
 
         Spacer(Modifier.height(12.dp))

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -42,7 +42,9 @@ data class SettingsUiState(
     val llmModelName: String?      = null,
     val llmDownloadProgress: Int?  = null,   // null = not downloading, 0-100 = progress
     val llmReady: Boolean          = false,
-    val modelBaseUrl: String        = "",
+    val llmValidationFailed: Boolean = false,
+    val modelDownloadUrl: String   = "",
+    val modelDownloadUrlError: Boolean = false,
     val freeRamMb: Int             = 0,
     val saveSuccess: Boolean       = false
 )
@@ -94,7 +96,7 @@ class SettingsViewModel @Inject constructor(
                 directClientId = saved.directClientId,
                 directClientSecret = clientSecret,
                 companionRunning = saved.companionEnabled,
-                modelBaseUrl = saved.modelBaseUrl,
+                modelDownloadUrl = saved.modelDownloadUrl,
                 tmdbApiKey = saved.tmdbApiKey,
                 tmdbConnected = saved.tmdbApiKey.isNotBlank()
             )
@@ -138,7 +140,14 @@ class SettingsViewModel @Inject constructor(
                                 llmReady = true
                             )
                         }
-                        WorkInfo.State.FAILED, WorkInfo.State.CANCELLED -> {
+                        WorkInfo.State.FAILED -> {
+                            val error = workInfo.outputData.getString(ModelDownloadWorker.KEY_ERROR) ?: ""
+                            _uiState.value = _uiState.value.copy(
+                                llmDownloadProgress = null,
+                                llmValidationFailed = error.startsWith("Validation:")
+                            )
+                        }
+                        WorkInfo.State.CANCELLED -> {
                             _uiState.value = _uiState.value.copy(llmDownloadProgress = null)
                         }
                         WorkInfo.State.ENQUEUED -> {
@@ -166,8 +175,12 @@ class SettingsViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(directClientSecret = secret)
     }
 
-    fun setModelBaseUrl(url: String) {
-        _uiState.value = _uiState.value.copy(modelBaseUrl = url)
+    fun setModelDownloadUrl(url: String) {
+        _uiState.value = _uiState.value.copy(
+            modelDownloadUrl = url,
+            llmValidationFailed = false,
+            modelDownloadUrlError = false
+        )
     }
 
     fun setTmdbApiKey(key: String) {
@@ -206,7 +219,7 @@ class SettingsViewModel @Inject constructor(
                     backendUrl = state.customBackendUrl,
                     directClientId = state.directClientId,
                     companionEnabled = state.companionRunning,
-                    modelBaseUrl = state.modelBaseUrl
+                    modelDownloadUrl = state.modelDownloadUrl
                 )
             )
             settingsRepository.saveClientSecret(state.directClientSecret)
@@ -242,12 +255,13 @@ class SettingsViewModel @Inject constructor(
     fun downloadModel() {
         val config = llmOrchestrator.selectConfig()
         val variant = config.modelVariant ?: return // no variant selected → nothing to download
-        val customBase = _uiState.value.modelBaseUrl
-        val modelUrl = if (customBase.isNotBlank()) {
-            "${customBase.trimEnd('/')}/${variant.fileName}"
-        } else {
-            variant.downloadUrl
+        val customUrl = _uiState.value.modelDownloadUrl.trim()
+        if (customUrl.isNotBlank() && !customUrl.endsWith(".litertlm", ignoreCase = true)) {
+            _uiState.value = _uiState.value.copy(modelDownloadUrlError = true)
+            return
         }
+        val modelUrl = customUrl.takeIf { it.isNotBlank() } ?: variant.downloadUrl
+        _uiState.value = _uiState.value.copy(llmValidationFailed = false, modelDownloadUrlError = false)
 
         val constraints = Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -70,6 +70,7 @@ class SettingsViewModel @Inject constructor(
         loadTraktUsername()
         detectLlm()
         observeModelReadyState()
+        observeDownloadProgress()
     }
 
     private fun loadTraktUsername() {
@@ -117,6 +118,36 @@ class SettingsViewModel @Inject constructor(
             settingsRepository.modelReady.collect { ready ->
                 _uiState.value = _uiState.value.copy(llmReady = ready)
             }
+        }
+    }
+
+    private fun observeDownloadProgress() {
+        viewModelScope.launch {
+            workManager.getWorkInfosForUniqueWorkFlow(ModelDownloadWorker.UNIQUE_WORK_NAME)
+                .collect { workInfoList ->
+                    val workInfo = workInfoList.firstOrNull() ?: return@collect
+                    when (workInfo.state) {
+                        WorkInfo.State.RUNNING -> {
+                            val progress = workInfo.progress.getInt(
+                                ModelDownloadWorker.KEY_PROGRESS, 0
+                            )
+                            _uiState.value = _uiState.value.copy(llmDownloadProgress = progress)
+                        }
+                        WorkInfo.State.SUCCEEDED -> {
+                            _uiState.value = _uiState.value.copy(
+                                llmDownloadProgress = null,
+                                llmReady = true
+                            )
+                        }
+                        WorkInfo.State.FAILED, WorkInfo.State.CANCELLED -> {
+                            _uiState.value = _uiState.value.copy(llmDownloadProgress = null)
+                        }
+                        WorkInfo.State.ENQUEUED -> {
+                            _uiState.value = _uiState.value.copy(llmDownloadProgress = 0)
+                        }
+                        else -> { /* BLOCKED — no UI update needed */ }
+                    }
+                }
         }
     }
 
@@ -237,41 +268,7 @@ class SettingsViewModel @Inject constructor(
             ExistingWorkPolicy.KEEP,
             workRequest
         )
-
-        // Observe work progress
-        viewModelScope.launch {
-            workManager.getWorkInfoByIdFlow(workRequest.id).collect { workInfo ->
-                if (workInfo == null) return@collect
-                when (workInfo.state) {
-                    WorkInfo.State.RUNNING -> {
-                        val progress = workInfo.progress.getInt(
-                            ModelDownloadWorker.KEY_PROGRESS, 0
-                        )
-                        _uiState.value = _uiState.value.copy(
-                            llmDownloadProgress = progress
-                        )
-                    }
-                    WorkInfo.State.SUCCEEDED -> {
-                        _uiState.value = _uiState.value.copy(
-                            llmDownloadProgress = null,
-                            llmReady = true
-                        )
-                    }
-                    WorkInfo.State.FAILED -> {
-                        _uiState.value = _uiState.value.copy(
-                            llmDownloadProgress = null,
-                            llmReady = false
-                        )
-                    }
-                    WorkInfo.State.ENQUEUED -> {
-                        _uiState.value = _uiState.value.copy(
-                            llmDownloadProgress = 0
-                        )
-                    }
-                    else -> { /* BLOCKED, CANCELLED — no UI update needed */ }
-                }
-            }
-        }
+        // Progress is tracked by observeDownloadProgress() running since init
     }
 
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -50,14 +50,13 @@ data class SettingsUiState(
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     application: Application,
+    private val workManager: WorkManager,
     private val llmOrchestrator: LlmOrchestrator,
     private val traktApi: TraktApiService,
     private val tokenRepository: TokenRepository,
     private val deviceCapabilityProvider: DeviceCapabilityProvider,
     private val settingsRepository: SettingsRepository
 ) : AndroidViewModel(application) {
-
-    private val workManager = WorkManager.getInstance(application)
 
     private val _uiState = MutableStateFlow(SettingsUiState(
         llmBackend = application.getString(R.string.settings_llm_detecting),

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -72,7 +72,9 @@
     <string name="settings_auth_client_id">Client ID</string>
     <string name="settings_auth_client_secret">Client Secret</string>
     <string name="settings_model_url_section">Modell-Download</string>
-    <string name="settings_model_url">Eigene Modell-Basis-URL</string>
+    <string name="settings_model_url">Eigene Download-URL</string>
+    <string name="settings_llm_validation_failed">Download fehlgeschlagen: Datei scheint ungültig zu sein</string>
+    <string name="settings_model_url_invalid">Die URL muss auf eine .litertlm-Datei zeigen</string>
     <string name="settings_save">Speichern</string>
     <string name="settings_saved">Einstellungen gespeichert</string>
     <string name="settings_cancel">Abbrechen</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -72,7 +72,9 @@
     <string name="settings_auth_client_id">Client ID</string>
     <string name="settings_auth_client_secret">Client Secret</string>
     <string name="settings_model_url_section">Descarga del modelo</string>
-    <string name="settings_model_url">URL base personalizada</string>
+    <string name="settings_model_url">URL de descarga personalizada</string>
+    <string name="settings_llm_validation_failed">Error de descarga: el archivo parece inválido</string>
+    <string name="settings_model_url_invalid">La URL debe apuntar a un archivo .litertlm</string>
     <string name="settings_save">Guardar</string>
     <string name="settings_saved">Ajustes guardados</string>
     <string name="settings_cancel">Cancelar</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -72,7 +72,9 @@
     <string name="settings_auth_client_id">Client ID</string>
     <string name="settings_auth_client_secret">Client Secret</string>
     <string name="settings_model_url_section">Téléchargement du modèle</string>
-    <string name="settings_model_url">URL de base personnalisée</string>
+    <string name="settings_model_url">URL de téléchargement personnalisée</string>
+    <string name="settings_llm_validation_failed">Échec du téléchargement : le fichier semble invalide</string>
+    <string name="settings_model_url_invalid">L\'URL doit pointer vers un fichier .litertlm</string>
     <string name="settings_save">Enregistrer</string>
     <string name="settings_saved">Paramètres enregistrés</string>
     <string name="settings_cancel">Annuler</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -72,7 +72,9 @@
     <string name="settings_auth_client_id">Client ID</string>
     <string name="settings_auth_client_secret">Client Secret</string>
     <string name="settings_model_url_section">Model download</string>
-    <string name="settings_model_url">Custom model base URL</string>
+    <string name="settings_model_url">Custom download URL</string>
+    <string name="settings_llm_validation_failed">Download failed: file appears invalid</string>
+    <string name="settings_model_url_invalid">URL must point to a .litertlm file</string>
     <string name="settings_save">Save</string>
     <string name="settings_saved">Settings saved</string>
     <string name="settings_cancel">Cancel</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -91,6 +91,12 @@
     <string name="companion_notification_title">WatchBuddy Companion</string>
     <string name="companion_notification_text">Ready for TV connection</string>
 
+    <!-- Model Download -->
+    <string name="model_download_channel_name">Model Download</string>
+    <string name="model_download_channel_description">Shows progress while downloading the AI model</string>
+    <string name="model_download_notification_title">Downloading AI model</string>
+    <string name="model_download_notification_text">WatchBuddy is downloading the AI model in the background</string>
+
     <!-- Common -->
     <string name="no_description">No description available.</string>
     <string name="loading">Loading…</string>

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorkerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorkerTest.kt
@@ -178,6 +178,31 @@ class ModelDownloadWorkerTest {
             val tempFile = File(tempDir, "$MODEL_FILENAME.tmp")
             assertFalse(tempFile.exists())
         }
+
+        @Test
+        fun `returns validation failure when downloaded file is too small`() = runTest {
+            // Serve a tiny payload — any real .litertlm model is several hundred MB
+            server.enqueue(MockResponse().setBody("tiny"))
+
+            val worker = createWorker(server.url("/model.bin").toString(), attemptCount = 3)
+            val result = worker.doWork()
+
+            assertTrue(result is Result.Failure)
+            val error = (result as Result.Failure).outputData.getString(ModelDownloadWorker.KEY_ERROR)
+            assertTrue(error?.startsWith("Validation:") == true)
+            // Final model file must be cleaned up on validation failure
+            assertFalse(File(tempDir, MODEL_FILENAME).exists())
+        }
+
+        @Test
+        fun `does not call setModelReady when file is too small`() = runTest {
+            server.enqueue(MockResponse().setBody("tiny"))
+
+            val worker = createWorker(server.url("/model.bin").toString(), attemptCount = 3)
+            worker.doWork()
+
+            verify(exactly = 0) { settingsRepository.setModelReady(any()) }
+        }
     }
 
     @Nested

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorkerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorkerTest.kt
@@ -31,6 +31,8 @@ class ModelDownloadWorkerTest {
 
     companion object {
         private const val MODEL_FILENAME = "gemma-4-E2B-it.litertlm"
+        // 1 MB + 1 byte — just over the validation threshold so successful downloads pass
+        private val VALID_MODEL_CONTENT = "x".repeat(1_048_577)
     }
 
     private lateinit var server: MockWebServer
@@ -84,11 +86,10 @@ class ModelDownloadWorkerTest {
 
         @Test
         fun `downloads file using dedicated download client`() = runTest {
-            val content = "model binary data"
             server.enqueue(
                 MockResponse()
-                    .setBody(content)
-                    .setHeader("Content-Length", content.length)
+                    .setBody(VALID_MODEL_CONTENT)
+                    .setHeader("Content-Length", VALID_MODEL_CONTENT.length)
             )
 
             val worker = createWorker(server.url("/model.bin").toString())
@@ -101,12 +102,12 @@ class ModelDownloadWorkerTest {
 
             val outputFile = File(tempDir, MODEL_FILENAME)
             assertTrue(outputFile.exists())
-            assertEquals(content, outputFile.readText())
+            assertEquals(VALID_MODEL_CONTENT.length.toLong(), outputFile.length())
         }
 
         @Test
         fun `sets model ready on successful download`() = runTest {
-            server.enqueue(MockResponse().setBody("data"))
+            server.enqueue(MockResponse().setBody(VALID_MODEL_CONTENT))
 
             val worker = createWorker(server.url("/model.bin").toString())
             worker.doWork()
@@ -230,18 +231,17 @@ class ModelDownloadWorkerTest {
 
         @Test
         fun `succeeds when content-length matches downloaded bytes`() = runTest {
-            val content = "exact content"
             server.enqueue(
                 MockResponse()
-                    .setBody(content)
-                    .setHeader("Content-Length", content.length)
+                    .setBody(VALID_MODEL_CONTENT)
+                    .setHeader("Content-Length", VALID_MODEL_CONTENT.length)
             )
 
             val worker = createWorker(server.url("/model.bin").toString())
             val result = worker.doWork()
 
             assertTrue(result is Result.Success)
-            assertEquals(content, File(tempDir, MODEL_FILENAME).readText())
+            assertEquals(VALID_MODEL_CONTENT.length.toLong(), File(tempDir, MODEL_FILENAME).length())
         }
     }
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorkerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorkerTest.kt
@@ -1,9 +1,7 @@
 package com.justb81.watchbuddy.phone.llm
 
-import android.app.Notification
 import android.content.Context
 import androidx.work.Data
-import androidx.work.ForegroundInfo
 import androidx.work.ListenableWorker.Result
 import androidx.work.WorkerParameters
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
@@ -76,7 +74,7 @@ class ModelDownloadWorkerTest {
         )
         coEvery { worker.setProgress(any()) } just Runs
         coEvery { worker.setForeground(any()) } just Runs
-        every { worker.createForegroundInfo() } returns ForegroundInfo(2, mockk<Notification>(relaxed = true))
+        every { worker.createForegroundInfo() } returns mockk(relaxed = true)
         return worker
     }
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorkerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/ModelDownloadWorkerTest.kt
@@ -1,7 +1,9 @@
 package com.justb81.watchbuddy.phone.llm
 
+import android.app.Notification
 import android.content.Context
 import androidx.work.Data
+import androidx.work.ForegroundInfo
 import androidx.work.ListenableWorker.Result
 import androidx.work.WorkerParameters
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
@@ -73,6 +75,8 @@ class ModelDownloadWorkerTest {
             ModelDownloadWorker(context, workerParams, settingsRepository, downloadClient)
         )
         coEvery { worker.setProgress(any()) } just Runs
+        coEvery { worker.setForeground(any()) } just Runs
+        every { worker.createForegroundInfo() } returns ForegroundInfo(2, mockk<Notification>(relaxed = true))
         return worker
     }
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
@@ -16,15 +16,12 @@ import com.justb81.watchbuddy.phone.settings.AppSettings
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -54,8 +51,6 @@ class SettingsViewModelTest {
 
     @BeforeEach
     fun setUp() {
-        mockkStatic(WorkManager::class)
-        every { WorkManager.getInstance(any()) } returns workManager
         every { workManager.getWorkInfosForUniqueWorkFlow(any()) } returns downloadWorkInfoFlow
         every { settingsRepository.settings } returns flowOf(AppSettings())
         every { settingsRepository.getClientSecret() } returns ""
@@ -68,13 +63,9 @@ class SettingsViewModelTest {
         )
     }
 
-    @AfterEach
-    fun tearDown() {
-        unmockkAll()
-    }
-
     private fun createViewModel(): SettingsViewModel = SettingsViewModel(
         application = application,
+        workManager = workManager,
         llmOrchestrator = llmOrchestrator,
         traktApi = traktApi,
         tokenRepository = tokenRepository,

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
@@ -2,6 +2,7 @@ package com.justb81.watchbuddy.phone.ui.settings
 
 import android.app.Application
 import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.workDataOf
@@ -205,7 +206,7 @@ class SettingsViewModelTest {
                 workManager.enqueueUniqueWork(
                     ModelDownloadWorker.UNIQUE_WORK_NAME,
                     ExistingWorkPolicy.KEEP,
-                    any()
+                    any<OneTimeWorkRequest>()
                 )
             }
         }
@@ -223,7 +224,7 @@ class SettingsViewModelTest {
             advanceUntilIdle()
 
             verify(exactly = 0) {
-                workManager.enqueueUniqueWork(any(), any(), any())
+                workManager.enqueueUniqueWork(any<String>(), any<ExistingWorkPolicy>(), any<OneTimeWorkRequest>())
             }
         }
 
@@ -244,7 +245,7 @@ class SettingsViewModelTest {
                 workManager.enqueueUniqueWork(
                     ModelDownloadWorker.UNIQUE_WORK_NAME,
                     ExistingWorkPolicy.KEEP,
-                    any()
+                    any<OneTimeWorkRequest>()
                 )
             }
         }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
@@ -1,0 +1,261 @@
+package com.justb81.watchbuddy.phone.ui.settings
+
+import android.app.Application
+import androidx.work.ExistingWorkPolicy
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import com.justb81.watchbuddy.core.model.LlmBackend
+import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.phone.MainDispatcherRule
+import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
+import com.justb81.watchbuddy.phone.llm.ModelDownloadWorker
+import com.justb81.watchbuddy.phone.server.DeviceCapabilityProvider
+import com.justb81.watchbuddy.phone.settings.AppSettings
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("SettingsViewModel")
+class SettingsViewModelTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcherRule = MainDispatcherRule()
+    }
+
+    private val application: Application = mockk(relaxed = true)
+    private val llmOrchestrator: LlmOrchestrator = mockk(relaxed = true)
+    private val traktApi: TraktApiService = mockk(relaxed = true)
+    private val tokenRepository: TokenRepository = mockk(relaxed = true)
+    private val deviceCapabilityProvider: DeviceCapabilityProvider = mockk(relaxed = true)
+    private val settingsRepository: SettingsRepository = mockk(relaxed = true)
+    private val workManager: WorkManager = mockk(relaxed = true)
+
+    private val downloadWorkInfoFlow = MutableStateFlow<List<WorkInfo>>(emptyList())
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(WorkManager::class)
+        every { WorkManager.getInstance(any()) } returns workManager
+        every { workManager.getWorkInfosForUniqueWorkFlow(any()) } returns downloadWorkInfoFlow
+        every { settingsRepository.settings } returns flowOf(AppSettings())
+        every { settingsRepository.getClientSecret() } returns ""
+        every { settingsRepository.modelReady } returns MutableStateFlow(false)
+        every { tokenRepository.getAccessToken() } returns null
+        every { llmOrchestrator.selectConfig() } returns LlmOrchestrator.LlmConfig(
+            backend = LlmBackend.NONE,
+            modelVariant = null,
+            qualityScore = 0
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun createViewModel(): SettingsViewModel = SettingsViewModel(
+        application = application,
+        llmOrchestrator = llmOrchestrator,
+        traktApi = traktApi,
+        tokenRepository = tokenRepository,
+        deviceCapabilityProvider = deviceCapabilityProvider,
+        settingsRepository = settingsRepository
+    )
+
+    @Nested
+    @DisplayName("Download progress observation")
+    inner class DownloadProgressObservation {
+
+        @Test
+        fun `shows progress when work is running`() = runTest {
+            val workInfo = mockk<WorkInfo> {
+                every { state } returns WorkInfo.State.RUNNING
+                every { progress } returns workDataOf(ModelDownloadWorker.KEY_PROGRESS to 42)
+            }
+
+            val vm = createViewModel()
+            downloadWorkInfoFlow.value = listOf(workInfo)
+            advanceUntilIdle()
+
+            assertEquals(42, vm.uiState.value.llmDownloadProgress)
+        }
+
+        @Test
+        fun `clears progress and marks ready when work succeeds`() = runTest {
+            val workInfo = mockk<WorkInfo> {
+                every { state } returns WorkInfo.State.SUCCEEDED
+                every { progress } returns workDataOf(ModelDownloadWorker.KEY_PROGRESS to 100)
+            }
+
+            val vm = createViewModel()
+            downloadWorkInfoFlow.value = listOf(workInfo)
+            advanceUntilIdle()
+
+            assertNull(vm.uiState.value.llmDownloadProgress)
+            assertTrue(vm.uiState.value.llmReady)
+        }
+
+        @Test
+        fun `clears progress when work fails`() = runTest {
+            val runningInfo = mockk<WorkInfo> {
+                every { state } returns WorkInfo.State.RUNNING
+                every { progress } returns workDataOf(ModelDownloadWorker.KEY_PROGRESS to 50)
+            }
+            val failedInfo = mockk<WorkInfo> {
+                every { state } returns WorkInfo.State.FAILED
+                every { progress } returns workDataOf()
+            }
+
+            val vm = createViewModel()
+            downloadWorkInfoFlow.value = listOf(runningInfo)
+            advanceUntilIdle()
+            downloadWorkInfoFlow.value = listOf(failedInfo)
+            advanceUntilIdle()
+
+            assertNull(vm.uiState.value.llmDownloadProgress)
+        }
+
+        @Test
+        fun `clears progress when work is cancelled`() = runTest {
+            val runningInfo = mockk<WorkInfo> {
+                every { state } returns WorkInfo.State.RUNNING
+                every { progress } returns workDataOf(ModelDownloadWorker.KEY_PROGRESS to 30)
+            }
+            val cancelledInfo = mockk<WorkInfo> {
+                every { state } returns WorkInfo.State.CANCELLED
+                every { progress } returns workDataOf()
+            }
+
+            val vm = createViewModel()
+            downloadWorkInfoFlow.value = listOf(runningInfo)
+            advanceUntilIdle()
+            downloadWorkInfoFlow.value = listOf(cancelledInfo)
+            advanceUntilIdle()
+
+            assertNull(vm.uiState.value.llmDownloadProgress)
+        }
+
+        @Test
+        fun `shows 0 progress when work is enqueued`() = runTest {
+            val workInfo = mockk<WorkInfo> {
+                every { state } returns WorkInfo.State.ENQUEUED
+                every { progress } returns workDataOf()
+            }
+
+            val vm = createViewModel()
+            downloadWorkInfoFlow.value = listOf(workInfo)
+            advanceUntilIdle()
+
+            assertEquals(0, vm.uiState.value.llmDownloadProgress)
+        }
+
+        @Test
+        fun `no progress update when work info list is empty`() = runTest {
+            val vm = createViewModel()
+            // downloadWorkInfoFlow starts with emptyList() — no state change expected
+            advanceUntilIdle()
+
+            assertNull(vm.uiState.value.llmDownloadProgress)
+        }
+
+        @Test
+        fun `picks up in-progress download on ViewModel creation`() = runTest {
+            // Simulate an already-running download when the ViewModel is created
+            val runningInfo = mockk<WorkInfo> {
+                every { state } returns WorkInfo.State.RUNNING
+                every { progress } returns workDataOf(ModelDownloadWorker.KEY_PROGRESS to 75)
+            }
+            downloadWorkInfoFlow.value = listOf(runningInfo)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertEquals(75, vm.uiState.value.llmDownloadProgress)
+        }
+    }
+
+    @Nested
+    @DisplayName("downloadModel")
+    inner class DownloadModel {
+
+        @Test
+        fun `enqueues unique work with correct work name`() = runTest {
+            every { llmOrchestrator.selectConfig() } returns LlmOrchestrator.LlmConfig(
+                backend = LlmBackend.LITERT,
+                modelVariant = LlmOrchestrator.ModelVariant.GEMMA4_E2B,
+                qualityScore = 70
+            )
+
+            val vm = createViewModel()
+            vm.downloadModel()
+            advanceUntilIdle()
+
+            verify {
+                workManager.enqueueUniqueWork(
+                    ModelDownloadWorker.UNIQUE_WORK_NAME,
+                    ExistingWorkPolicy.KEEP,
+                    any()
+                )
+            }
+        }
+
+        @Test
+        fun `does nothing when no model variant is available`() = runTest {
+            every { llmOrchestrator.selectConfig() } returns LlmOrchestrator.LlmConfig(
+                backend = LlmBackend.AICORE,
+                modelVariant = null,
+                qualityScore = 150
+            )
+
+            val vm = createViewModel()
+            vm.downloadModel()
+            advanceUntilIdle()
+
+            verify(exactly = 0) {
+                workManager.enqueueUniqueWork(any(), any(), any())
+            }
+        }
+
+        @Test
+        fun `uses custom base URL when set`() = runTest {
+            every { llmOrchestrator.selectConfig() } returns LlmOrchestrator.LlmConfig(
+                backend = LlmBackend.LITERT,
+                modelVariant = LlmOrchestrator.ModelVariant.GEMMA4_E2B,
+                qualityScore = 70
+            )
+
+            val vm = createViewModel()
+            vm.setModelBaseUrl("https://my-server.example.com")
+            vm.downloadModel()
+            advanceUntilIdle()
+
+            verify {
+                workManager.enqueueUniqueWork(
+                    ModelDownloadWorker.UNIQUE_WORK_NAME,
+                    ExistingWorkPolicy.KEEP,
+                    any()
+                )
+            }
+        }
+    }
+}

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
@@ -116,6 +116,7 @@ class SettingsViewModelTest {
             val failedInfo = mockk<WorkInfo> {
                 every { state } returns WorkInfo.State.FAILED
                 every { progress } returns workDataOf()
+                every { outputData } returns workDataOf()
             }
 
             val vm = createViewModel()
@@ -125,6 +126,25 @@ class SettingsViewModelTest {
             advanceUntilIdle()
 
             assertNull(vm.uiState.value.llmDownloadProgress)
+            assertFalse(vm.uiState.value.llmValidationFailed)
+        }
+
+        @Test
+        fun `sets llmValidationFailed when failure error starts with Validation`() = runTest {
+            val failedInfo = mockk<WorkInfo> {
+                every { state } returns WorkInfo.State.FAILED
+                every { progress } returns workDataOf()
+                every { outputData } returns workDataOf(
+                    ModelDownloadWorker.KEY_ERROR to "Validation: model file too small (4 bytes)"
+                )
+            }
+
+            val vm = createViewModel()
+            downloadWorkInfoFlow.value = listOf(failedInfo)
+            advanceUntilIdle()
+
+            assertNull(vm.uiState.value.llmDownloadProgress)
+            assertTrue(vm.uiState.value.llmValidationFailed)
         }
 
         @Test
@@ -229,7 +249,7 @@ class SettingsViewModelTest {
         }
 
         @Test
-        fun `uses custom base URL when set`() = runTest {
+        fun `sets modelDownloadUrlError when URL does not end with litertlm`() = runTest {
             every { llmOrchestrator.selectConfig() } returns LlmOrchestrator.LlmConfig(
                 backend = LlmBackend.LITERT,
                 modelVariant = LlmOrchestrator.ModelVariant.GEMMA4_E2B,
@@ -237,7 +257,36 @@ class SettingsViewModelTest {
             )
 
             val vm = createViewModel()
-            vm.setModelBaseUrl("https://my-server.example.com")
+            vm.setModelDownloadUrl("https://example.com/model.bin")
+            vm.downloadModel()
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.modelDownloadUrlError)
+            verify(exactly = 0) {
+                workManager.enqueueUniqueWork(any<String>(), any<ExistingWorkPolicy>(), any<OneTimeWorkRequest>())
+            }
+        }
+
+        @Test
+        fun `clears modelDownloadUrlError when URL is corrected`() = runTest {
+            val vm = createViewModel()
+            vm.setModelDownloadUrl("https://example.com/model.bin")
+            vm.setModelDownloadUrl("https://example.com/model.litertlm")
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.modelDownloadUrlError)
+        }
+
+        @Test
+        fun `uses custom download URL when set`() = runTest {
+            every { llmOrchestrator.selectConfig() } returns LlmOrchestrator.LlmConfig(
+                backend = LlmBackend.LITERT,
+                modelVariant = LlmOrchestrator.ModelVariant.GEMMA4_E2B,
+                qualityScore = 70
+            )
+
+            val vm = createViewModel()
+            vm.setModelDownloadUrl("https://my-server.example.com/model.litertlm")
             vm.downloadModel()
             advanceUntilIdle()
 

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
@@ -8,7 +8,6 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
-import okhttp3.CertificatePinner
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -28,21 +27,11 @@ object NetworkModule {
         coerceInputValues = true
     }
 
-    // Pin intermediate CA certificates for Trakt and TMDB APIs.
-    // Using wildcard pins on intermediate CAs for resilience during leaf cert rotation.
-    private val certificatePinner = CertificatePinner.Builder()
-        .add("api.trakt.tv", "sha256/jQJTbIh0grw0/1TkHSumWb+Fs0Ggogr621gT3PvPKG0=")         // Let's Encrypt R3
-        .add("api.trakt.tv", "sha256/C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=")         // ISRG Root X1
-        .add("api.themoviedb.org", "sha256/jQJTbIh0grw0/1TkHSumWb+Fs0Ggogr621gT3PvPKG0=")    // Let's Encrypt R3
-        .add("api.themoviedb.org", "sha256/C5+lpZ7tcVwmwQIMcRtPbsQtWLABXhQzejna0wHFr8M=")    // ISRG Root X1
-        .build()
-
     @Provides
     @Singleton
     fun provideOkHttpClient(
         @Named("isDebugBuild") isDebug: Boolean
     ): OkHttpClient = OkHttpClient.Builder()
-        .certificatePinner(certificatePinner)
         .addInterceptor { chain ->
             // Trakt required headers
             val request = chain.request().newBuilder()
@@ -103,15 +92,15 @@ object NetworkModule {
         retrofit.create(TmdbApiService::class.java)
 
     /**
-     * Retrofit-Instanz für den Token-Proxy-Backend.
+     * Retrofit instance for the token proxy backend.
      *
-     * Wird nur bereitgestellt, wenn [backendUrl] nicht leer ist — d.h. wenn
-     * BuildConfig.TOKEN_BACKEND_URL in app-phone/build.gradle.kts gesetzt ist.
-     * Andernfalls ist [TokenProxyService] im Hilt-Graph nicht verfügbar und
-     * der Onboarding-Flow blendet die Trakt-Anmeldung aus.
+     * Only provided when [backendUrl] is non-blank — i.e. when
+     * BuildConfig.TOKEN_BACKEND_URL is set in app-phone/build.gradle.kts.
+     * Otherwise [TokenProxyService] is unavailable in the Hilt graph and
+     * the onboarding flow hides the Trakt sign-in option.
      *
-     * Hinweis: Der OkHttpClient wird hier bewusst ohne die Trakt-spezifischen
-     * Header verwendet — der Proxy braucht kein 'trakt-api-version'-Header.
+     * Note: The OkHttpClient is intentionally used without Trakt-specific
+     * headers — the proxy does not require a 'trakt-api-version' header.
      */
     @Provides
     @Singleton

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
@@ -1,6 +1,5 @@
 package com.justb81.watchbuddy.core.network
 
-import okhttp3.CertificatePinner
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
@@ -53,7 +52,7 @@ class NetworkModuleTest {
         @Test
         fun `does not apply certificate pinning`() {
             val client = NetworkModule.provideOkHttpClient(isDebug = false)
-            assertEquals(CertificatePinner.DEFAULT, client.certificatePinner)
+            assertTrue(client.certificatePinner.pins.isEmpty())
         }
     }
 

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.core.network
 
+import okhttp3.CertificatePinner
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
@@ -34,7 +35,7 @@ class NetworkModuleTest {
         @Test
         fun `adds Content-Type header`() {
             server.enqueue(MockResponse().setBody("{}"))
-            val client = createTestClient()
+            val client = NetworkModule.provideOkHttpClient(isDebug = false)
             client.newCall(Request.Builder().url(server.url("/test")).build()).execute()
             val recorded = server.takeRequest()
             assertEquals("application/json", recorded.getHeader("Content-Type"))
@@ -43,23 +44,16 @@ class NetworkModuleTest {
         @Test
         fun `adds trakt-api-version header`() {
             server.enqueue(MockResponse().setBody("{}"))
-            val client = createTestClient()
+            val client = NetworkModule.provideOkHttpClient(isDebug = false)
             client.newCall(Request.Builder().url(server.url("/test")).build()).execute()
             val recorded = server.takeRequest()
             assertEquals("2", recorded.getHeader("trakt-api-version"))
         }
 
-        private fun createTestClient(): OkHttpClient {
-            // Build a client that mimics NetworkModule's interceptor logic but without certificate pinning
-            return OkHttpClient.Builder()
-                .addInterceptor { chain ->
-                    val request = chain.request().newBuilder()
-                        .addHeader("Content-Type", "application/json")
-                        .addHeader("trakt-api-version", "2")
-                        .build()
-                    chain.proceed(request)
-                }
-                .build()
+        @Test
+        fun `does not apply certificate pinning`() {
+            val client = NetworkModule.provideOkHttpClient(isDebug = false)
+            assertEquals(CertificatePinner.DEFAULT, client.certificatePinner)
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes two P1-high issues and implements one P2-medium enhancement in the phone app.

### Closes #138 — Remove certificate pinning

Certificate pinning was hardcoded to Let&#39;s Encrypt R3 / ISRG Root X1 pins for `api.trakt.tv` and `api.themoviedb.org`. After trakt.tv migrated to Google Trust Services, every API call fails with:

```
Certificate pinning failure!
Peer certificate chain: sha256/OJ2P65QsdF1C... CN=trakt.tv
Pinned certificates: sha256/jQJTbIh0grw0... (Let&#39;s Encrypt R3)
```

**Fix:** Remove `CertificatePinner` entirely from `NetworkModule`. Standard TLS validation (valid cert chain to a trusted CA) is sufficient and resilient to future CA rotations.

- `NetworkModule.kt` — removed `CertificatePinner` import and property, removed `.certificatePinner()` call, translated German comments to English
- `NetworkModuleTest.kt` — tests now call `NetworkModule.provideOkHttpClient()` directly; asserts `client.certificatePinner.pins.isEmpty()`

---

### Closes #132 — Model download stops and resets when app loses focus

Two root causes:

1. **Wrong observation key**: `downloadModel()` observed `getWorkInfoByIdFlow(workRequest.id)`. When the user navigated away, the ViewModel was cleared. On return, a new `OneTimeWorkRequest` was created (correctly rejected by `KEEP` policy), but progress was observed via the *new* request&#39;s ID — which had no running work. The UI showed the download button instead of the progress bar.

2. **No foreground service priority**: Without a foreground notification, Android could terminate the download process when the app moved to the background.

**Fix:**
- `SettingsViewModel` — moved progress observation to `init` via `getWorkInfosForUniqueWorkFlow(UNIQUE_WORK_NAME)`. This survives ViewModel recreation and immediately picks up any in-progress download on the next screen visit. `downloadModel()` now only enqueues work. `WorkManager` is injected via Hilt (via `AppModule.provideWorkManager`) for testability.
- `ModelDownloadWorker` — calls `setForeground(createForegroundInfo())` before starting the download, promoting it to a foreground service with `FOREGROUND_SERVICE_TYPE_DATA_SYNC` priority on API 29+.
- `WatchBuddyPhoneApp` — registers the `model_download` notification channel on startup.
- `AndroidManifest.xml` — merges `foregroundServiceType="dataSync"` into WorkManager&#39;s `SystemForegroundService` declaration (required for Android 14+).

---

### Closes #133 — Custom model download URL + post-download validation

**Changes:**
- **Full URL replaces base URL**: Users now paste the complete URL to a `.litertlm` file (e.g. `https://example.com/gemma-4-E2B-it.litertlm`) instead of a base URL that had the variant filename appended automatically.
- **URL format validation**: If a custom URL is provided it must end with `.litertlm` (case-insensitive). The text field shows a red error hint and the download is blocked until corrected.
- **Post-download file size validation** in `ModelDownloadWorker`: after writing, verifies `size >= 1 MB`. Anything smaller (HTML error page, truncated response) is deleted and returns `Result.failure` with `KEY_ERROR` prefixed `"Validation:"`. The Settings screen shows a red *"Download failed: file appears invalid"* message in the LLM card.
- **All four locale string files updated** (en, de, fr, es) with new and renamed resources.

---

## Test plan

- [ ] `NetworkModuleTest` — `does not apply certificate pinning` asserts `client.certificatePinner.pins.isEmpty()`
- [ ] `ModelDownloadWorkerTest` — all download tests pass with mocked `setForeground` / `createForegroundInfo`; new tests verify validation failure (file too small, `setModelReady` not called)
- [ ] `SettingsViewModelTest` — tests verify all `WorkInfo.State` transitions (RUNNING, SUCCEEDED, FAILED, CANCELLED, ENQUEUED), validation-failure flag set from `KEY_ERROR`, URL format rejection, and that an already-running download is detected on ViewModel creation
- [ ] CI build (Android debug APKs) passes

https://claude.ai/code/session_012CyX7rBS2tPJzKRXZsTr9W