### PR TITLE
fix(tv): resolve deep links for slug-only and no-variable services when tmdb_id is absent

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModel.kt
@@ -29,22 +29,31 @@ class ShowDetailViewModel @Inject constructor(
 
     /**
      * Resolves the best deep link for a show based on user's preferred streaming services.
-     * Returns the first available service's deep link, respecting priority order.
+     * Iterates through subscribed services in priority order and returns the first link that
+     * can be generated with the available show IDs.  Services whose templates require a TMDB
+     * numeric ID are skipped when [TraktIds.tmdb] is null, allowing slug-only services
+     * (Joyn, Prime Video, ZDF) and no-variable services (WaipuTV) to work regardless.
+     * Returns null only when no subscribed service can produce a valid link.
      */
     fun resolveDeepLink(
         entry: TraktWatchedEntry,
         subscribedServices: List<StreamingService>
     ): String? {
-        val tmdbId = entry.show.ids.tmdb ?: return null
-        val slug = entry.show.ids.slug ?: entry.show.title.lowercase().replace(" ", "-")
+        val tmdbId = entry.show.ids.tmdb
+        val slug   = entry.show.ids.slug ?: entry.show.title.lowercase().replace(" ", "-")
 
-        val service = subscribedServices.firstOrNull()
-            ?: KNOWN_STREAMING_SERVICES.firstOrNull()
-            ?: return null
+        val servicesToTry = subscribedServices.ifEmpty { KNOWN_STREAMING_SERVICES }
 
-        return service.deepLinkTemplate
-            .replace("{tmdb_id}", tmdbId.toString())
-            .replace("{slug}", slug)
-            .replace("{id}", tmdbId.toString())
+        for (service in servicesToTry) {
+            val template = service.deepLinkTemplate
+            val needsId  = template.contains("{tmdb_id}") || template.contains("{id}")
+            if (needsId && tmdbId == null) continue
+
+            return template
+                .replace("{tmdb_id}", tmdbId?.toString() ?: "")
+                .replace("{slug}", slug)
+                .replace("{id}",     tmdbId?.toString() ?: "")
+        }
+        return null
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModelTest.kt
@@ -70,81 +70,175 @@ class ShowDetailViewModelTest {
             viewModel = ShowDetailViewModel(streamingPrefs)
         }
 
+        // ── Services that require a TMDB ID ──────────────────────────────────
+
         @Test
-        fun `substitutes tmdb_id placeholder`() {
+        fun `substitutes tmdb_id placeholder for Netflix`() {
             val entry = TraktWatchedEntry(TraktShow("Test", 2024, TraktIds(tmdb = 42, slug = "test")))
             val services = listOf(
                 StreamingService("netflix", "Netflix", "pkg", "https://netflix.com/title/{tmdb_id}")
             )
-            val result = viewModel.resolveDeepLink(entry, services)
-            assertEquals("https://netflix.com/title/42", result)
+            assertEquals("https://netflix.com/title/42", viewModel.resolveDeepLink(entry, services))
         }
 
         @Test
-        fun `substitutes slug placeholder`() {
-            val entry = TraktWatchedEntry(TraktShow("Test", 2024, TraktIds(tmdb = 1, slug = "test-show")))
-            val services = listOf(
-                StreamingService("joyn", "Joyn", "pkg", "https://joyn.de/serien/{slug}")
-            )
-            val result = viewModel.resolveDeepLink(entry, services)
-            assertEquals("https://joyn.de/serien/test-show", result)
-        }
-
-        @Test
-        fun `Prime Video uses search URL with slug`() {
-            val entry = TraktWatchedEntry(TraktShow("Breaking Bad", 2008, TraktIds(tmdb = 1399, slug = "breaking-bad")))
-            val services = listOf(
-                StreamingService("prime", "Prime Video", "pkg", "https://www.primevideo.com/search?phrase={slug}")
-            )
-            val result = viewModel.resolveDeepLink(entry, services)
-            assertEquals("https://www.primevideo.com/search?phrase=breaking-bad", result)
-        }
-
-        @Test
-        fun `substitutes id placeholder`() {
+        fun `substitutes id placeholder for ARD`() {
             val entry = TraktWatchedEntry(TraktShow("Test", 2024, TraktIds(tmdb = 77, slug = "test")))
             val services = listOf(
                 StreamingService("ard", "ARD", "pkg", "https://ard.de/video/{id}")
             )
-            val result = viewModel.resolveDeepLink(entry, services)
-            assertEquals("https://ard.de/video/77", result)
+            assertEquals("https://ard.de/video/77", viewModel.resolveDeepLink(entry, services))
         }
 
         @Test
-        fun `returns null when tmdb id is null`() {
-            val entry = TraktWatchedEntry(TraktShow("Test", 2024, TraktIds(tmdb = null)))
-            val result = viewModel.resolveDeepLink(entry, KNOWN_STREAMING_SERVICES)
-            assertNull(result)
+        fun `substitutes both tmdb_id and slug for Disney+`() {
+            val entry = TraktWatchedEntry(TraktShow("Test", 2024, TraktIds(tmdb = 5, slug = "test-show")))
+            val services = listOf(
+                StreamingService("disney", "Disney+", "pkg", "https://disney.com/series/{slug}/{tmdb_id}")
+            )
+            assertEquals("https://disney.com/series/test-show/5", viewModel.resolveDeepLink(entry, services))
+        }
+
+        // ── Services that only need a slug ────────────────────────────────────
+
+        @Test
+        fun `Joyn generates slug link without tmdb_id`() {
+            val entry = TraktWatchedEntry(TraktShow("Test Show", 2024, TraktIds(tmdb = null, slug = "test-show")))
+            val services = listOf(
+                StreamingService("joyn", "Joyn", "pkg", "https://joyn.de/serien/{slug}")
+            )
+            assertEquals("https://joyn.de/serien/test-show", viewModel.resolveDeepLink(entry, services))
         }
 
         @Test
-        fun `falls back to title-based slug when slug is null`() {
+        fun `Prime Video generates search URL without tmdb_id`() {
+            val entry = TraktWatchedEntry(TraktShow("Breaking Bad", 2008, TraktIds(tmdb = null, slug = "breaking-bad")))
+            val services = listOf(
+                StreamingService("prime", "Prime Video", "pkg", "https://www.primevideo.com/search?phrase={slug}")
+            )
+            assertEquals(
+                "https://www.primevideo.com/search?phrase=breaking-bad",
+                viewModel.resolveDeepLink(entry, services)
+            )
+        }
+
+        @Test
+        fun `ZDF generates slug link without tmdb_id`() {
+            val entry = TraktWatchedEntry(TraktShow("Tatort", 2024, TraktIds(tmdb = null, slug = "tatort")))
+            val services = listOf(
+                StreamingService("zdf", "ZDF", "pkg", "https://www.zdf.de/serien/{slug}")
+            )
+            assertEquals("https://www.zdf.de/serien/tatort", viewModel.resolveDeepLink(entry, services))
+        }
+
+        @Test
+        fun `slug-only service still works when tmdb_id is present`() {
+            val entry = TraktWatchedEntry(TraktShow("Test", 2024, TraktIds(tmdb = 99, slug = "test")))
+            val services = listOf(
+                StreamingService("joyn", "Joyn", "pkg", "https://joyn.de/serien/{slug}")
+            )
+            assertEquals("https://joyn.de/serien/test", viewModel.resolveDeepLink(entry, services))
+        }
+
+        // ── Services with no template variables ───────────────────────────────
+
+        @Test
+        fun `WaipuTV generates deep link without tmdb_id`() {
+            val entry = TraktWatchedEntry(TraktShow("Any Show", 2024, TraktIds(tmdb = null)))
+            val services = listOf(
+                StreamingService("waipu", "WaipuTV", "tv.waipu.app", "waipu://tv")
+            )
+            assertEquals("waipu://tv", viewModel.resolveDeepLink(entry, services))
+        }
+
+        @Test
+        fun `WaipuTV generates deep link even with tmdb_id present`() {
+            val entry = TraktWatchedEntry(TraktShow("Any Show", 2024, TraktIds(tmdb = 1)))
+            val services = listOf(
+                StreamingService("waipu", "WaipuTV", "tv.waipu.app", "waipu://tv")
+            )
+            assertEquals("waipu://tv", viewModel.resolveDeepLink(entry, services))
+        }
+
+        // ── Slug derivation from title ─────────────────────────────────────────
+
+        @Test
+        fun `derives slug from show title when slug field is null`() {
             val entry = TraktWatchedEntry(TraktShow("My Show", 2024, TraktIds(tmdb = 1, slug = null)))
             val services = listOf(
                 StreamingService("test", "Test", "pkg", "https://test.com/{slug}")
             )
-            val result = viewModel.resolveDeepLink(entry, services)
-            assertEquals("https://test.com/my-show", result)
+            assertEquals("https://test.com/my-show", viewModel.resolveDeepLink(entry, services))
         }
 
         @Test
-        fun `uses first subscribed service`() {
+        fun `derives slug from title for slug-only service when both slug and tmdb_id are null`() {
+            val entry = TraktWatchedEntry(TraktShow("Breaking Bad", 2008, TraktIds(tmdb = null, slug = null)))
+            val services = listOf(
+                StreamingService("joyn", "Joyn", "pkg", "https://joyn.de/serien/{slug}")
+            )
+            assertEquals("https://joyn.de/serien/breaking-bad", viewModel.resolveDeepLink(entry, services))
+        }
+
+        // ── Service priority and fallback ─────────────────────────────────────
+
+        @Test
+        fun `returns first subscribed service link when all ids available`() {
             val entry = TraktWatchedEntry(TraktShow("Test", 2024, TraktIds(tmdb = 1, slug = "test")))
             val services = listOf(
                 StreamingService("disney", "Disney+", "pkg", "https://disney.com/{tmdb_id}"),
                 StreamingService("netflix", "Netflix", "pkg", "https://netflix.com/{tmdb_id}")
             )
-            val result = viewModel.resolveDeepLink(entry, services)
-            assertEquals("https://disney.com/1", result)
+            assertEquals("https://disney.com/1", viewModel.resolveDeepLink(entry, services))
         }
 
         @Test
-        fun `falls back to first known service when subscribed list empty`() {
+        fun `skips Netflix and falls back to WaipuTV when tmdb_id is null`() {
+            val entry = TraktWatchedEntry(TraktShow("Test", 2024, TraktIds(tmdb = null, slug = "test")))
+            val services = listOf(
+                StreamingService("netflix", "Netflix", "pkg", "https://netflix.com/title/{tmdb_id}"),
+                StreamingService("waipu",   "WaipuTV", "tv.waipu.app", "waipu://tv")
+            )
+            assertEquals("waipu://tv", viewModel.resolveDeepLink(entry, services))
+        }
+
+        @Test
+        fun `skips all id-requiring services and uses first slug-only service`() {
+            val entry = TraktWatchedEntry(TraktShow("Test", 2024, TraktIds(tmdb = null, slug = "test-show")))
+            val services = listOf(
+                StreamingService("netflix", "Netflix",  "pkg", "https://netflix.com/title/{tmdb_id}"),
+                StreamingService("disney",  "Disney+",  "pkg", "https://disney.com/series/{slug}/{tmdb_id}"),
+                StreamingService("prime",   "Prime",    "pkg", "https://www.primevideo.com/search?phrase={slug}")
+            )
+            assertEquals("https://www.primevideo.com/search?phrase=test-show", viewModel.resolveDeepLink(entry, services))
+        }
+
+        @Test
+        fun `returns null only when all subscribed services need an unavailable tmdb_id`() {
+            val entry = TraktWatchedEntry(TraktShow("Test", 2024, TraktIds(tmdb = null)))
+            val services = listOf(
+                StreamingService("netflix", "Netflix", "pkg", "https://netflix.com/title/{tmdb_id}"),
+                StreamingService("ard",     "ARD",     "pkg", "https://ard.de/video/{id}")
+            )
+            assertNull(viewModel.resolveDeepLink(entry, services))
+        }
+
+        @Test
+        fun `falls back to KNOWN_STREAMING_SERVICES when subscribed list is empty and tmdb_id present`() {
             val entry = TraktWatchedEntry(TraktShow("Test", 2024, TraktIds(tmdb = 1, slug = "test")))
             val result = viewModel.resolveDeepLink(entry, emptyList())
-            // Should use first KNOWN_STREAMING_SERVICES (netflix)
+            // Netflix is first in KNOWN_STREAMING_SERVICES and tmdb_id is available
             assertNotNull(result)
             assertTrue(result!!.contains("1"))
+        }
+
+        @Test
+        fun `falls back to slug-only service in KNOWN_STREAMING_SERVICES when tmdb_id is null`() {
+            val entry = TraktWatchedEntry(TraktShow("Test Show", 2024, TraktIds(tmdb = null, slug = "test-show")))
+            val result = viewModel.resolveDeepLink(entry, emptyList())
+            // Netflix and Disney+ fail (need tmdb_id); Prime Video succeeds with slug
+            assertNotNull(result)
+            assertTrue(result!!.contains("test-show"))
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #151 — the "Watch Now" button was silently broken for any show that lacked a TMDB ID, even when the user's preferred streaming service doesn't need one.

**Root cause:** `resolveDeepLink` called `entry.show.ids.tmdb ?: return null` before examining which service was selected, so WaipuTV (`waipu://tv`), Joyn (`{slug}`), Prime Video (`{slug}`), and ZDF (`{slug}`) all failed even though none of them require a TMDB ID. Additionally the old code only ever tried the *first* subscribed service — if that service couldn't produce a link, no fallback was attempted.

**Fix:** Iterate through subscribed services in priority order; skip a service only if its template contains `{tmdb_id}` or `{id}` and the TMDB ID is actually missing. Return the first link that can be generated. Null is returned only when every subscribed service has an unsatisfiable template requirement.

| Service | Template | Needs tmdb_id? | Fixed? |
|---------|----------|----------------|--------|
| Netflix | `…/title/{tmdb_id}` | ✅ yes | — (still correctly skipped when absent) |
| Disney+ | `…/{slug}/{tmdb_id}` | ✅ yes | — |
| ARD | `…/video/{id}` | ✅ yes | — |
| **WaipuTV** | `waipu://tv` | ❌ no | ✅ now works |
| **Joyn** | `…/serien/{slug}` | ❌ no | ✅ now works |
| **Prime Video** | `…/search?phrase={slug}` | ❌ no | ✅ now works |
| **ZDF** | `…/serien/{slug}` | ❌ no | ✅ now works |

## Changes

- `app-tv/…/showdetail/ShowDetailViewModel.kt` — `resolveDeepLink` rewritten to loop through services and skip those whose templates need an unavailable ID
- `app-tv/…/showdetail/ShowDetailViewModelTest.kt` — replaces former buggy-behaviour test with 18 targeted tests covering all service types, slug derivation, and service-priority fallback cascade

## Test plan

- [ ] `./gradlew :app-tv:test` passes (CI)
- [ ] Verify the 8 existing `availableServices` tests still pass
- [ ] Verify all 18 new `resolveDeepLink` tests pass:
  - Services requiring tmdb_id generate correct URLs when ID present
  - WaipuTV generates `waipu://tv` regardless of tmdb_id
  - Joyn, Prime Video, ZDF generate slug-based URLs without tmdb_id
  - Slug is derived from show title when `TraktIds.slug` is null
  - Returns first subscribed service link in priority order
  - Falls back past Netflix/Disney+/ARD to WaipuTV/Joyn/Prime when tmdb_id absent
  - Returns null only when ALL subscribed services need the unavailable ID
  - Falls back to `KNOWN_STREAMING_SERVICES` when subscribed list is empty

https://claude.ai/code/session_01KbC36m5uAFs3LVN2dwai4E