### PR TITLE
fix: use draft status for Play Store uploads on pre-1.0.0 releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,17 @@ jobs:
           UPDATED=$(printf "%s\n\n%b" "$EXISTING" "$DOWNLOADS")
           gh release edit "${TAG}" --notes "$UPDATED"
 
+      # -- Determine Play Store release status ------------------------------
+      - name: Determine Play Store release status
+        id: play-status
+        run: |
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          if [ "$MAJOR" -ge 1 ]; then
+            echo "status=completed" >> "$GITHUB_OUTPUT"
+          else
+            echo "status=draft" >> "$GITHUB_OUTPUT"
+          fi
+
       # -- Publish to Google Play Store ------------------------------------
       - name: Upload to Google Play Store
         if: steps.keystore.outputs.available == 'true' && steps.play-store.outputs.available == 'true'
@@ -193,7 +204,7 @@ jobs:
           packageName: com.justb81.watchbuddy
           releaseFiles: release-assets/*-release.aab
           track: internal
-          status: completed
+          status: ${{ steps.play-status.outputs.status }}
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Google Play rejects uploads with `status: completed` when the app is still in draft state (pre-1.0.0)
- Adds a step that dynamically determines the Play Store release status based on the major version number
- Pre-1.0.0 releases use `status: draft`, releases >= 1.0.0 use `status: completed`

## Test plan

- [ ] Verify the workflow YAML is syntactically valid (CI build passes)
- [ ] Next release (still < 1.0.0) should upload to Play Store successfully with draft status
- [ ] Once version reaches 1.0.0, verify the status switches to `completed` automatically

https://claude.ai/code/session_015EaFyiaYtPV7B9GJPRev3L