### PR TITLE
fix(tv): R8 build crash — missing errorprone annotations

### DIFF
--- a/app-tv/proguard-rules.pro
+++ b/app-tv/proguard-rules.pro
@@ -44,8 +44,9 @@
 # ── Coil ─────────────────────────────────────────────────────────────────────
 -dontwarn coil.**
 
-# ── Security Crypto ──────────────────────────────────────────────────────────
+# ── Security Crypto / Tink ───────────────────────────────────────────────────
 -keep class androidx.security.crypto.** { *; }
+-dontwarn com.google.errorprone.annotations.**
 
 # ── Coroutines ───────────────────────────────────────────────────────────────
 -keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}


### PR DESCRIPTION
## Summary

- Add `-dontwarn com.google.errorprone.annotations.**` to the TV ProGuard rules
- Fixes `minifyReleaseWithR8` crash caused by Google Tink referencing compile-time errorprone annotations that aren't on the Android runtime classpath

These annotations are purely for static analysis and have no runtime behavior — suppressing the warning is the standard fix.

Closes #148

## Test plan

- [ ] CI build passes (the `assembleDebug` task runs R8 lint checks)
- [ ] After merge: release workflow `assembleRelease` / `bundleRelease` for TV completes without R8 errors

https://claude.ai/code/session_01Na15TJg7WkHa9q7uuKEbJ1