### PR TITLE
feat(ci): automate Google Play Store publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           manifest-file: .release-please-manifest.json
 
   build-release:
-    name: Build Release APKs
+    name: Build & Publish Release
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
@@ -55,21 +55,21 @@ jobs:
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # -- Release-signierte APKs (nur wenn Keystore vorhanden) -----------
-      - name: Build signed Phone APK
-        if: steps.keystore.outputs.available == 'true'
+      # -- Check Play Store credentials -----------------------------------
+      - name: Check Play Store credentials
+        id: play-store
         env:
-          KEYSTORE_FILE: /tmp/release.keystore
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          VERSION_NAME: ${{ needs.release-please.outputs.version }}
-          VERSION_CODE: ${{ github.run_number }}
-          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
-          TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
-        run: ./gradlew :app-phone:assembleRelease
+          GOOGLE_PLAY_KEY: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          if [ -n "$GOOGLE_PLAY_KEY" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GOOGLE_PLAY_SERVICE_ACCOUNT_JSON secret not set — skipping Play Store upload."
+          fi
 
-      - name: Build signed TV APK
+      # -- Signed release builds (APK + AAB) ------------------------------
+      - name: Build signed Phone release (APK + AAB)
         if: steps.keystore.outputs.available == 'true'
         env:
           KEYSTORE_FILE: /tmp/release.keystore
@@ -80,7 +80,21 @@ jobs:
           VERSION_CODE: ${{ github.run_number }}
           TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
-        run: ./gradlew :app-tv:assembleRelease
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+        run: ./gradlew :app-phone:assembleRelease :app-phone:bundleRelease
+
+      - name: Build signed TV release (APK + AAB)
+        if: steps.keystore.outputs.available == 'true'
+        env:
+          KEYSTORE_FILE: /tmp/release.keystore
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+          VERSION_NAME: ${{ needs.release-please.outputs.version }}
+          VERSION_CODE: ${{ github.run_number }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
+          TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
+        run: ./gradlew :app-tv:assembleRelease :app-tv:bundleRelease
 
       # -- Debug APKs (always) — signed with release keystore when available -----
       - name: Build debug APKs (signed)
@@ -105,8 +119,8 @@ jobs:
           TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
         run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
 
-      # -- APKs sammeln und umbenennen -------------------------------------
-      - name: Collect APKs
+      # -- Collect release artifacts ---------------------------------------
+      - name: Collect release artifacts
         run: |
           mkdir -p release-assets
 
@@ -116,7 +130,7 @@ jobs:
           cp app-tv/build/outputs/apk/debug/*.apk \
              "release-assets/watchbuddy-tv-${VERSION}-debug.apk"
 
-          # Release APKs (nur wenn vorhanden)
+          # Release APKs (when available)
           for apk in app-phone/build/outputs/apk/release/*.apk; do
             [ -f "$apk" ] && cp "$apk" "release-assets/watchbuddy-phone-${VERSION}-release.apk"
           done
@@ -124,15 +138,23 @@ jobs:
             [ -f "$apk" ] && cp "$apk" "release-assets/watchbuddy-tv-${VERSION}-release.apk"
           done
 
+          # Release AABs (when available)
+          for aab in app-phone/build/outputs/bundle/release/*.aab; do
+            [ -f "$aab" ] && cp "$aab" "release-assets/watchbuddy-phone-${VERSION}-release.aab"
+          done
+          for aab in app-tv/build/outputs/bundle/release/*.aab; do
+            [ -f "$aab" ] && cp "$aab" "release-assets/watchbuddy-tv-${VERSION}-release.aab"
+          done
+
           ls -lh release-assets/
 
-      # -- APKs an GitHub Release hochladen --------------------------------
-      - name: Upload APKs to GitHub Release
+      # -- Upload to GitHub Release ----------------------------------------
+      - name: Upload release assets to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for apk in release-assets/*.apk; do
-            gh release upload "${TAG}" "$apk" --clobber
+          for file in release-assets/*.apk release-assets/*.aab; do
+            [ -f "$file" ] && gh release upload "${TAG}" "$file" --clobber
           done
 
       # -- Download-Links in Release-Notes ergaenzen -----------------------
@@ -145,16 +167,16 @@ jobs:
 
           DOWNLOADS="---"
           DOWNLOADS="${DOWNLOADS}\n\n## Downloads\n"
-          DOWNLOADS="${DOWNLOADS}\n| APK | Link |"
-          DOWNLOADS="${DOWNLOADS}\n|-----|------|"
+          DOWNLOADS="${DOWNLOADS}\n| Asset | Link |"
+          DOWNLOADS="${DOWNLOADS}\n|-------|------|"
           DOWNLOADS="${DOWNLOADS}\n| Phone (debug) | [watchbuddy-phone-${VERSION}-debug.apk](${BASE}/watchbuddy-phone-${VERSION}-debug.apk) |"
           DOWNLOADS="${DOWNLOADS}\n| TV (debug) | [watchbuddy-tv-${VERSION}-debug.apk](${BASE}/watchbuddy-tv-${VERSION}-debug.apk) |"
 
           if [ -f "release-assets/watchbuddy-phone-${VERSION}-release.apk" ]; then
-            DOWNLOADS="${DOWNLOADS}\n| Phone (signed) | [watchbuddy-phone-${VERSION}-release.apk](${BASE}/watchbuddy-phone-${VERSION}-release.apk) |"
+            DOWNLOADS="${DOWNLOADS}\n| Phone (signed APK) | [watchbuddy-phone-${VERSION}-release.apk](${BASE}/watchbuddy-phone-${VERSION}-release.apk) |"
           fi
           if [ -f "release-assets/watchbuddy-tv-${VERSION}-release.apk" ]; then
-            DOWNLOADS="${DOWNLOADS}\n| TV (signed) | [watchbuddy-tv-${VERSION}-release.apk](${BASE}/watchbuddy-tv-${VERSION}-release.apk) |"
+            DOWNLOADS="${DOWNLOADS}\n| TV (signed APK) | [watchbuddy-tv-${VERSION}-release.apk](${BASE}/watchbuddy-tv-${VERSION}-release.apk) |"
           fi
 
           # Bestehende Notes holen und Download-Sektion anhaengen
@@ -162,11 +184,24 @@ jobs:
           UPDATED=$(printf "%s\n\n%b" "$EXISTING" "$DOWNLOADS")
           gh release edit "${TAG}" --notes "$UPDATED"
 
-      - name: Upload APKs as Artifacts
+      # -- Publish to Google Play Store ------------------------------------
+      - name: Upload to Google Play Store
+        if: steps.keystore.outputs.available == 'true' && steps.play-store.outputs.available == 'true'
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: com.justb81.watchbuddy
+          releaseFiles: release-assets/*-release.aab
+          track: internal
+          status: completed
+
+      - name: Upload release artifacts
         uses: actions/upload-artifact@v7
         with:
           name: watchbuddy-release-${{ needs.release-please.outputs.version }}
-          path: release-assets/*.apk
+          path: |
+            release-assets/*.apk
+            release-assets/*.aab
 
   update-stable:
     name: Update stable branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,13 @@ The `release-please--` prefix is reserved for the automated release-please bot �
 - release-please with Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
 - Version tracked in `.release-please-manifest.json`
 - `versionCode` derived from `github.run_number` in CI
-- release-please opens its own PR (`release-please--branches--main`) to bump the version and update `CHANGELOG.md` — merge it to trigger a GitHub Release with signed APKs
+- release-please opens its own PR (`release-please--branches--main`) to bump the version and update `CHANGELOG.md` — merge it to trigger a GitHub Release with signed APKs and AABs
+
+### Distribution
+- **Google Play Store:** AABs are automatically uploaded to the **internal** track on each release. Promote to production via Google Play Console.
+- **GitHub Releases:** Signed APKs and AABs are attached to each GitHub Release for sideloading.
+- **Multi-APK delivery:** Both apps share `applicationId = com.justb81.watchbuddy` with different versionCode offsets (phone 1000+, TV 2000+). The TV manifest requires `android.software.leanback` so Google Play serves the correct AAB per device type.
+- **CI secrets for Play Store:** `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` (Google Cloud service account key with Google Play Android Developer API access). If not set, the Play Store upload step is skipped gracefully.
 
 ### Localization
 - Supported languages: English (default), German, French, Spanish

--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -14,9 +14,11 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
-    <!-- Play Store: TV app — no touchscreen required -->
+    <!-- Play Store: TV app — no touchscreen, leanback required for correct
+         multi-APK device targeting (prevents phone devices from receiving the
+         TV AAB which has a higher versionCode). -->
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
-    <uses-feature android:name="android.software.leanback" android:required="false" />
+    <uses-feature android:name="android.software.leanback" android:required="true" />
 
     <!-- 64-bit required from August 2026 (arm64 only) -->
     <uses-feature android:name="android.hardware.type.television" android:required="false" />


### PR DESCRIPTION
## Summary

- **Build AABs** alongside APKs in the release workflow (`bundleRelease`) — required by Google Play
- **Upload AABs to Google Play Store** internal track automatically on each release via `r0adkll/upload-google-play@v1`
- **Fix TV device targeting**: make `android.software.leanback` required in TV manifest so Google Play serves the correct AAB per device type (phone devices no longer receive the TV AAB)
- **Graceful skip**: Play Store upload is skipped with a notice when `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` is not configured

## Setup required

To enable Play Store publishing, add this GitHub Actions secret:

| Secret | Description |
|--------|-------------|
| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | Full JSON content of a Google Cloud service account key with **Google Play Android Developer API** access |

### How to create the service account:
1. Go to [Google Cloud Console](https://console.cloud.google.com/) → IAM & Admin → Service Accounts
2. Create a service account (e.g. `play-store-deploy`)
3. Create a JSON key and copy its content
4. In [Google Play Console](https://play.google.com/console/) → Settings → API access, grant this service account **Release manager** permissions for WatchBuddy
5. Add the JSON key content as `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` in GitHub repo settings → Secrets

### Release flow after merge:
1. release-please creates a version bump PR
2. Merge the version bump PR → triggers the release workflow
3. Signed AABs are uploaded to the **internal** track on Google Play
4. Promote from internal → production via Google Play Console when ready

## Test plan

- [ ] Verify CI build passes (no Gradle config changes needed — `bundleRelease` works with existing signing setup)
- [ ] After merge: confirm release workflow builds AABs alongside APKs
- [ ] After adding `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` secret: confirm AABs appear on the internal track in Google Play Console
- [ ] Without the secret: confirm the workflow completes successfully and logs a notice about the skipped upload

https://claude.ai/code/session_01Na15TJg7WkHa9q7uuKEbJ1