### PR TITLE
fix(phone): group advanced settings by function and fix toggle label

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -319,7 +319,7 @@ fun SettingsScreen(
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     Text(
-                        stringResource(R.string.settings_auth_mode),
+                        stringResource(R.string.settings_advanced),
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurface
                     )
@@ -367,6 +367,14 @@ fun SettingsScreen(
 @Composable
 private fun AdvancedAuthSettings(uiState: SettingsUiState, viewModel: SettingsViewModel) {
     Column(modifier = Modifier.padding(horizontal = 16.dp)) {
+        // ── Authentication group ──
+        Text(
+            text  = stringResource(R.string.settings_auth_mode),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Spacer(Modifier.height(4.dp))
+
         // Auth mode selector
         AuthMode.entries.forEach { mode ->
             Row(
@@ -423,9 +431,14 @@ private fun AdvancedAuthSettings(uiState: SettingsUiState, viewModel: SettingsVi
             else -> {}
         }
 
-        Spacer(Modifier.height(16.dp))
+        Spacer(Modifier.height(12.dp))
+        HorizontalDivider(
+            color     = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+            thickness = 0.5.dp
+        )
+        Spacer(Modifier.height(12.dp))
 
-        // Model download URL override
+        // ── Model download group ──
         Text(
             text  = stringResource(R.string.settings_model_url_section),
             style = MaterialTheme.typography.labelMedium,


### PR DESCRIPTION
## Summary

- **Issue #134**: The advanced settings toggle was mislabeled "Trakt authentication" despite containing both auth and model download settings. Renamed the toggle to "Advanced settings" and added sub-group headers ("Trakt authentication", "Model download") with a visual divider between them.
- **Issue #117**: Closed as already resolved — the unused `searchShow`, `getSeason`, `TmdbSearchResponse`, and `TmdbSeasonResponse` do not exist in the current codebase.

## Changes

Single file change in `SettingsScreen.kt`:
- Toggle row label changed from `settings_auth_mode` to `settings_advanced`
- Added "Trakt authentication" group header inside the expanded section
- Added `HorizontalDivider` between authentication and model download groups
- No new string resources, no ViewModel changes

## Test plan

- [ ] Verify the advanced settings toggle row displays "Advanced settings" (not "Trakt authentication")
- [ ] Expand the toggle and verify two grouped sub-sections with headers: "Trakt authentication" and "Model download"
- [ ] Verify a divider separates the two groups
- [ ] Verify Save button still persists all advanced settings correctly
- [ ] Verify all four locales render correctly (EN, DE, FR, ES)

Closes #134

https://claude.ai/code/session_01EAoRtg5MHWi6baqP2V6Jo4