### PR TITLE
feat(phone): default TMDB API key + clickable registration link

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -80,6 +80,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
         run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
 
       - name: Build Phone and TV debug APKs (unsigned fallback)
@@ -88,6 +89,7 @@ jobs:
           VERSION_CODE: ${{ github.run_number }}
           TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
         run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
 
       - name: Upload Phone APK

--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -36,6 +36,16 @@ android {
             "String", "TOKEN_BACKEND_URL",
             "\"${providers.environmentVariable("TOKEN_BACKEND_URL").orElse("").get()}\""
         )
+
+        // ── TMDB configuration ────────────────────────────────────────────────
+        // A default TMDB API v3 key bundled at build time so the app works out of
+        // the box without requiring users to supply their own key.  Users can still
+        // override it in Settings.  Set via the TMDB_API_KEY CI secret; leave empty
+        // in development builds to force users through the settings flow.
+        buildConfigField(
+            "String", "DEFAULT_TMDB_API_KEY",
+            "\"${providers.environmentVariable("TMDB_API_KEY").orElse("").get()}\""
+        )
     }
 
     // CI signing: keystore path + credentials via environment variables.

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
@@ -36,6 +36,15 @@ object AppModule {
     @Singleton
     fun provideTokenBackendUrl(): String = BuildConfig.TOKEN_BACKEND_URL
 
+    /**
+     * Default TMDB API v3 key from BuildConfig (set via TMDB_API_KEY env var at build time).
+     * Empty string → no built-in key, users must supply their own in Settings.
+     */
+    @Provides
+    @Singleton
+    @Named("defaultTmdbApiKey")
+    fun provideDefaultTmdbApiKey(): String = BuildConfig.DEFAULT_TMDB_API_KEY
+
     /** Debug flag for NetworkModule (controls HTTP logging level). */
     @Provides
     @Singleton

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/AppSettings.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/AppSettings.kt
@@ -8,5 +8,7 @@ data class AppSettings(
     val directClientId: String = "",
     val companionEnabled: Boolean = false,
     val modelDownloadUrl: String = "",
-    val tmdbApiKey: String = ""
+    val tmdbApiKey: String = "",
+    /** True when a default TMDB API key was baked in at build time. */
+    val defaultTmdbApiKeyAvailable: Boolean = false
 )

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.io.File
 import javax.inject.Inject
+import javax.inject.Named
 import javax.inject.Singleton
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
@@ -28,7 +29,8 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(na
 @Singleton
 class SettingsRepository @Inject constructor(
     @param:ApplicationContext private val context: Context,
-    private val tokenRepository: TokenRepository
+    private val tokenRepository: TokenRepository,
+    @Named("defaultTmdbApiKey") private val defaultTmdbApiKey: String
 ) {
     private object Keys {
         val AUTH_MODE = stringPreferencesKey("auth_mode")
@@ -62,7 +64,8 @@ class SettingsRepository @Inject constructor(
             directClientId = prefs[Keys.DIRECT_CLIENT_ID] ?: "",
             companionEnabled = prefs[Keys.COMPANION_ENABLED] ?: false,
             modelDownloadUrl = prefs[Keys.MODEL_DOWNLOAD_URL] ?: "",
-            tmdbApiKey = prefs[Keys.TMDB_API_KEY] ?: ""
+            tmdbApiKey = prefs[Keys.TMDB_API_KEY] ?: "",
+            defaultTmdbApiKeyAvailable = defaultTmdbApiKey.isNotBlank()
         )
     }
 
@@ -83,9 +86,17 @@ class SettingsRepository @Inject constructor(
         tokenRepository.saveClientSecret(secret)
     }
 
+    /**
+     * Returns the effective TMDB API key: the user's custom key when set, otherwise the
+     * default key baked in at build time.  Returns an empty string when neither is available.
+     */
     fun getTmdbApiKey(): Flow<String> = context.dataStore.data.map { prefs ->
-        prefs[Keys.TMDB_API_KEY] ?: ""
+        val userKey = prefs[Keys.TMDB_API_KEY] ?: ""
+        userKey.ifBlank { defaultTmdbApiKey }
     }
+
+    /** True when a default TMDB API key was embedded at build time. */
+    fun hasDefaultTmdbApiKey(): Boolean = defaultTmdbApiKey.isNotBlank()
 
     fun setModelReady(ready: Boolean) {
         scope.launch {

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.phone.ui.settings
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -9,9 +10,11 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.justb81.watchbuddy.R
@@ -95,51 +98,102 @@ fun SettingsScreen(
             SettingsSectionHeader(stringResource(R.string.settings_tmdb))
 
             SettingsCard {
-                SettingsRow(
-                    label    = stringResource(R.string.settings_tmdb_account),
-                    value    = if (uiState.tmdbConnected)
-                                   stringResource(R.string.settings_tmdb_connected)
-                               else
-                                   stringResource(R.string.settings_not_connected),
-                    showDivider = true
-                )
-                if (uiState.tmdbConnected) {
-                    TextButton(
-                        onClick  = { viewModel.disconnectTmdb() },
-                        modifier = Modifier.padding(horizontal = 8.dp)
-                    ) {
-                        Text(
-                            stringResource(R.string.settings_disconnect),
-                            color = MaterialTheme.colorScheme.error
+                when {
+                    uiState.tmdbConnected -> {
+                        // User has saved their own API key
+                        SettingsRow(
+                            label    = stringResource(R.string.settings_tmdb_account),
+                            value    = stringResource(R.string.settings_tmdb_connected),
+                            showDivider = true
                         )
-                    }
-                } else {
-                    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                        OutlinedTextField(
-                            value         = uiState.tmdbApiKey,
-                            onValueChange = viewModel::setTmdbApiKey,
-                            label         = { Text(stringResource(R.string.settings_tmdb_api_key)) },
-                            modifier      = Modifier.fillMaxWidth(),
-                            singleLine    = true,
-                            visualTransformation = PasswordVisualTransformation()
-                        )
-                        Spacer(Modifier.height(4.dp))
-                        Text(
-                            text  = stringResource(R.string.settings_tmdb_helper),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
-                        )
-                        Spacer(Modifier.height(8.dp))
-                        Button(
-                            onClick  = { viewModel.saveTmdbApiKey() },
-                            modifier = Modifier.fillMaxWidth(),
-                            enabled  = uiState.tmdbApiKey.isNotBlank()
+                        TextButton(
+                            onClick  = { viewModel.disconnectTmdb() },
+                            modifier = Modifier.padding(horizontal = 8.dp)
                         ) {
-                            Text(stringResource(R.string.settings_save))
+                            Text(
+                                stringResource(R.string.settings_disconnect),
+                                color = MaterialTheme.colorScheme.error
+                            )
                         }
-                        Spacer(Modifier.height(4.dp))
+                    }
+                    uiState.defaultTmdbApiKeyAvailable -> {
+                        // No user key, but a built-in key is available
+                        SettingsRow(
+                            label    = stringResource(R.string.settings_tmdb_account),
+                            value    = stringResource(R.string.settings_tmdb_default_key_active),
+                            showDivider = true
+                        )
+                        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                            Text(
+                                text  = stringResource(R.string.settings_tmdb_default_key_hint),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                            )
+                            Spacer(Modifier.height(8.dp))
+                            OutlinedTextField(
+                                value         = uiState.tmdbApiKey,
+                                onValueChange = viewModel::setTmdbApiKey,
+                                label         = { Text(stringResource(R.string.settings_tmdb_api_key)) },
+                                modifier      = Modifier.fillMaxWidth(),
+                                singleLine    = true,
+                                visualTransformation = PasswordVisualTransformation()
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            TmdbHelperLink()
+                            Spacer(Modifier.height(8.dp))
+                            Button(
+                                onClick  = { viewModel.saveTmdbApiKey() },
+                                modifier = Modifier.fillMaxWidth(),
+                                enabled  = uiState.tmdbApiKey.isNotBlank()
+                            ) {
+                                Text(stringResource(R.string.settings_save))
+                            }
+                            Spacer(Modifier.height(4.dp))
+                        }
+                    }
+                    else -> {
+                        // No key at all — user must enter one
+                        SettingsRow(
+                            label    = stringResource(R.string.settings_tmdb_account),
+                            value    = stringResource(R.string.settings_not_connected),
+                            showDivider = true
+                        )
+                        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
+                            OutlinedTextField(
+                                value         = uiState.tmdbApiKey,
+                                onValueChange = viewModel::setTmdbApiKey,
+                                label         = { Text(stringResource(R.string.settings_tmdb_api_key)) },
+                                modifier      = Modifier.fillMaxWidth(),
+                                singleLine    = true,
+                                visualTransformation = PasswordVisualTransformation()
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            TmdbHelperLink()
+                            Spacer(Modifier.height(8.dp))
+                            Button(
+                                onClick  = { viewModel.saveTmdbApiKey() },
+                                modifier = Modifier.fillMaxWidth(),
+                                enabled  = uiState.tmdbApiKey.isNotBlank()
+                            ) {
+                                Text(stringResource(R.string.settings_save))
+                            }
+                            Spacer(Modifier.height(4.dp))
+                        }
                     }
                 }
+
+                // TMDB attribution (always visible)
+                HorizontalDivider(
+                    color     = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+                    thickness = 0.5.dp,
+                    modifier  = Modifier.padding(horizontal = 16.dp)
+                )
+                Text(
+                    text     = stringResource(R.string.settings_tmdb_attribution),
+                    style    = MaterialTheme.typography.labelSmall,
+                    color    = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f),
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                )
             }
 
             // ── Companion Service ─────────────────────────────────────────────
@@ -399,6 +453,30 @@ private fun AdvancedAuthSettings(uiState: SettingsUiState, viewModel: SettingsVi
         }
         Spacer(Modifier.height(12.dp))
     }
+}
+
+// ── TMDB helper link ──────────────────────────────────────────────────────────
+
+@Composable
+private fun TmdbHelperLink() {
+    val uriHandler = LocalUriHandler.current
+    val url = stringResource(R.string.settings_tmdb_api_url)
+    val linkText = stringResource(R.string.settings_tmdb_helper_link)
+    val helperText = stringResource(R.string.settings_tmdb_helper)
+
+    Text(
+        text  = helperText,
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+    )
+    Spacer(Modifier.height(2.dp))
+    Text(
+        text            = linkText,
+        style           = MaterialTheme.typography.bodySmall,
+        color           = MaterialTheme.colorScheme.primary,
+        textDecoration  = TextDecoration.Underline,
+        modifier        = Modifier.clickable { uriHandler.openUri(url) }
+    )
 }
 
 // ── Reusable components ───────────────────────────────────────────────────────

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -33,6 +33,8 @@ data class SettingsUiState(
     val traktUsername: String?     = null,
     val tmdbConnected: Boolean     = false,
     val tmdbApiKey: String         = "",
+    /** True when the build ships a default TMDB API key and the user has not set a custom one. */
+    val defaultTmdbApiKeyAvailable: Boolean = false,
     val companionRunning: Boolean  = false,
     val authMode: AuthMode         = AuthMode.MANAGED,
     val customBackendUrl: String   = "",
@@ -98,7 +100,8 @@ class SettingsViewModel @Inject constructor(
                 companionRunning = saved.companionEnabled,
                 modelDownloadUrl = saved.modelDownloadUrl,
                 tmdbApiKey = saved.tmdbApiKey,
-                tmdbConnected = saved.tmdbApiKey.isNotBlank()
+                tmdbConnected = saved.tmdbApiKey.isNotBlank(),
+                defaultTmdbApiKeyAvailable = saved.defaultTmdbApiKeyAvailable && saved.tmdbApiKey.isBlank()
             )
         }
     }
@@ -194,6 +197,7 @@ class SettingsViewModel @Inject constructor(
             settingsRepository.saveSettings(current.copy(tmdbApiKey = key))
             _uiState.value = _uiState.value.copy(
                 tmdbConnected = key.isNotBlank(),
+                defaultTmdbApiKeyAvailable = key.isBlank() && current.defaultTmdbApiKeyAvailable,
                 saveSuccess = true
             )
         }
@@ -205,7 +209,8 @@ class SettingsViewModel @Inject constructor(
             settingsRepository.saveSettings(current.copy(tmdbApiKey = ""))
             _uiState.value = _uiState.value.copy(
                 tmdbApiKey = "",
-                tmdbConnected = false
+                tmdbConnected = false,
+                defaultTmdbApiKeyAvailable = current.defaultTmdbApiKeyAvailable
             )
         }
     }

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -50,7 +50,10 @@
     <string name="settings_tmdb_account">TMDB-Konto</string>
     <string name="settings_tmdb_connected">Verbunden</string>
     <string name="settings_tmdb_api_key">TMDB-API-Schlüssel (v3 Auth)</string>
-    <string name="settings_tmdb_helper">Hol dir deinen kostenlosen API-Schlüssel auf themoviedb.org unter Einstellungen → API.</string>
+    <string name="settings_tmdb_helper">Kostenlosen API-Schlüssel auf themoviedb.org → Einstellungen → API holen</string>
+    <string name="settings_tmdb_helper_link">API-Schlüssel holen</string>
+    <string name="settings_tmdb_default_key_active">Integrierter Schlüssel aktiv</string>
+    <string name="settings_tmdb_default_key_hint">Ein integrierter TMDB-Schlüssel ist aktiv. Du kannst optional deinen eigenen Schlüssel eingeben, um ihn zu überschreiben.</string>
     <string name="settings_disconnect">Trennen</string>
     <string name="settings_companion">Companion-Dienst</string>
     <string name="settings_companion_running">Läuft (Port 8765)</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -50,7 +50,10 @@
     <string name="settings_tmdb_account">Cuenta de TMDB</string>
     <string name="settings_tmdb_connected">Conectado</string>
     <string name="settings_tmdb_api_key">Clave API de TMDB (auth v3)</string>
-    <string name="settings_tmdb_helper">Obtén tu clave API gratuita en themoviedb.org en Ajustes → API.</string>
+    <string name="settings_tmdb_helper">Obtén tu clave API gratuita en themoviedb.org → Ajustes → API</string>
+    <string name="settings_tmdb_helper_link">Obtener clave API</string>
+    <string name="settings_tmdb_default_key_active">Clave integrada activa</string>
+    <string name="settings_tmdb_default_key_hint">Una clave TMDB integrada está activa. Puedes ingresar tu propia clave a continuación para reemplazarla.</string>
     <string name="settings_disconnect">Desconectar</string>
     <string name="settings_companion">Servicio compañero</string>
     <string name="settings_companion_running">En ejecución (puerto 8765)</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -50,7 +50,10 @@
     <string name="settings_tmdb_account">Compte TMDB</string>
     <string name="settings_tmdb_connected">Connecté</string>
     <string name="settings_tmdb_api_key">Clé API TMDB (auth v3)</string>
-    <string name="settings_tmdb_helper">Obtenez votre clé API gratuite sur themoviedb.org sous Paramètres → API.</string>
+    <string name="settings_tmdb_helper">Obtenez votre clé API gratuite sur themoviedb.org → Paramètres → API</string>
+    <string name="settings_tmdb_helper_link">Obtenir la clé API</string>
+    <string name="settings_tmdb_default_key_active">Clé intégrée active</string>
+    <string name="settings_tmdb_default_key_hint">Une clé TMDB intégrée est active. Vous pouvez optionnellement entrer votre propre clé ci-dessous pour la remplacer.</string>
     <string name="settings_disconnect">Déconnecter</string>
     <string name="settings_companion">Service compagnon</string>
     <string name="settings_companion_running">En cours (port 8765)</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -50,7 +50,12 @@
     <string name="settings_tmdb_account">TMDB account</string>
     <string name="settings_tmdb_connected">Connected</string>
     <string name="settings_tmdb_api_key">TMDB API key (v3 auth)</string>
-    <string name="settings_tmdb_helper">Get your free API key at themoviedb.org under Settings → API.</string>
+    <string name="settings_tmdb_helper">Get your free API key at themoviedb.org → Settings → API</string>
+    <string name="settings_tmdb_helper_link">Get API key</string>
+    <string name="settings_tmdb_api_url" translatable="false">https://www.themoviedb.org/settings/api</string>
+    <string name="settings_tmdb_default_key_active">Built-in key active</string>
+    <string name="settings_tmdb_default_key_hint">A built-in TMDB key is active. You can optionally enter your own key below to override it.</string>
+    <string name="settings_tmdb_attribution" translatable="false">This app uses the TMDB API but is not endorsed or certified by TMDB.</string>
     <string name="settings_disconnect">Disconnect</string>
     <string name="settings_companion">Companion service</string>
     <string name="settings_companion_running">Running (port 8765)</string>

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/settings/AppSettingsTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/settings/AppSettingsTest.kt
@@ -29,6 +29,33 @@ class AppSettingsTest {
     }
 
     @Test
+    fun `default tmdbApiKey is empty`() {
+        assertEquals("", AppSettings().tmdbApiKey)
+    }
+
+    @Test
+    fun `default defaultTmdbApiKeyAvailable is false`() {
+        assertFalse(AppSettings().defaultTmdbApiKeyAvailable)
+    }
+
+    @Test
+    fun `defaultTmdbApiKeyAvailable can be set to true`() {
+        val settings = AppSettings(defaultTmdbApiKeyAvailable = true)
+        assertTrue(settings.defaultTmdbApiKeyAvailable)
+    }
+
+    @Test
+    fun `copy with defaultTmdbApiKeyAvailable preserves other fields`() {
+        val original = AppSettings(
+            tmdbApiKey = "my-key",
+            defaultTmdbApiKeyAvailable = false
+        )
+        val modified = original.copy(defaultTmdbApiKeyAvailable = true)
+        assertEquals("my-key", modified.tmdbApiKey)
+        assertTrue(modified.defaultTmdbApiKeyAvailable)
+    }
+
+    @Test
     fun `copy preserves unchanged fields`() {
         val original = AppSettings(authMode = AuthMode.DIRECT, backendUrl = "https://example.com")
         val modified = original.copy(companionEnabled = true)

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
@@ -15,6 +15,7 @@ import com.justb81.watchbuddy.phone.llm.ModelDownloadWorker
 import com.justb81.watchbuddy.phone.server.DeviceCapabilityProvider
 import com.justb81.watchbuddy.phone.settings.AppSettings
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -297,6 +298,96 @@ class SettingsViewModelTest {
                     any<OneTimeWorkRequest>()
                 )
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("TMDB API key state")
+    inner class TmdbApiKeyState {
+
+        @Test
+        fun `tmdbConnected is false and defaultTmdbApiKeyAvailable is false when no keys`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(tmdbApiKey = "", defaultTmdbApiKeyAvailable = false)
+            )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.tmdbConnected)
+            assertFalse(vm.uiState.value.defaultTmdbApiKeyAvailable)
+        }
+
+        @Test
+        fun `tmdbConnected is true when user has set a custom key`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(tmdbApiKey = "user-key-123", defaultTmdbApiKeyAvailable = false)
+            )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.tmdbConnected)
+            assertFalse(vm.uiState.value.defaultTmdbApiKeyAvailable)
+        }
+
+        @Test
+        fun `defaultTmdbApiKeyAvailable is true when build has default key and user has no custom key`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(tmdbApiKey = "", defaultTmdbApiKeyAvailable = true)
+            )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.tmdbConnected)
+            assertTrue(vm.uiState.value.defaultTmdbApiKeyAvailable)
+        }
+
+        @Test
+        fun `defaultTmdbApiKeyAvailable is false when user has custom key even if build has default`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(tmdbApiKey = "user-key-123", defaultTmdbApiKeyAvailable = true)
+            )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.tmdbConnected)
+            assertFalse(vm.uiState.value.defaultTmdbApiKeyAvailable)
+        }
+
+        @Test
+        fun `disconnectTmdb restores defaultTmdbApiKeyAvailable when build has default key`() = runTest {
+            val savedSettings = AppSettings(tmdbApiKey = "user-key", defaultTmdbApiKeyAvailable = true)
+            every { settingsRepository.settings } returns flowOf(savedSettings)
+            coEvery { settingsRepository.saveSettings(any()) } returns Unit
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.disconnectTmdb()
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.tmdbConnected)
+            assertTrue(vm.uiState.value.defaultTmdbApiKeyAvailable)
+        }
+
+        @Test
+        fun `saveTmdbApiKey hides default key banner after saving a custom key`() = runTest {
+            val savedSettings = AppSettings(tmdbApiKey = "", defaultTmdbApiKeyAvailable = true)
+            every { settingsRepository.settings } returns flowOf(savedSettings)
+            coEvery { settingsRepository.saveSettings(any()) } returns Unit
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.setTmdbApiKey("my-new-key")
+            vm.saveTmdbApiKey()
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.tmdbConnected)
+            assertFalse(vm.uiState.value.defaultTmdbApiKeyAvailable)
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements two related open issues that improve the TMDB experience:

