### PR TITLE
fix(phone): replace exception messages in HTTP error responses with generic strings

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -102,7 +102,7 @@ internal fun Application.configureCompanionRoutes(
                 call.respond(shows)
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch shows", e)
-                call.respond(HttpStatusCode.InternalServerError, ErrorResponse(e.message ?: "Unknown error"))
+                call.respond(HttpStatusCode.InternalServerError, ErrorResponse("Internal server error"))
             }
         }
 
@@ -181,7 +181,7 @@ internal fun Application.configureCompanionRoutes(
                 call.respond(mapOf("html" to html))
             } catch (e: Exception) {
                 Log.e(TAG, "Recap generation failed for show $showId", e)
-                call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Recap generation failed: ${e.message}"))
+                call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Recap generation failed"))
             }
         }
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -142,14 +142,15 @@ class CompanionHttpServerTest {
         }
 
         @Test
-        fun `returns 500 when show repository throws`() = testApp {
+        fun `returns 500 when show repository throws — no exception detail leaked`() = testApp {
             every { tokenRepository.getAccessToken() } returns "test-token"
             coEvery { showRepository.getShows() } throws RuntimeException("Trakt API down")
 
             val response = client.get("/shows")
 
             assertEquals(HttpStatusCode.InternalServerError, response.status)
-            assertTrue(response.bodyAsText().contains("Trakt API down"))
+            assertTrue(response.bodyAsText().contains("Internal server error"))
+            assertFalse(response.bodyAsText().contains("Trakt API down"))
         }
 
         @Test
@@ -447,7 +448,7 @@ class CompanionHttpServerTest {
         }
 
         @Test
-        fun `returns 503 when recap generation throws`() = testApp {
+        fun `returns 503 when recap generation throws — no exception detail leaked`() = testApp {
             every { tokenRepository.getAccessToken() } returns "token"
             coEvery { showRepository.getShows() } returns listOf(watchedEntry)
             coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
@@ -460,6 +461,8 @@ class CompanionHttpServerTest {
             }
 
             assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+            assertTrue(response.bodyAsText().contains("Recap generation failed"))
+            assertFalse(response.bodyAsText().contains("LLM crashed"))
         }
 
         @Test


### PR DESCRIPTION
Closes #160.

## Summary

- **`CompanionHttpServer` — `/shows` endpoint**: replaced `ErrorResponse(e.message ?: "Unknown error")` with `ErrorResponse("Internal server error")`. Internal exception text no longer reaches the caller.
- **`CompanionHttpServer` — `/recap/{traktShowId}` endpoint**: replaced `ErrorResponse("Recap generation failed: ${e.message}")` with `ErrorResponse("Recap generation failed")`. Same fix.
- **`CompanionHttpServerTest`**: updated the existing `returns 500 when show repository throws` test to assert the generic message is present **and** the internal exception detail (`"Trakt API down"`) is absent. Extended the `returns 503 when recap generation throws` test with equivalent body assertions (`"Recap generation failed"` present, `"LLM crashed"` absent).

## Before / After

| Endpoint | Exception thrown | Before (leaked) | After (safe) |
|----------|-----------------|-----------------|--------------|
| `GET /shows` | `RuntimeException("Trakt API down")` | `{"error":"Trakt API down"}` | `{"error":"Internal server error"}` |
| `POST /recap/{id}` | `RuntimeException("LLM crashed")` | `{"error":"Recap generation failed: LLM crashed"}` | `{"error":"Recap generation failed"}` |

Full exception details continue to be written to the Android log via `Log.e` — no diagnostic information is lost, it just stays on the device.

## Test plan

- [ ] CI build (`build-android.yml`) passes green
- [ ] `CompanionHttpServerTest` — all existing tests pass with updated assertions
- [ ] Response bodies for 500 and 503 do not contain any exception message text

https://claude.ai/code/session_013x3Ko1FsdyHGXQoGd9ktU5