### PR TITLE
fix(tv): add missing permission, recommended TV manifest settings, and optimize versionCode scheme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ The `release-please--` prefix is reserved for the automated release-please bot â
 ### Distribution
 - **Google Play Store:** AABs are automatically uploaded to the **internal** track on each release. Promote to production via Google Play Console.
 - **GitHub Releases:** Signed APKs and AABs are attached to each GitHub Release for sideloading.
-- **Multi-APK delivery:** Both apps share `applicationId = com.justb81.watchbuddy` with different versionCode offsets (phone 1000+, TV 2000+). The TV manifest requires `android.software.leanback` so Google Play serves the correct AAB per device type.
+- **Multi-APK delivery:** Both apps share `applicationId = com.justb81.watchbuddy` with a multiplier-based versionCode scheme (`run_number * 10 + 1` for phone, `run_number * 10 + 2` for TV) to guarantee no collisions. The TV manifest requires `android.software.leanback` so Google Play serves the correct AAB per device type.
 - **CI secrets for Play Store:** `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` (Google Cloud service account key with Google Play Android Developer API access). If not set, the Play Store upload step is skipped gracefully.
 
 ### Localization

--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -15,10 +15,12 @@ android {
         minSdk = 26
         targetSdk = 35
 
-        // versionCode: CI sets VERSION_CODE (run_number). Phone offset 1000.
+        // versionCode: CI sets VERSION_CODE (run_number).
+        // Multiplier scheme avoids collisions between phone and TV APKs that
+        // share the same applicationId: phone = *10+1, TV = *10+2.
         val ciVersionCode = providers.environmentVariable("VERSION_CODE")
             .orElse("1").get().toIntOrNull() ?: 1
-        versionCode = 1000 + ciVersionCode
+        versionCode = ciVersionCode * 10 + 1
 
         // versionName: release-please sets VERSION_NAME, fallback to hardcoded value
         versionName = providers.environmentVariable("VERSION_NAME")

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -15,10 +15,12 @@ android {
         minSdk = 26
         targetSdk = 35
 
-        // versionCode: CI sets VERSION_CODE (run_number). TV offset 2000 (higher → Play prefers for TV).
+        // versionCode: CI sets VERSION_CODE (run_number).
+        // Multiplier scheme avoids collisions between phone and TV APKs that
+        // share the same applicationId: phone = *10+1, TV = *10+2.
         val ciVersionCode = providers.environmentVariable("VERSION_CODE")
             .orElse("1").get().toIntOrNull() ?: 1
-        versionCode = 2000 + ciVersionCode
+        versionCode = ciVersionCode * 10 + 2
 
         // versionName: release-please sets VERSION_NAME, fallback to hardcoded value
         versionName = providers.environmentVariable("VERSION_NAME")

--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <!-- Background sync -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
 
     <!-- Play Store: TV app — no touchscreen, leanback required for correct
          multi-APK device targeting (prevents phone devices from receiving the
@@ -20,8 +21,23 @@
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
     <uses-feature android:name="android.software.leanback" android:required="true" />
 
-    <!-- 64-bit required from August 2026 (arm64 only) -->
+    <!-- Declare TV hardware support without requiring it — the leanback
+         requirement above is the primary gate for Play Store device targeting. -->
     <uses-feature android:name="android.hardware.type.television" android:required="false" />
+
+    <!-- Hardware features unavailable on TV — declared as not required to
+         prevent implicit feature requirements from library dependencies. -->
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
+    <uses-feature android:name="android.hardware.camera.autofocus" android:required="false" />
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
+    <uses-feature android:name="android.hardware.telephony" android:required="false" />
+    <uses-feature android:name="android.hardware.sensor.accelerometer" android:required="false" />
+    <uses-feature android:name="android.hardware.sensor.compass" android:required="false" />
+    <uses-feature android:name="android.hardware.location.gps" android:required="false" />
+    <uses-feature android:name="android.hardware.nfc" android:required="false" />
+    <uses-feature android:name="android.hardware.usb.host" android:required="false" />
+    <uses-feature android:name="android.hardware.wifi.direct" android:required="false" />
+    <uses-feature android:name="android.hardware.bluetooth" android:required="false" />
 
     <application
         android:name=".WatchBuddyTvApp"
@@ -36,6 +52,7 @@
         <activity
             android:name=".tv.ui.TvMainActivity"
             android:exported="true"
+            android:screenOrientation="landscape"
             android:configChanges="keyboard|keyboardHidden|navigation"
             android:theme="@style/Theme.WatchBuddy">
             <intent-filter>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,7 +137,7 @@ does not block the others.
 | | Phone APK | TV APK |
 |---|---|---|
 | Package name | `com.justb81.watchbuddy` | `com.justb81.watchbuddy` |
-| versionCode | ~1000 | ~2000 |
+| versionCode | run_number × 10 + 1 | run_number × 10 + 2 |
 | LAUNCHER | ✅ | ❌ |
 | LEANBACK_LAUNCHER | ❌ | ✅ |
 | touchscreen required | true | false |


### PR DESCRIPTION
## Summary

- **Bug fix:** Add missing `FOREGROUND_SERVICE_DATA_SYNC` permission — required on Android 14+ (API 34) for `PhoneDiscoveryService` which uses `foregroundServiceType="dataSync"`. Without it, `startForeground()` throws a `SecurityException` on newer Google TV devices. The phone manifest already had this permission.
- **Defensive feature declarations:** Declare 11 TV-unavailable hardware features as `required="false"` (camera, microphone, telephony, sensors, GPS, NFC, USB, Wi-Fi Direct, Bluetooth). Prevents Play Store from filtering the app if a transitive dependency adds an implicit feature requirement via manifest merger.
- **Landscape orientation:** Add explicit `android:screenOrientation="landscape"` to `TvMainActivity` as recommended by Google for TV apps.
- **Fix misleading comment:** The comment on `android.hardware.type.television` incorrectly referenced 64-bit requirements; replaced with an accurate description.
- **Optimize versionCode scheme:** Replace the offset-based scheme (`phone 1000+N`, `TV 2000+N`) with a multiplier scheme (`phone N*10+1`, `TV N*10+2`). The old scheme would collide once `run_number` exceeds 1000. The new scheme guarantees unique codes up to ~214M builds and is trivially extensible for additional form factors.

## Test plan

- [ ] CI build (`build-android.yml`) passes
- [ ] Verify merged manifest contains all new `uses-feature` declarations
- [ ] Test `PhoneDiscoveryService` on an Android 14+ TV device — no `SecurityException` on `startForeground()`
- [ ] Confirm versionCode values: e.g. for `run_number=100` → phone=1001, TV=1002

https://claude.ai/code/session_01U4ok2k5WvJhevUx9yxJstu