### PR TITLE
feat(ci): send changelog to Play Console on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
+      body: ${{ steps.release.outputs.body }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -181,6 +182,40 @@ jobs:
           UPDATED=$(printf "%s\n\n%b" "$EXISTING" "$DOWNLOADS")
           gh release edit "${TAG}" --notes "$UPDATED"
 
+      # -- Extract changelog for Play Store --------------------------------
+      - name: Generate Play Store changelog
+        env:
+          RELEASE_BODY: ${{ needs.release-please.outputs.body }}
+        run: |
+          # Strip markdown formatting for plain-text Play Store listing
+          NOTES=$(echo "$RELEASE_BODY" | sed -E \
+            -e 's/^\*\*([^*]+)\*\*/\1/g' \
+            -e 's/\*\*//g' \
+            -e 's/\[#[0-9]+\]\([^)]*\)//g' \
+            -e 's/\[([^]]*)\]\([^)]*\)/\1/g' \
+            -e 's/\([0-9a-f]{7}\)//g' \
+            -e 's/, *closes *//g' \
+            -e 's/[[:space:]]*$//g')
+
+          # Trim leading/trailing blank lines
+          NOTES=$(echo "$NOTES" | sed '/./,$!d' | sed -e :a -e '/^[[:space:]]*$/{ $d; N; ba; }')
+
+          # Play Store limits "What's New" to 500 characters
+          if [ ${#NOTES} -gt 500 ]; then
+            NOTES="${NOTES:0:497}..."
+          fi
+
+          # Write locale files — all locales get the same English text
+          # (matches supported languages: EN, DE, FR, ES)
+          mkdir -p whatsnew
+          for LOCALE in en-US de-DE fr-FR es-ES; do
+            echo "$NOTES" > "whatsnew/${LOCALE}"
+          done
+
+          echo "--- Play Store changelog (en-US) ---"
+          cat whatsnew/en-US
+          echo "--- ${#NOTES} characters ---"
+
       # -- Determine Play Store release status ------------------------------
       - name: Determine Play Store release status
         id: play-status
@@ -202,6 +237,7 @@ jobs:
           releaseFiles: release-assets/*-release.aab
           track: internal
           status: ${{ steps.play-status.outputs.status }}
+          whatsNewDirectory: whatsnew
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- Forward the `body` output from release-please to the `build-release` job
- Strip markdown formatting and truncate to 500 chars (Play Store limit)
- Write locale-specific files (`en-US`, `de-DE`, `fr-FR`, `es-ES`) into a `whatsnew/` directory
- Pass `whatsNewDirectory: whatsnew` to `r0adkll/upload-google-play` so each release auto-populates "What's New" in the Play Console

Uses the release notes that release-please already generates — no CHANGELOG.md parsing needed.

## Test plan

- [ ] Verify the workflow YAML is valid (CI build check)
- [ ] On next release: confirm `whatsnew/` files are created with correct content in the workflow logs
- [ ] Check that the Play Console internal track listing shows the changelog text

https://claude.ai/code/session_01XffsLtMgLfJH8cYCksx9fs