### PR TITLE
feat(phone): automatic Trakt token refresh via TokenRefreshManager

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRefreshManager.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRefreshManager.kt
@@ -1,0 +1,142 @@
+package com.justb81.watchbuddy.phone.auth
+
+import android.util.Log
+import com.justb81.watchbuddy.core.network.TokenProxyServiceFactory
+import com.justb81.watchbuddy.core.trakt.ProxyRefreshRequest
+import com.justb81.watchbuddy.core.trakt.RefreshTokenRequest
+import com.justb81.watchbuddy.core.trakt.TokenProxyService
+import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import com.justb81.watchbuddy.phone.ui.settings.AuthMode
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
+import javax.inject.Named
+import javax.inject.Singleton
+
+private const val TAG = "TokenRefreshManager"
+
+/**
+ * Ensures the app always has a valid Trakt access token.
+ *
+ * Call [getValidAccessToken] before any authenticated API request. If the stored token is
+ * still valid it is returned immediately. If it has expired (or will expire within
+ * [REFRESH_BUFFER_MS]) a refresh is attempted via the appropriate backend depending on
+ * the user's configured [AuthMode]:
+ *
+ * - **MANAGED** — calls `POST /trakt/token/refresh` on the WatchBuddy token proxy.
+ * - **SELF_HOSTED** — calls the same endpoint on the user-supplied proxy URL.
+ * - **DIRECT** — calls `POST /oauth/token` directly on the Trakt API.
+ *
+ * A [Mutex] serialises concurrent refresh attempts so that only one network call is
+ * made even when multiple requests arrive simultaneously with an expired token.
+ */
+@Singleton
+class TokenRefreshManager @Inject constructor(
+    private val tokenRepository: TokenRepository,
+    private val settingsRepository: SettingsRepository,
+    private val traktApi: TraktApiService,
+    private val tokenProxy: TokenProxyService?,
+    private val tokenProxyServiceFactory: TokenProxyServiceFactory,
+    @Named("traktClientId") private val clientId: String
+) {
+    private val mutex = Mutex()
+
+    /**
+     * Returns a valid access token, refreshing it first if it has expired or is about to.
+     *
+     * Returns `null` when:
+     * - no token is stored (user never authenticated), or
+     * - no refresh token is available, or
+     * - the refresh call fails (network error, revoked token, etc.).
+     */
+    suspend fun getValidAccessToken(): String? {
+        // Fast path — token is valid and not expiring soon; no lock needed.
+        if (!tokenRepository.isTokenExpiredOrExpiringSoon(REFRESH_BUFFER_MS)) {
+            return tokenRepository.getAccessToken()
+        }
+
+        // Slow path — refresh under lock to avoid duplicate refresh calls.
+        mutex.withLock {
+            // Re-check after acquiring the lock; another coroutine may have already
+            // refreshed the token while we were waiting.
+            if (!tokenRepository.isTokenExpiredOrExpiringSoon(REFRESH_BUFFER_MS)) {
+                return tokenRepository.getAccessToken()
+            }
+
+            return performRefresh()
+        }
+    }
+
+    private suspend fun performRefresh(): String? {
+        val refreshToken = tokenRepository.getRefreshToken()
+        if (refreshToken.isNullOrBlank()) {
+            Log.w(TAG, "No refresh token available — user must re-authenticate")
+            return null
+        }
+
+        return try {
+            val settings = settingsRepository.settings.first()
+            val (accessToken, newRefreshToken, expiresIn) = when (settings.authMode) {
+                AuthMode.MANAGED -> refreshViaManagedProxy(refreshToken)
+                AuthMode.SELF_HOSTED -> refreshViaSelfHostedProxy(refreshToken, settings.backendUrl)
+                AuthMode.DIRECT -> refreshViaTraktDirect(refreshToken, settings.directClientId)
+            } ?: return null
+
+            tokenRepository.saveTokens(accessToken, newRefreshToken, expiresIn)
+            Log.d(TAG, "Token refreshed successfully (mode=${settings.authMode})")
+            accessToken
+        } catch (e: Exception) {
+            Log.e(TAG, "Token refresh failed", e)
+            null
+        }
+    }
+
+    private suspend fun refreshViaManagedProxy(refreshToken: String): Triple<String, String, Int>? {
+        val proxy = tokenProxy ?: run {
+            Log.w(TAG, "Managed proxy not available — cannot refresh")
+            return null
+        }
+        val response = proxy.refreshToken(ProxyRefreshRequest(refresh_token = refreshToken))
+        return Triple(response.access_token, response.refresh_token, response.expires_in)
+    }
+
+    private suspend fun refreshViaSelfHostedProxy(
+        refreshToken: String,
+        backendUrl: String
+    ): Triple<String, String, Int>? {
+        if (backendUrl.isBlank()) {
+            Log.w(TAG, "Self-hosted backend URL not configured — cannot refresh")
+            return null
+        }
+        val proxy = tokenProxyServiceFactory.create(backendUrl)
+        val response = proxy.refreshToken(ProxyRefreshRequest(refresh_token = refreshToken))
+        return Triple(response.access_token, response.refresh_token, response.expires_in)
+    }
+
+    private suspend fun refreshViaTraktDirect(
+        refreshToken: String,
+        directClientId: String
+    ): Triple<String, String, Int>? {
+        val effectiveClientId = directClientId.ifBlank { clientId }
+        val clientSecret = settingsRepository.getClientSecret()
+        if (effectiveClientId.isBlank() || clientSecret.isBlank()) {
+            Log.w(TAG, "DIRECT mode: client ID or secret missing — cannot refresh")
+            return null
+        }
+        val response = traktApi.refreshToken(
+            RefreshTokenRequest(
+                refresh_token = refreshToken,
+                client_id = effectiveClientId,
+                client_secret = clientSecret
+            )
+        )
+        return Triple(response.access_token, response.refresh_token, response.expires_in)
+    }
+
+    companion object {
+        /** Refresh the token this many milliseconds before it actually expires. */
+        const val REFRESH_BUFFER_MS = 5 * 60 * 1_000L // 5 minutes
+    }
+}

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRepository.kt
@@ -40,6 +40,18 @@ class TokenRepository(context: Context) {
         return System.currentTimeMillis() < expiresAt
     }
 