**Closes #141 — Default TMDB API key**
- `DEFAULT_TMDB_API_KEY` baked in at build time via `TMDB_API_KEY` CI secret (same pattern as `TRAKT_CLIENT_ID`)
- `SettingsRepository.getTmdbApiKey()` falls back to the built-in key when the user has not set a custom one — recap generation works out-of-the-box without any setup
- Three-state TMDB card in Settings:
  1. **Custom key saved** → "Connected" + Disconnect (existing behaviour)
  2. **Built-in key active, no custom key** → "Built-in key active" banner + optional override input
  3. **No key at all** → API key input form (existing behaviour)
- `AppSettings` + `SettingsUiState` expose `defaultTmdbApiKeyAvailable` so the UI stays in sync on save/disconnect

**Closes #139 — Clickable TMDB registration link + attribution**
- Helper text below the API key field is now split: a static label + a separately tappable link that opens `https://www.themoviedb.org/settings/api` via `LocalUriHandler` (no `ClickableText` deprecation — uses `Text` + `Modifier.clickable`)
- TMDB attribution notice always visible at the bottom of the TMDB card as required by TMDB's attribution guidelines
- All new strings translated into DE, FR, ES

## Test plan

- [ ] `AppSettingsTest`: `defaultTmdbApiKeyAvailable` default value and copy behaviour
- [ ] `SettingsViewModelTest` (6 new cases):
  - no keys → both flags false
  - custom key only → `tmdbConnected=true`, banner hidden
  - default key only → banner shown, `tmdbConnected=false`
  - custom key + default key available → `tmdbConnected=true`, banner hidden
  - `disconnectTmdb()` restores banner when default key available
  - `saveTmdbApiKey()` hides banner after saving a custom key
- [ ] Build: `./gradlew test :app-phone:assembleDebug :app-tv:assembleDebug`

https://claude.ai/code/session_01FsJ9YdrU7YpCRcUnzXJUKT