### PR TITLE
feat(discovery): publish NSD TXT records on phone, cache them on TV for bestPhone ranking

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
@@ -12,6 +12,7 @@ import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
 import com.justb81.watchbuddy.phone.server.CompanionHttpServer
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -23,8 +24,9 @@ class CompanionService : Service() {
         private const val TAG = "CompanionService"
         const val CHANNEL_ID = "companion_service"
         private const val NOTIFICATION_ID = 1
-        private const val NSD_SERVICE_TYPE = "_http._tcp."
+        private const val NSD_SERVICE_TYPE = "_watchbuddy._tcp."
         private const val NSD_SERVICE_NAME = "watchbuddy-companion"
+        private const val NSD_TXT_VERSION = "1"
 
         fun start(context: Context) {
             val intent = Intent(context, CompanionService::class.java)
@@ -37,6 +39,7 @@ class CompanionService : Service() {
     }
 
     @Inject lateinit var companionHttpServer: CompanionHttpServer
+    @Inject lateinit var llmOrchestrator: LlmOrchestrator
 
     private var nsdManager: NsdManager? = null
     private var nsdRegistrationListener: NsdManager.RegistrationListener? = null
@@ -83,10 +86,14 @@ class CompanionService : Service() {
             .build()
 
     private fun registerNsd() {
+        val llmConfig = llmOrchestrator.selectConfig()
         val serviceInfo = NsdServiceInfo().apply {
             serviceName = NSD_SERVICE_NAME
             serviceType = NSD_SERVICE_TYPE
             port = CompanionHttpServer.PORT
+            setAttribute("version", NSD_TXT_VERSION)
+            setAttribute("modelQuality", llmConfig.qualityScore.toString())
+            setAttribute("llmBackend", llmConfig.backend.name)
         }
 
         val listener = object : NsdManager.RegistrationListener {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -5,6 +5,7 @@ import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.util.Log
 import com.justb81.watchbuddy.core.model.DeviceCapability
+import com.justb81.watchbuddy.core.model.LlmBackend
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,10 +18,15 @@ import javax.inject.Singleton
 /**
  * Discovers WatchBuddy companion phones on the local network via NSD (mDNS).
  *
- * Service pattern: trakt-companion-{username}._tcp.local (port 8765)
+ * Service pattern: watchbuddy-companion._watchbuddy._tcp.local (port 8765)
  *
- * Also ranks phones by capability score for recap generation:
- *   Score = modelQuality (0–150) + speedBonus (0–20) + ramBonus (0–10)
+ * Discovery flow:
+ *   1. NSD resolves a service → TXT records are parsed immediately for fast scoring.
+ *   2. /capability is fetched for full data (tmdbApiKey, freeRamMb, userAvatarUrl).
+ *   3. If /capability fails, the phone is still added using TXT record data alone.
+ *
+ * Ranking formula:
+ *   Score = modelQuality (0–150) + ramBonus (0–10, only when capability is available)
  */
 @Singleton
 class PhoneDiscoveryManager @Inject constructor(
@@ -38,8 +44,19 @@ class PhoneDiscoveryManager @Inject constructor(
 
     private val nsdManager = context.getSystemService(Context.NSD_SERVICE) as NsdManager
 
+    /**
+     * Lightweight device info extracted from NSD TXT records.
+     * Available immediately after service resolution without any HTTP round-trip.
+     */
+    data class PhoneTxtRecord(
+        val version: String,
+        val modelQuality: Int,
+        val llmBackend: LlmBackend,
+    )
+
     data class DiscoveredPhone(
         val serviceInfo: NsdServiceInfo,
+        val txtRecord: PhoneTxtRecord?,
         val capability: DeviceCapability?,
         val score: Int,
         val baseUrl: String
@@ -75,44 +92,87 @@ class PhoneDiscoveryManager @Inject constructor(
         runCatching { nsdManager.stopServiceDiscovery(discoveryListener) }
     }
 
-    /** Returns the best available phone for recap generation, or null if none available. */
+    /**
+     * Returns the best available phone for recap generation, or null if none available.
+     *
+     * Phones that have TXT records but no capability (e.g. /capability fetch failed) are
+     * included in the ranking and treated as available unless capability explicitly marks
+     * them unavailable.
+     */
     fun getBestPhone(): DiscoveredPhone? =
         _discoveredPhones.value
-            .filter { it.capability?.isAvailable == true }
+            .filter { it.capability?.isAvailable != false }
             .maxByOrNull { it.score }
 
     private fun fetchCapabilityAndAdd(serviceInfo: NsdServiceInfo) {
         @Suppress("DEPRECATION")
         val hostAddress = serviceInfo.host?.hostAddress ?: return
+        val baseUrl = "http://${hostAddress}:${serviceInfo.port}/"
+        val txtRecord = parseTxtRecord(serviceInfo)
+
         val url = "http://${hostAddress}:${serviceInfo.port}${CAPABILITY_PATH}"
         try {
             val response = httpClient.newCall(Request.Builder().url(url).build()).execute()
             val capability = response.body?.string()?.let {
                 Json.decodeFromString<DeviceCapability>(it)
             }
-            val score = calculateScore(capability)
-            val baseUrl = "http://${hostAddress}:${serviceInfo.port}/"
-            val phone = DiscoveredPhone(serviceInfo, capability, score, baseUrl)
-            _discoveredPhones.value = (_discoveredPhones.value
-                .filter { it.serviceInfo.serviceName != serviceInfo.serviceName } + phone)
-                .sortedByDescending { it.score }
+            val score = calculateScore(txtRecord, capability)
+            addOrUpdatePhone(DiscoveredPhone(serviceInfo, txtRecord, capability, score, baseUrl))
         } catch (e: Exception) {
             Log.w(TAG, "Phone discovered at $url but capability fetch failed: ${e.message}")
+            if (txtRecord != null) {
+                // Still add the phone using TXT record data so it appears in the ranked list
+                val score = calculateScore(txtRecord, null)
+                addOrUpdatePhone(DiscoveredPhone(serviceInfo, txtRecord, null, score, baseUrl))
+            }
         }
     }
 
     /**
-     * Device ranking formula:
-     *   Score = modelQuality (0–150) + RAM bonus (0–10) + availability bonus
+     * Parses WatchBuddy TXT records from a resolved NsdServiceInfo.
+     * Returns null if any required field is missing or unparseable.
      */
-    private fun calculateScore(cap: DeviceCapability?): Int {
-        if (cap == null) return 0
-        val ramBonus = when {
-            cap.freeRamMb >= 6_000 -> 10
-            cap.freeRamMb >= 4_000 -> 6
-            cap.freeRamMb >= 3_000 -> 3
-            else -> 0
+    private fun parseTxtRecord(serviceInfo: NsdServiceInfo): PhoneTxtRecord? {
+        return try {
+            val attrs = serviceInfo.attributes
+            val version = attrs["version"]?.toString(Charsets.UTF_8) ?: return null
+            val modelQuality = attrs["modelQuality"]?.toString(Charsets.UTF_8)?.toIntOrNull()
+                ?: return null
+            val llmBackendStr = attrs["llmBackend"]?.toString(Charsets.UTF_8) ?: return null
+            val llmBackend = try {
+                LlmBackend.valueOf(llmBackendStr)
+            } catch (_: IllegalArgumentException) {
+                return null
+            }
+            PhoneTxtRecord(version = version, modelQuality = modelQuality, llmBackend = llmBackend)
+        } catch (_: Exception) {
+            null
         }
-        return cap.modelQuality + ramBonus
+    }
+
+    private fun addOrUpdatePhone(phone: DiscoveredPhone) {
+        _discoveredPhones.value = (_discoveredPhones.value
+            .filter { it.serviceInfo.serviceName != phone.serviceInfo.serviceName } + phone)
+            .sortedByDescending { it.score }
+    }
+
+    /**
+     * Device ranking formula:
+     *   Score = modelQuality (0–150) + RAM bonus (0–10, only when capability is available)
+     *
+     * When only TXT records are available (capability fetch failed), modelQuality from
+     * TXT records is used directly with no RAM bonus.
+     */
+    private fun calculateScore(txt: PhoneTxtRecord?, cap: DeviceCapability?): Int {
+        if (cap != null) {
+            val ramBonus = when {
+                cap.freeRamMb >= 6_000 -> 10
+                cap.freeRamMb >= 4_000 -> 6
+                cap.freeRamMb >= 3_000 -> 3
+                else -> 0
+            }
+            return cap.modelQuality + ramBonus
+        }
+        return txt?.modelQuality ?: 0
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
@@ -27,42 +27,63 @@ class PhoneDiscoveryManagerTest {
         manager = PhoneDiscoveryManager(context, httpClient)
     }
 
+    // ── DiscoveredPhone construction helpers ───────────────────────────────────
+
+    private fun makePhone(
+        capability: DeviceCapability?,
+        txtRecord: PhoneDiscoveryManager.PhoneTxtRecord? = null,
+        score: Int = 0,
+        name: String = "test"
+    ): PhoneDiscoveryManager.DiscoveredPhone {
+        val serviceInfo = mockk<NsdServiceInfo>()
+        every { serviceInfo.serviceName } returns name
+        return PhoneDiscoveryManager.DiscoveredPhone(
+            serviceInfo = serviceInfo,
+            txtRecord = txtRecord,
+            capability = capability,
+            score = score,
+            baseUrl = "http://test/"
+        )
+    }
+
+    private fun makeTxtRecord(
+        modelQuality: Int = 70,
+        llmBackend: LlmBackend = LlmBackend.LITERT,
+        version: String = "1"
+    ) = PhoneDiscoveryManager.PhoneTxtRecord(
+        version = version,
+        modelQuality = modelQuality,
+        llmBackend = llmBackend
+    )
+
+    // ── getBestPhone ───────────────────────────────────────────────────────────
+
     @Nested
-    @DisplayName("calculateScore")
-    inner class CalculateScoreTest {
+    @DisplayName("getBestPhone")
+    inner class GetBestPhoneTest {
 
-        private fun makePhone(
-            capability: DeviceCapability?,
-            score: Int = 0,
-            name: String = "test"
-        ): PhoneDiscoveryManager.DiscoveredPhone {
-            val serviceInfo = mockk<NsdServiceInfo>()
-            every { serviceInfo.serviceName } returns name
-            return PhoneDiscoveryManager.DiscoveredPhone(serviceInfo, capability, score, "http://test/")
-        }
-
-        @Test
-        fun `getBestPhone returns null when no phones discovered`() {
-            assertNull(manager.getBestPhone())
-        }
-
-        @Test
-        fun `getBestPhone returns highest scoring available phone`() {
-            val cap1 = DeviceCapability("d1", "u1", null, "P1", LlmBackend.NONE, 0, 1000, true)
-            val cap2 = DeviceCapability("d2", "u2", null, "P2", LlmBackend.AICORE, 150, 8000, true)
-
-            // Simulate phones being added via the StateFlow
-            // We can't easily trigger NSD discovery, so test getBestPhone with pre-set phones
-            // by testing the discoveredPhones StateFlow directly
-            val phone1 = makePhone(cap1, score = 0, name = "phone1")
-            val phone2 = makePhone(cap2, score = 160, name = "phone2")
-
-            // Access the private _discoveredPhones field to set test data
+        private fun setPhones(vararg phones: PhoneDiscoveryManager.DiscoveredPhone) {
             val field = PhoneDiscoveryManager::class.java.getDeclaredField("_discoveredPhones")
             field.isAccessible = true
             @Suppress("UNCHECKED_CAST")
             val flow = field.get(manager) as kotlinx.coroutines.flow.MutableStateFlow<List<PhoneDiscoveryManager.DiscoveredPhone>>
-            flow.value = listOf(phone1, phone2)
+            flow.value = phones.toList()
+        }
+
+        @Test
+        fun `returns null when no phones discovered`() {
+            assertNull(manager.getBestPhone())
+        }
+
+        @Test
+        fun `returns highest scoring available phone`() {
+            val cap1 = DeviceCapability("d1", "u1", null, "P1", LlmBackend.NONE, 0, 1000, true)
+            val cap2 = DeviceCapability("d2", "u2", null, "P2", LlmBackend.AICORE, 150, 8000, true)
+
+            val phone1 = makePhone(cap1, score = 0, name = "phone1")
+            val phone2 = makePhone(cap2, score = 160, name = "phone2")
+
+            setPhones(phone1, phone2)
 
             val best = manager.getBestPhone()
             assertNotNull(best)
@@ -70,68 +91,248 @@ class PhoneDiscoveryManagerTest {
         }
 
         @Test
-        fun `getBestPhone excludes unavailable phones`() {
+        fun `excludes phones where capability marks them unavailable`() {
             val cap = DeviceCapability("d1", "u1", null, "P1", LlmBackend.AICORE, 150, 8000, false)
             val phone = makePhone(cap, score = 160, name = "phone1")
-
-            val field = PhoneDiscoveryManager::class.java.getDeclaredField("_discoveredPhones")
-            field.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val flow = field.get(manager) as kotlinx.coroutines.flow.MutableStateFlow<List<PhoneDiscoveryManager.DiscoveredPhone>>
-            flow.value = listOf(phone)
+            setPhones(phone)
 
             assertNull(manager.getBestPhone())
         }
-    }
 
-    @Nested
-    @DisplayName("scoring formula")
-    inner class ScoringFormulaTest {
+        @Test
+        fun `includes TXT-only phones (no capability) in ranking`() {
+            val txt = makeTxtRecord(modelQuality = 90, llmBackend = LlmBackend.LITERT)
+            val phone = makePhone(capability = null, txtRecord = txt, score = 90, name = "txt-only")
+            setPhones(phone)
 
-        // Test calculateScore indirectly via reflection since it's private
-        private fun calculateScore(cap: DeviceCapability?): Int {
-            val method = PhoneDiscoveryManager::class.java.getDeclaredMethod(
-                "calculateScore", DeviceCapability::class.java
-            )
-            method.isAccessible = true
-            return method.invoke(manager, cap) as Int
+            assertNotNull(manager.getBestPhone())
         }
 
         @Test
-        fun `returns 0 for null capability`() {
-            assertEquals(0, calculateScore(null))
+        fun `prefers phone with capability over TXT-only phone when score is higher`() {
+            val capPhone = makePhone(
+                capability = DeviceCapability("d1", "u1", null, "P1", LlmBackend.AICORE, 150, 8000, true),
+                score = 160,
+                name = "cap-phone"
+            )
+            val txtPhone = makePhone(
+                capability = null,
+                txtRecord = makeTxtRecord(modelQuality = 90),
+                score = 90,
+                name = "txt-phone"
+            )
+            setPhones(txtPhone, capPhone)
+
+            val best = manager.getBestPhone()
+            assertEquals("cap-phone", best?.serviceInfo?.serviceName)
+        }
+    }
+
+    // ── calculateScore ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("calculateScore")
+    inner class CalculateScoreTest {
+
+        private fun calculateScore(
+            txt: PhoneDiscoveryManager.PhoneTxtRecord?,
+            cap: DeviceCapability?
+        ): Int {
+            val method = PhoneDiscoveryManager::class.java.getDeclaredMethod(
+                "calculateScore",
+                PhoneDiscoveryManager.PhoneTxtRecord::class.java,
+                DeviceCapability::class.java
+            )
+            method.isAccessible = true
+            return method.invoke(manager, txt, cap) as Int
+        }
+
+        @Test
+        fun `returns 0 when both txt and capability are null`() {
+            assertEquals(0, calculateScore(null, null))
+        }
+
+        @Test
+        fun `returns modelQuality from TXT when capability is null`() {
+            val txt = makeTxtRecord(modelQuality = 70)
+            assertEquals(70, calculateScore(txt, null))
+        }
+
+        @Test
+        fun `returns 0 when txt is null and capability is null`() {
+            assertEquals(0, calculateScore(null, null))
+        }
+
+        @Test
+        fun `uses capability score when capability is present (ignores txt)`() {
+            val txt = makeTxtRecord(modelQuality = 70)
+            val cap = DeviceCapability("d", "u", null, "P", LlmBackend.AICORE, 150, 8000, true)
+            // Capability wins: 150 (modelQuality) + 10 (ramBonus for >=6000 MB) = 160
+            assertEquals(160, calculateScore(txt, cap))
         }
 
         @Test
         fun `adds ramBonus 10 for at least 6000 MB`() {
             val cap = DeviceCapability("d", "u", null, "P", LlmBackend.NONE, 50, 6000, true)
-            assertEquals(60, calculateScore(cap)) // 50 + 10
+            assertEquals(60, calculateScore(null, cap)) // 50 + 10
         }
 
         @Test
         fun `adds ramBonus 6 for at least 4000 MB`() {
             val cap = DeviceCapability("d", "u", null, "P", LlmBackend.NONE, 50, 4500, true)
-            assertEquals(56, calculateScore(cap)) // 50 + 6
+            assertEquals(56, calculateScore(null, cap)) // 50 + 6
         }
 
         @Test
         fun `adds ramBonus 3 for at least 3000 MB`() {
             val cap = DeviceCapability("d", "u", null, "P", LlmBackend.NONE, 50, 3500, true)
-            assertEquals(53, calculateScore(cap)) // 50 + 3
+            assertEquals(53, calculateScore(null, cap)) // 50 + 3
         }
 
         @Test
         fun `adds ramBonus 0 for less than 3000 MB`() {
             val cap = DeviceCapability("d", "u", null, "P", LlmBackend.NONE, 50, 2000, true)
-            assertEquals(50, calculateScore(cap)) // 50 + 0
+            assertEquals(50, calculateScore(null, cap)) // 50 + 0
         }
 
         @Test
-        fun `adds modelQuality to ramBonus`() {
+        fun `adds modelQuality to ramBonus for AICore with large RAM`() {
             val cap = DeviceCapability("d", "u", null, "P", LlmBackend.AICORE, 150, 8000, true)
-            assertEquals(160, calculateScore(cap)) // 150 + 10
+            assertEquals(160, calculateScore(null, cap)) // 150 + 10
         }
     }
+
+    // ── parseTxtRecord ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("parseTxtRecord")
+    inner class ParseTxtRecordTest {
+
+        private fun parseTxtRecord(serviceInfo: NsdServiceInfo): PhoneDiscoveryManager.PhoneTxtRecord? {
+            val method = PhoneDiscoveryManager::class.java.getDeclaredMethod(
+                "parseTxtRecord", NsdServiceInfo::class.java
+            )
+            method.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            return method.invoke(manager, serviceInfo) as PhoneDiscoveryManager.PhoneTxtRecord?
+        }
+
+        private fun mockServiceInfo(attrs: Map<String, ByteArray>): NsdServiceInfo {
+            val info = mockk<NsdServiceInfo>()
+            every { info.attributes } returns attrs
+            return info
+        }
+
+        @Test
+        fun `parses valid TXT records`() {
+            val info = mockServiceInfo(
+                mapOf(
+                    "version" to "1".toByteArray(),
+                    "modelQuality" to "90".toByteArray(),
+                    "llmBackend" to "LITERT".toByteArray()
+                )
+            )
+            val result = parseTxtRecord(info)
+            assertNotNull(result)
+            assertEquals("1", result!!.version)
+            assertEquals(90, result.modelQuality)
+            assertEquals(LlmBackend.LITERT, result.llmBackend)
+        }
+
+        @Test
+        fun `parses AICORE backend`() {
+            val info = mockServiceInfo(
+                mapOf(
+                    "version" to "1".toByteArray(),
+                    "modelQuality" to "150".toByteArray(),
+                    "llmBackend" to "AICORE".toByteArray()
+                )
+            )
+            val result = parseTxtRecord(info)
+            assertNotNull(result)
+            assertEquals(LlmBackend.AICORE, result!!.llmBackend)
+            assertEquals(150, result.modelQuality)
+        }
+
+        @Test
+        fun `parses NONE backend`() {
+            val info = mockServiceInfo(
+                mapOf(
+                    "version" to "1".toByteArray(),
+                    "modelQuality" to "0".toByteArray(),
+                    "llmBackend" to "NONE".toByteArray()
+                )
+            )
+            val result = parseTxtRecord(info)
+            assertNotNull(result)
+            assertEquals(LlmBackend.NONE, result!!.llmBackend)
+        }
+
+        @Test
+        fun `returns null when version attribute is missing`() {
+            val info = mockServiceInfo(
+                mapOf(
+                    "modelQuality" to "70".toByteArray(),
+                    "llmBackend" to "LITERT".toByteArray()
+                )
+            )
+            assertNull(parseTxtRecord(info))
+        }
+
+        @Test
+        fun `returns null when modelQuality attribute is missing`() {
+            val info = mockServiceInfo(
+                mapOf(
+                    "version" to "1".toByteArray(),
+                    "llmBackend" to "LITERT".toByteArray()
+                )
+            )
+            assertNull(parseTxtRecord(info))
+        }
+
+        @Test
+        fun `returns null when llmBackend attribute is missing`() {
+            val info = mockServiceInfo(
+                mapOf(
+                    "version" to "1".toByteArray(),
+                    "modelQuality" to "70".toByteArray()
+                )
+            )
+            assertNull(parseTxtRecord(info))
+        }
+
+        @Test
+        fun `returns null when modelQuality is not a valid integer`() {
+            val info = mockServiceInfo(
+                mapOf(
+                    "version" to "1".toByteArray(),
+                    "modelQuality" to "not-a-number".toByteArray(),
+                    "llmBackend" to "LITERT".toByteArray()
+                )
+            )
+            assertNull(parseTxtRecord(info))
+        }
+
+        @Test
+        fun `returns null when llmBackend is an unknown value`() {
+            val info = mockServiceInfo(
+                mapOf(
+                    "version" to "1".toByteArray(),
+                    "modelQuality" to "70".toByteArray(),
+                    "llmBackend" to "UNKNOWN_BACKEND".toByteArray()
+                )
+            )
+            assertNull(parseTxtRecord(info))
+        }
+
+        @Test
+        fun `returns null when all attributes map is empty`() {
+            val info = mockServiceInfo(emptyMap())
+            assertNull(parseTxtRecord(info))
+        }
+    }
+
+    // ── constants ──────────────────────────────────────────────────────────────
 
     @Test
     fun `SERVICE_TYPE constant is correct`() {
@@ -145,7 +346,6 @@ class PhoneDiscoveryManagerTest {
 
     @Test
     fun `stopDiscovery does not throw`() {
-        // Should handle gracefully even if discovery was never started
         manager.stopDiscovery()
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobblerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobblerTest.kt
@@ -61,6 +61,7 @@ class MediaSessionScrobblerTest {
         )
         return PhoneDiscoveryManager.DiscoveredPhone(
             serviceInfo = mockk<NsdServiceInfo>(relaxed = true),
+            txtRecord = null,
             capability = capability,
             score = 75,
             baseUrl = baseUrl
@@ -255,6 +256,7 @@ class MediaSessionScrobblerTest {
             )
             val offlinePhone = PhoneDiscoveryManager.DiscoveredPhone(
                 serviceInfo = mockk(relaxed = true),
+                txtRecord = null,
                 capability = unavailableCapability,
                 score = 0,
                 baseUrl = "http://offline:8765/"


### PR DESCRIPTION
## Summary

Closes #173.

The issue correctly observed that the phone's NSD registration duplicates information already available to the TV. This PR wires up NSD TXT records on the phone side and reads them on the TV side, so the TV can rank phones without an HTTP round-trip for every discovered device.

**Key findings during investigation:**
- The phone was registering with `_http._tcp.` but the TV discovers `_watchbuddy._tcp.` — a type mismatch that would prevent discovery entirely. Fixed here.
- The phone published no TXT records at all despite the issue describing them — also fixed here.

## Changes

### Phone — `CompanionService`
- Fix NSD service type: `_http._tcp.` → `_watchbuddy._tcp.` (must match TV's `SERVICE_TYPE` constant)
- Inject `LlmOrchestrator` to read the current LLM config synchronously at registration time
- Publish TXT records: `version=1`, `modelQuality=<score>`, `llmBackend=<AICORE|LITERT|NONE>`

### TV — `PhoneDiscoveryManager`
- Add `PhoneTxtRecord` data class (`version`, `modelQuality`, `llmBackend`) — available immediately from NSD resolution, no HTTP round-trip
- Add `txtRecord: PhoneTxtRecord?` to `DiscoveredPhone` alongside the existing `capability`
- `parseTxtRecord()` reads `NsdServiceInfo.attributes` (API 21+, safe for minSdk 26) and returns `null` gracefully on any missing or invalid field
- `calculateScore()` uses `txtRecord.modelQuality` as fallback when the `/capability` fetch fails
- `getBestPhone()` filter changed from `capability?.isAvailable == true` to `capability?.isAvailable != false` — TXT-only phones (where capability fetch failed) are now included in the ranking and treated as available
- On capability fetch failure: phone is still added to the discovered list using its TXT score instead of being silently dropped

### Why `/capability` stays
`tmdbApiKey`, `freeRamMb`, and `userAvatarUrl` cannot go in DNS-SD TXT records (too long / sensitive / volatile). The endpoint is still fetched for those fields; the change makes the system resilient when it is unreachable.

## Test plan

- [x] `PhoneDiscoveryManagerTest`: updated `DiscoveredPhone` construction for new `txtRecord` field; updated `calculateScore` reflection tests to match new two-argument signature; added `parseTxtRecord` tests (valid records, missing fields, unknown backend); added `getBestPhone` tests for TXT-only phones
- [x] `MediaSessionScrobblerTest`: updated `DiscoveredPhone` constructors to include `txtRecord = null`
- [x] All other tests using `mockk<DiscoveredPhone>()` are unaffected (no constructor call)

https://claude.ai/code/session_016AYKWWQSyhpdyAZfNu9LCD