+    /**
+     * Returns `true` when the access token is missing, blank, already expired, or will
+     * expire within [bufferMs] milliseconds. Used by [TokenRefreshManager] to trigger a
+     * proactive refresh before the token actually expires.
+     */
+    fun isTokenExpiredOrExpiringSoon(bufferMs: Long): Boolean {
+        val token = getAccessToken()
+        if (token.isNullOrBlank()) return true
+        val expiresAt = prefs.getLong(KEY_EXPIRES_AT, 0L)
+        return System.currentTimeMillis() + bufferMs >= expiresAt
+    }
+
     fun clearTokens() {
         prefs.edit()
             .remove(KEY_ACCESS_TOKEN)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.justb81.watchbuddy.core.locale.LocaleHelper
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.core.tmdb.TmdbCache
+import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.llm.RecapGenerator
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
@@ -45,6 +46,7 @@ class CompanionHttpServer @Inject constructor(
     private val capabilityProvider: DeviceCapabilityProvider,
     private val showRepository: ShowRepository,
     private val tokenRepository: TokenRepository,
+    private val tokenRefreshManager: TokenRefreshManager,
     private val tmdbApiService: TmdbApiService,
     private val tmdbCache: TmdbCache,
     private val settingsRepository: SettingsRepository
@@ -59,7 +61,7 @@ class CompanionHttpServer @Inject constructor(
         server = embeddedServer(Netty, port = PORT) {
             configureCompanionRoutes(
                 recapGenerator, capabilityProvider, showRepository,
-                tokenRepository, tmdbApiService, tmdbCache, settingsRepository
+                tokenRepository, tokenRefreshManager, tmdbApiService, tmdbCache, settingsRepository
             )
         }.start(wait = false)
     }
@@ -79,6 +81,7 @@ internal fun Application.configureCompanionRoutes(
     capabilityProvider: DeviceCapabilityProvider,
     showRepository: ShowRepository,
     tokenRepository: TokenRepository,
+    tokenRefreshManager: TokenRefreshManager,
     tmdbApiService: TmdbApiService,
     tmdbCache: TmdbCache,
     settingsRepository: SettingsRepository
@@ -186,7 +189,7 @@ internal fun Application.configureCompanionRoutes(
         }
 
         get("/auth/token") {
-            val token = tokenRepository.getAccessToken()
+            val token = tokenRefreshManager.getValidAccessToken()
                 ?: return@get call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
             call.respond(TokenResponse(accessToken = token))
         }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
@@ -2,14 +2,14 @@ package com.justb81.watchbuddy.phone.server
 
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.trakt.TraktApiService
-import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class ShowRepository @Inject constructor(
     private val traktApi: TraktApiService,
-    private val tokenRepository: TokenRepository
+    private val tokenRefreshManager: TokenRefreshManager
 ) {
     private var cachedShows: List<TraktWatchedEntry> = emptyList()
     private var lastFetch: Long = 0L
@@ -17,7 +17,7 @@ class ShowRepository @Inject constructor(
     suspend fun getShows(): List<TraktWatchedEntry> {
         val now = System.currentTimeMillis()
         if (now - lastFetch > CACHE_TTL || cachedShows.isEmpty()) {
-            val token = tokenRepository.getAccessToken()
+            val token = tokenRefreshManager.getValidAccessToken()
                 ?: return emptyList()
             cachedShows = traktApi.getWatchedShows("Bearer $token")
             lastFetch = now

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRefreshManagerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRefreshManagerTest.kt
@@ -1,0 +1,376 @@
+package com.justb81.watchbuddy.phone.auth
+
+import com.justb81.watchbuddy.core.network.TokenProxyServiceFactory
+import com.justb81.watchbuddy.core.trakt.DeviceTokenResponse
+import com.justb81.watchbuddy.core.trakt.ProxyRefreshRequest
+import com.justb81.watchbuddy.core.trakt.ProxyTokenResponse
+import com.justb81.watchbuddy.core.trakt.RefreshTokenRequest
+import com.justb81.watchbuddy.core.trakt.TokenProxyService
+import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.phone.settings.AppSettings
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import com.justb81.watchbuddy.phone.ui.settings.AuthMode
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("TokenRefreshManager")
+class TokenRefreshManagerTest {
+
+    private val tokenRepository: TokenRepository = mockk(relaxed = true)
+    private val settingsRepository: SettingsRepository = mockk(relaxed = true)
+    private val traktApi: TraktApiService = mockk(relaxed = true)
+    private val tokenProxy: TokenProxyService = mockk(relaxed = true)
+    private val tokenProxyServiceFactory: TokenProxyServiceFactory = mockk(relaxed = true)
+    private val buildClientId = "build-client-id"
+
+    private lateinit var manager: TokenRefreshManager
+
+    private val proxyTokenResponse = ProxyTokenResponse(
+        access_token = "new-access-token",
+        refresh_token = "new-refresh-token",
+        expires_in = 7776000,
+        token_type = "Bearer",
+        scope = "public"
+    )
+
+    private val traktTokenResponse = DeviceTokenResponse(
+        access_token = "new-access-token",
+        token_type = "Bearer",
+        expires_in = 7776000,
+        refresh_token = "new-refresh-token",
+        scope = "public"
+    )
+
+    @BeforeEach
+    fun setUp() {
+        manager = TokenRefreshManager(
+            tokenRepository = tokenRepository,
+            settingsRepository = settingsRepository,
+            traktApi = traktApi,
+            tokenProxy = tokenProxy,
+            tokenProxyServiceFactory = tokenProxyServiceFactory,
+            clientId = buildClientId
+        )
+    }
+
+    // ── Fast path ─────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("when token is valid and not expiring soon")
+    inner class ValidToken {
+
+        @Test
+        fun `returns stored token without refreshing`() = runTest {
+            every { tokenRepository.isTokenExpiredOrExpiringSoon(any()) } returns false
+            every { tokenRepository.getAccessToken() } returns "valid-token"
+
+            val result = manager.getValidAccessToken()
+
+            assertEquals("valid-token", result)
+            coVerify(exactly = 0) { tokenProxy.refreshToken(any()) }
+            coVerify(exactly = 0) { traktApi.refreshToken(any()) }
+        }
+    }
+
+    // ── MANAGED mode ──────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("MANAGED auth mode")
+    inner class ManagedMode {
+
+        @BeforeEach
+        fun setUpManagedMode() {
+            every { tokenRepository.isTokenExpiredOrExpiringSoon(any()) } returns true
+            every { tokenRepository.getRefreshToken() } returns "old-refresh-token"
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+        }
+
+        @Test
+        fun `refreshes via managed proxy and returns new token`() = runTest {
+            coEvery { tokenProxy.refreshToken(ProxyRefreshRequest("old-refresh-token")) } returns proxyTokenResponse
+
+            val result = manager.getValidAccessToken()
+
+            assertEquals("new-access-token", result)
+            verify {
+                tokenRepository.saveTokens("new-access-token", "new-refresh-token", 7776000)
+            }
+        }
+
+        @Test
+        fun `returns null when managed proxy is not configured`() = runTest {
+            val managerWithoutProxy = TokenRefreshManager(
+                tokenRepository = tokenRepository,
+                settingsRepository = settingsRepository,
+                traktApi = traktApi,
+                tokenProxy = null,
+                tokenProxyServiceFactory = tokenProxyServiceFactory,
+                clientId = buildClientId
+            )
+
+            val result = managerWithoutProxy.getValidAccessToken()
+
+            assertNull(result)
+        }
+
+        @Test
+        fun `returns null when proxy refresh call throws`() = runTest {
+            coEvery { tokenProxy.refreshToken(any()) } throws RuntimeException("Network error")
+
+            val result = manager.getValidAccessToken()
+
+            assertNull(result)
+        }
+    }
+
+    // ── SELF_HOSTED mode ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("SELF_HOSTED auth mode")
+    inner class SelfHostedMode {
+
+        private val selfHostedProxy: TokenProxyService = mockk()
+
+        @BeforeEach
+        fun setUpSelfHostedMode() {
+            every { tokenRepository.isTokenExpiredOrExpiringSoon(any()) } returns true
+            every { tokenRepository.getRefreshToken() } returns "old-refresh-token"
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(
+                    authMode = AuthMode.SELF_HOSTED,
+                    backendUrl = "https://my-proxy.example.com"
+                )
+            )
+            every { tokenProxyServiceFactory.create("https://my-proxy.example.com") } returns selfHostedProxy
+        }
+
+        @Test
+        fun `refreshes via self-hosted proxy and returns new token`() = runTest {
+            coEvery {
+                selfHostedProxy.refreshToken(ProxyRefreshRequest("old-refresh-token"))
+            } returns proxyTokenResponse
+
+            val result = manager.getValidAccessToken()
+
+            assertEquals("new-access-token", result)
+            verify {
+                tokenRepository.saveTokens("new-access-token", "new-refresh-token", 7776000)
+            }
+        }
+
+        @Test
+        fun `returns null when backend URL is blank`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.SELF_HOSTED, backendUrl = "")
+            )
+
+            val result = manager.getValidAccessToken()
+
+            assertNull(result)
+            coVerify(exactly = 0) { selfHostedProxy.refreshToken(any()) }
+        }
+
+        @Test
+        fun `returns null when self-hosted proxy refresh call throws`() = runTest {
+            coEvery { selfHostedProxy.refreshToken(any()) } throws RuntimeException("Proxy error")
+
+            val result = manager.getValidAccessToken()
+
+            assertNull(result)
+        }
+    }
+
+    // ── DIRECT mode ───────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("DIRECT auth mode")
+    inner class DirectMode {
+
+        @BeforeEach
+        fun setUpDirectMode() {
+            every { tokenRepository.isTokenExpiredOrExpiringSoon(any()) } returns true
+            every { tokenRepository.getRefreshToken() } returns "old-refresh-token"
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.DIRECT, directClientId = "user-client-id")
+            )
+            every { settingsRepository.getClientSecret() } returns "user-client-secret"
+        }
+
+        @Test
+        fun `refreshes directly via Trakt API and returns new token`() = runTest {
+            coEvery {
+                traktApi.refreshToken(
+                    RefreshTokenRequest(
+                        refresh_token = "old-refresh-token",
+                        client_id = "user-client-id",
+                        client_secret = "user-client-secret"
+                    )
+                )
+            } returns traktTokenResponse
+
+            val result = manager.getValidAccessToken()
+
+            assertEquals("new-access-token", result)
+            verify {
+                tokenRepository.saveTokens("new-access-token", "new-refresh-token", 7776000)
+            }
+        }
+
+        @Test
+        fun `uses build-time clientId when directClientId is blank`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.DIRECT, directClientId = "")
+            )
+            coEvery {
+                traktApi.refreshToken(
+                    RefreshTokenRequest(
+                        refresh_token = "old-refresh-token",
+                        client_id = buildClientId,
+                        client_secret = "user-client-secret"
+                    )
+                )
+            } returns traktTokenResponse
+
+            val result = manager.getValidAccessToken()
+
+            assertEquals("new-access-token", result)
+        }
+
+        @Test
+        fun `returns null when client secret is blank`() = runTest {
+            every { settingsRepository.getClientSecret() } returns ""
+
+            val result = manager.getValidAccessToken()
+
+            assertNull(result)
+            coVerify(exactly = 0) { traktApi.refreshToken(any()) }
+        }
+
+        @Test
+        fun `returns null when both client IDs are blank`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.DIRECT, directClientId = "")
+            )
+            val managerWithoutBuildClientId = TokenRefreshManager(
+                tokenRepository = tokenRepository,
+                settingsRepository = settingsRepository,
+                traktApi = traktApi,
+                tokenProxy = tokenProxy,
+                tokenProxyServiceFactory = tokenProxyServiceFactory,
+                clientId = ""
+            )
+
+            val result = managerWithoutBuildClientId.getValidAccessToken()
+
+            assertNull(result)
+            coVerify(exactly = 0) { traktApi.refreshToken(any()) }
+        }
+
+        @Test
+        fun `returns null when Trakt refresh call throws`() = runTest {
+            coEvery { traktApi.refreshToken(any()) } throws RuntimeException("Trakt API error")
+
+            val result = manager.getValidAccessToken()
+
+            assertNull(result)
+        }
+    }
+
+    // ── No refresh token ──────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("when no refresh token is stored")
+    inner class NoRefreshToken {
+
+        @Test
+        fun `returns null without calling any refresh endpoint`() = runTest {
+            every { tokenRepository.isTokenExpiredOrExpiringSoon(any()) } returns true
+            every { tokenRepository.getRefreshToken() } returns null
+
+            val result = manager.getValidAccessToken()
+
+            assertNull(result)
+            coVerify(exactly = 0) { tokenProxy.refreshToken(any()) }
+            coVerify(exactly = 0) { traktApi.refreshToken(any()) }
+        }
+
+        @Test
+        fun `returns null when refresh token is blank`() = runTest {
+            every { tokenRepository.isTokenExpiredOrExpiringSoon(any()) } returns true
+            every { tokenRepository.getRefreshToken() } returns ""
+
+            val result = manager.getValidAccessToken()
+
+            assertNull(result)
+        }
+    }
+
+    // ── Post-refresh re-use ───────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("after a successful refresh")
+    inner class PostRefresh {
+
+        @Test
+        fun `second call skips refresh when token becomes valid`() = runTest {
+            // First call: token is expired — triggers refresh
+            every { tokenRepository.isTokenExpiredOrExpiringSoon(any()) } returns true
+            every { tokenRepository.getRefreshToken() } returns "old-refresh-token"
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { tokenProxy.refreshToken(any()) } returns proxyTokenResponse
+            every { tokenRepository.getAccessToken() } returns "new-access-token"
+
+            val first = manager.getValidAccessToken()
+            assertEquals("new-access-token", first)
+
+            // Simulate that saveTokens made the token valid
+            every { tokenRepository.isTokenExpiredOrExpiringSoon(any()) } returns false
+
+            val second = manager.getValidAccessToken()
+            assertEquals("new-access-token", second)
+
+            // Proxy only called once across both calls
+            coVerify(exactly = 1) { tokenProxy.refreshToken(any()) }
+        }
+
+        @Test
+        fun `concurrent callers obtain a token and proxy is called at most once`() = runTest {
+            var tokenSaved = false
+            // Before saveTokens: token appears expired; after: it appears valid
+            every { tokenRepository.isTokenExpiredOrExpiringSoon(any()) } answers { !tokenSaved }
+            every { tokenRepository.saveTokens(any(), any(), any()) } answers { tokenSaved = true }
+            every { tokenRepository.getRefreshToken() } returns "old-refresh-token"
+            every { tokenRepository.getAccessToken() } returns "new-access-token"
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { tokenProxy.refreshToken(any()) } returns proxyTokenResponse
+
+            val results = (1..5).map {
+                async { manager.getValidAccessToken() }
+            }.awaitAll()
+
+            results.forEach { assertNotNull(it) }
+            // Mutex serialises concurrent requests — at most one refresh call is made
+            coVerify(atMost = 1) { tokenProxy.refreshToken(any()) }
+        }
+    }
+}

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -11,6 +11,7 @@ import com.justb81.watchbuddy.core.model.TraktWatchedEpisode
 import com.justb81.watchbuddy.core.model.TraktWatchedSeason
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.core.tmdb.TmdbCache
+import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.llm.RecapGenerator
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
@@ -35,6 +36,7 @@ class CompanionHttpServerTest {
     private val capabilityProvider: DeviceCapabilityProvider = mockk()
     private val showRepository: ShowRepository = mockk()
     private val tokenRepository: TokenRepository = mockk()
+    private val tokenRefreshManager: TokenRefreshManager = mockk()
     private val tmdbApiService: TmdbApiService = mockk()
     private val tmdbCache = TmdbCache()
     private val settingsRepository: SettingsRepository = mockk()
@@ -79,7 +81,7 @@ class CompanionHttpServerTest {
         application {
             configureCompanionRoutes(
                 recapGenerator, capabilityProvider, showRepository,
-                tokenRepository, tmdbApiService, tmdbCache, settingsRepository
+                tokenRepository, tokenRefreshManager, tmdbApiService, tmdbCache, settingsRepository
             )
         }
         block()
@@ -523,8 +525,8 @@ class CompanionHttpServerTest {
     inner class AuthTokenEndpoint {
 
         @Test
-        fun `returns 401 when no access token`() = testApp {
-            every { tokenRepository.getAccessToken() } returns null
+        fun `returns 401 when token refresh returns null`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns null
 
             val response = client.get("/auth/token")
 
@@ -532,8 +534,8 @@ class CompanionHttpServerTest {
         }
 
         @Test
-        fun `returns 200 with access token`() = testApp {
-            every { tokenRepository.getAccessToken() } returns "my-secret-token"
+        fun `returns 200 with valid access token after refresh`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "my-secret-token"
 
             val response = client.get("/auth/token")
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
@@ -4,7 +4,7 @@ import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.trakt.TraktApiService
-import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import io.mockk.*
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test
 class ShowRepositoryTest {
 
     private val traktApi: TraktApiService = mockk()
-    private val tokenRepository: TokenRepository = mockk()
+    private val tokenRefreshManager: TokenRefreshManager = mockk()
     private lateinit var repository: ShowRepository
 
     private val testShows = listOf(
@@ -26,12 +26,12 @@ class ShowRepositoryTest {
 
     @BeforeEach
     fun setUp() {
-        repository = ShowRepository(traktApi, tokenRepository)
+        repository = ShowRepository(traktApi, tokenRefreshManager)
     }
 
     @Test
     fun `getShows fetches from API on first call`() = runTest {
-        every { tokenRepository.getAccessToken() } returns "test-token"
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
         coEvery { traktApi.getWatchedShows("Bearer test-token") } returns testShows
 
         val result = repository.getShows()
@@ -42,7 +42,7 @@ class ShowRepositoryTest {
 
     @Test
     fun `getShows returns cached result on second call`() = runTest {
-        every { tokenRepository.getAccessToken() } returns "test-token"
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
         coEvery { traktApi.getWatchedShows(any()) } returns testShows
 
         repository.getShows()
@@ -52,8 +52,8 @@ class ShowRepositoryTest {
     }
 
     @Test
-    fun `getShows returns empty list when no token`() = runTest {
-        every { tokenRepository.getAccessToken() } returns null
+    fun `getShows returns empty list when token refresh fails`() = runTest {
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns null
 
         val result = repository.getShows()
         assertTrue(result.isEmpty())
@@ -62,7 +62,7 @@ class ShowRepositoryTest {
 
     @Test
     fun `getShows calls API with Bearer token`() = runTest {
-        every { tokenRepository.getAccessToken() } returns "my-secret-token"
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns "my-secret-token"
         coEvery { traktApi.getWatchedShows("Bearer my-secret-token") } returns testShows
 
         repository.getShows()


### PR DESCRIPTION
Closes #156.

## Summary

- **New `TokenRefreshManager` singleton** — checks the stored access token against a 5-minute expiry buffer and refreshes proactively via the correct backend for the user's configured auth mode (MANAGED proxy, SELF_HOSTED proxy, or direct Trakt API). A `Mutex` serialises concurrent callers so only one network refresh is ever in flight at a time.
- **`TokenRepository.isTokenExpiredOrExpiringSoon(bufferMs)`** — new method that returns `true` if the token is missing, blank, already expired, or will expire within the given buffer window.
- **`ShowRepository`** — replaced `tokenRepository.getAccessToken()` with `tokenRefreshManager.getValidAccessToken()` so watched-shows fetches transparently refresh the token when needed.
- **`CompanionHttpServer /auth/token`** — same change: the TV app always receives a fresh token.
- **`TokenRefreshManagerTest`** — 14 new tests covering all three auth modes (MANAGED, SELF_HOSTED, DIRECT), the null/blank refresh-token guard, individual failure paths (proxy null, blank URL, missing credentials, network exception), post-refresh re-use without a second network call, and mutex serialisation for concurrent callers.
- **`ShowRepositoryTest` / `CompanionHttpServerTest`** — updated to inject/mock `TokenRefreshManager` instead of `TokenRepository` for the token-fetch paths.

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Token expires after ~3 months | Every API call fails silently; user must re-authenticate | Token is refreshed automatically in the background |
| TV app requests `/auth/token` | Returns stale/expired token | Returns a freshly refreshed token |
| Multiple concurrent requests with expired token | Each caller attempts a separate refresh | Mutex ensures exactly one refresh call; others wait and get the result |

## Test plan

- [ ] CI build (`build-android.yml`) passes green
- [ ] `TokenRefreshManagerTest` — all 14 tests pass
- [ ] `ShowRepositoryTest` — all 4 tests pass
- [ ] `CompanionHttpServerTest` — all existing tests pass

https://claude.ai/code/session_01LfMWoKW1gkiWdVgiV5mg1N