### PR TITLE
fix(phone): handle Trakt API exceptions in ShowRepository and serve stale cache

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
@@ -1,10 +1,13 @@
 package com.justb81.watchbuddy.phone.server
 
+import android.util.Log
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import javax.inject.Inject
 import javax.inject.Singleton
+
+private const val TAG = "ShowRepository"
 
 @Singleton
 class ShowRepository @Inject constructor(
@@ -19,8 +22,13 @@ class ShowRepository @Inject constructor(
         if (now - lastFetch > CACHE_TTL || cachedShows.isEmpty()) {
             val token = tokenRepository.getAccessToken()
                 ?: return emptyList()
-            cachedShows = traktApi.getWatchedShows("Bearer $token")
-            lastFetch = now
+            try {
+                cachedShows = traktApi.getWatchedShows("Bearer $token")
+                lastFetch = now
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to fetch shows from Trakt; serving ${cachedShows.size} cached entries", e)
+                // Do not update lastFetch so the next call retries the API.
+            }
         }
         return cachedShows
     }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
@@ -68,4 +68,55 @@ class ShowRepositoryTest {
         repository.getShows()
         coVerify { traktApi.getWatchedShows("Bearer my-secret-token") }
     }
+
+    @Test
+    fun `getShows returns empty list when API throws with no prior cache`() = runTest {
+        every { tokenRepository.getAccessToken() } returns "test-token"
+        coEvery { traktApi.getWatchedShows(any()) } throws RuntimeException("Network error")
+
+        val result = repository.getShows()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `getShows returns stale cached data when API throws after a successful fetch`() = runTest {
+        every { tokenRepository.getAccessToken() } returns "test-token"
+        coEvery { traktApi.getWatchedShows(any()) } returns testShows
+
+        // Prime the cache with a successful fetch
+        repository.getShows()
+
+        // Simulate cache TTL expiry by resetting lastFetch to 0 via reflection
+        ShowRepository::class.java.getDeclaredField("lastFetch").apply {
+            isAccessible = true
+            setLong(repository, 0L)
+        }
+
+        // API now throws on the refresh attempt
+        coEvery { traktApi.getWatchedShows(any()) } throws RuntimeException("Trakt unavailable")
+
+        // Stale cached data should be returned instead of propagating the exception
+        val result = repository.getShows()
+
+        assertEquals(2, result.size)
+        // API was retried (two total calls: initial fetch + failed refresh attempt)
+        coVerify(exactly = 2) { traktApi.getWatchedShows(any()) }
+    }
+
+    @Test
+    fun `getShows retries API on next call after a failure`() = runTest {
+        every { tokenRepository.getAccessToken() } returns "test-token"
+        // First call: API throws
+        coEvery { traktApi.getWatchedShows(any()) } throws RuntimeException("Network error")
+        repository.getShows()
+
+        // Second call: API succeeds
+        coEvery { traktApi.getWatchedShows(any()) } returns testShows
+        val result = repository.getShows()
+
+        // Both calls should have hit the API because lastFetch was not updated on failure
+        coVerify(exactly = 2) { traktApi.getWatchedShows(any()) }
+        assertEquals(2, result.size)
+    }
 }


### PR DESCRIPTION
Closes #158.

## Summary

- **`ShowRepository.getShows()`** — wraps `traktApi.getWatchedShows()` in a try/catch. On failure the exception is logged and the current value of `cachedShows` is returned (stale data when available, empty list on the first call). `lastFetch` is deliberately NOT updated on failure, so the next request will retry the API.
- **Three new `ShowRepositoryTest` cases:**
  - `returns empty list when API throws with no prior cache` — no stale data available, empty list returned
  - `returns stale cached data when API throws after a successful fetch` — TTL expiry simulated via reflection, stale cache served
  - `retries API on next call after a failure` — verifies `lastFetch` is not updated on error, so exactly two API calls are made across two `getShows()` invocations

## Before / After

| Scenario | Before | After |
|----------|--------|-------|
| Trakt API throws a network error | Exception propagates to `CompanionHttpServer`; TV app receives HTTP 500 | Exception caught; stale cached shows returned (or empty list if no cache) |
| Trakt API transiently unavailable | Every call returns 500 until API recovers | Stale cache served; API retried on every subsequent call |
| First call ever with API unavailable | Exception propagates | Empty list returned gracefully |

## Test plan

- [ ] CI build (`build-android.yml`) passes green
- [ ] `ShowRepositoryTest` — all 7 tests pass (4 existing + 3 new)

https://claude.ai/code/session_01Qr2Q6GZDYp8KgSXScf6tTi