### PR TITLE
fix(phone): improve Trakt connect flow

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingScreen.kt
@@ -1,8 +1,10 @@
 package com.justb81.watchbuddy.phone.ui.onboarding
 
+import android.widget.Toast
 import androidx.compose.animation.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -12,10 +14,15 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -184,6 +191,11 @@ private fun NotConfiguredCard(
 
 @Composable
 private fun PinCard(userCode: String, verificationUrl: String, expiresIn: Int) {
+    val uriHandler = LocalUriHandler.current
+    val clipboardManager = LocalClipboardManager.current
+    val context = LocalContext.current
+    val copiedMessage = stringResource(R.string.onboarding_code_copied)
+
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp)
@@ -195,10 +207,12 @@ private fun PinCard(userCode: String, verificationUrl: String, expiresIn: Int) {
             color = MaterialTheme.colorScheme.onBackground
         )
         Text(
-            text       = stringResource(R.string.onboarding_activate_url),
-            style      = MaterialTheme.typography.titleMedium,
-            color      = MaterialTheme.colorScheme.primary,
-            fontWeight = FontWeight.Bold
+            text           = stringResource(R.string.onboarding_activate_url),
+            style          = MaterialTheme.typography.titleMedium,
+            color          = MaterialTheme.colorScheme.primary,
+            fontWeight     = FontWeight.Bold,
+            textDecoration = TextDecoration.Underline,
+            modifier       = Modifier.clickable { uriHandler.openUri("https://trakt.tv/activate") }
         )
 
         // Step 2
@@ -220,7 +234,11 @@ private fun PinCard(userCode: String, verificationUrl: String, expiresIn: Int) {
                     color = MaterialTheme.colorScheme.primary,
                     shape = RoundedCornerShape(12.dp)
                 )
-                .padding(horizontal = 32.dp, vertical = 16.dp),
+                .padding(horizontal = 32.dp, vertical = 16.dp)
+                .clickable {
+                    clipboardManager.setText(AnnotatedString(userCode))
+                    Toast.makeText(context, copiedMessage, Toast.LENGTH_SHORT).show()
+                },
             contentAlignment = Alignment.Center
         ) {
             Text(

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
@@ -2,6 +2,7 @@ package com.justb81.watchbuddy.phone.ui.onboarding
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.network.TokenProxyServiceFactory
@@ -16,6 +17,8 @@ import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import com.justb81.watchbuddy.phone.ui.settings.AuthMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -58,6 +61,7 @@ sealed class OnboardingState {
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
     application: Application,
+    private val savedStateHandle: SavedStateHandle,
     private val traktApi: TraktApiService,
     private val tokenProxy: TokenProxyService?,
     @param:Named("traktClientId") private val buildConfigClientId: String,
@@ -71,6 +75,37 @@ class OnboardingViewModel @Inject constructor(
 
     private var countdownJob: Job? = null
     private var pollingJob: Job? = null
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    private fun saveDeviceCodeToState(response: DeviceCodeResponse) {
+        savedStateHandle[KEY_DEVICE_CODE_JSON] = json.encodeToString(response)
+        savedStateHandle[KEY_DEVICE_CODE_TIMESTAMP] = System.currentTimeMillis()
+    }
+
+    private fun restoreDeviceCodeFromState(): DeviceCodeResponse? {
+        val jsonStr = savedStateHandle.get<String>(KEY_DEVICE_CODE_JSON) ?: return null
+        val timestamp = savedStateHandle.get<Long>(KEY_DEVICE_CODE_TIMESTAMP) ?: return null
+        return try {
+            val response = json.decodeFromString<DeviceCodeResponse>(jsonStr)
+            val elapsedSeconds = ((System.currentTimeMillis() - timestamp) / 1000).toInt()
+            val remainingSeconds = response.expires_in - elapsedSeconds
+            if (remainingSeconds > 0) {
+                response.copy(expires_in = remainingSeconds)
+            } else {
+                clearSavedDeviceCode()
+                null
+            }
+        } catch (_: Exception) {
+            clearSavedDeviceCode()
+            null
+        }
+    }
+
+    private fun clearSavedDeviceCode() {
+        savedStateHandle.remove<String>(KEY_DEVICE_CODE_JSON)
+        savedStateHandle.remove<Long>(KEY_DEVICE_CODE_TIMESTAMP)
+    }
 
     /**
      * Resolves the effective client ID based on the current auth mode.
@@ -115,7 +150,15 @@ class OnboardingViewModel @Inject constructor(
                     return@launch
                 }
 
-                val response = traktApi.requestDeviceCode(DeviceCodeRequest(clientId))
+                val restored = restoreDeviceCodeFromState()
+                val response = if (restored != null) {
+                    restored
+                } else {
+                    val fresh = traktApi.requestDeviceCode(DeviceCodeRequest(clientId))
+                    saveDeviceCodeToState(fresh)
+                    fresh
+                }
+
                 startCountdown(response)
                 startPolling(response, settings.authMode, settings.backendUrl, clientId)
             } catch (e: Exception) {
@@ -142,6 +185,7 @@ class OnboardingViewModel @Inject constructor(
                 delay(1_000)
                 remaining--
             }
+            clearSavedDeviceCode()
             _state.value = OnboardingState.Error(
                 getApplication<Application>().getString(R.string.onboarding_code_expired)
             )
@@ -206,6 +250,7 @@ class OnboardingViewModel @Inject constructor(
                     )
                     val profile = traktApi.getProfile("Bearer $accessToken")
                     countdownJob?.cancel()
+                    clearSavedDeviceCode()
                     _state.value = OnboardingState.Success(profile.username)
                     return@launch
                 } catch (e: Exception) {
@@ -218,6 +263,7 @@ class OnboardingViewModel @Inject constructor(
                         consecutiveNetworkFailures++
                         if (consecutiveNetworkFailures >= 3) {
                             countdownJob?.cancel()
+                            clearSavedDeviceCode()
                             _state.value = OnboardingState.Error(
                                 getApplication<Application>().getString(
                                     R.string.onboarding_error_polling_network
@@ -230,5 +276,10 @@ class OnboardingViewModel @Inject constructor(
                 attempts++
             }
         }
+    }
+
+    private companion object {
+        const val KEY_DEVICE_CODE_JSON = "device_code_json"
+        const val KEY_DEVICE_CODE_TIMESTAMP = "device_code_timestamp"
     }
 }

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -13,6 +13,7 @@
     <string name="onboarding_success">Verbunden! Willkommen, %1$s</string>
     <string name="onboarding_error">Verbindung fehlgeschlagen. Bitte versuche es erneut.</string>
     <string name="onboarding_retry">Erneut versuchen</string>
+    <string name="onboarding_code_copied">Code in die Zwischenablage kopiert</string>
     <string name="onboarding_code_expires">Code läuft ab in %1$d Sekunden</string>
     <string name="onboarding_error_loading_code">Fehler beim Laden des Codes: %1$s</string>
     <string name="onboarding_code_expired">Code abgelaufen. Bitte erneut versuchen.</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -13,6 +13,7 @@
     <string name="onboarding_success">¡Conectado! Bienvenido/a, %1$s</string>
     <string name="onboarding_error">La conexión ha fallado. Por favor, inténtalo de nuevo.</string>
     <string name="onboarding_retry">Reintentar</string>
+    <string name="onboarding_code_copied">Código copiado al portapapeles</string>
     <string name="onboarding_code_expires">El código expira en %1$d segundos</string>
     <string name="onboarding_error_loading_code">Error al cargar el código: %1$s</string>
     <string name="onboarding_code_expired">Código expirado. Por favor, inténtalo de nuevo.</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -13,6 +13,7 @@
     <string name="onboarding_success">Connecté ! Bienvenue, %1$s</string>
     <string name="onboarding_error">La connexion a échoué. Veuillez réessayer.</string>
     <string name="onboarding_retry">Réessayer</string>
+    <string name="onboarding_code_copied">Code copié dans le presse-papiers</string>
     <string name="onboarding_code_expires">Le code expire dans %1$d secondes</string>
     <string name="onboarding_error_loading_code">Erreur lors du chargement du code : %1$s</string>
     <string name="onboarding_code_expired">Code expiré. Veuillez réessayer.</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="onboarding_success">Connected! Welcome, %1$s</string>
     <string name="onboarding_error">Connection failed. Please try again.</string>
     <string name="onboarding_retry">Try again</string>
+    <string name="onboarding_code_copied">Code copied to clipboard</string>
     <string name="onboarding_code_expires">Code expires in %1$d seconds</string>
     <string name="onboarding_error_loading_code">Error loading code: %1$s</string>
     <string name="onboarding_code_expired">Code expired. Please try again.</string>

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.justb81.watchbuddy.phone.ui.onboarding
 
 import android.app.Application
+import androidx.lifecycle.SavedStateHandle
 import com.justb81.watchbuddy.core.network.TokenProxyServiceFactory
 import com.justb81.watchbuddy.core.trakt.DeviceCodeResponse
 import com.justb81.watchbuddy.core.trakt.DeviceTokenResponse
@@ -14,10 +15,13 @@ import com.justb81.watchbuddy.phone.settings.AppSettings
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import com.justb81.watchbuddy.phone.ui.settings.AuthMode
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
@@ -67,9 +71,11 @@ class OnboardingViewModelTest {
 
     private fun createViewModel(
         buildClientId: String = BUILD_CLIENT_ID,
-        proxy: TokenProxyService? = tokenProxy
+        proxy: TokenProxyService? = tokenProxy,
+        savedStateHandle: SavedStateHandle = SavedStateHandle()
     ): OnboardingViewModel = OnboardingViewModel(
         application = application,
+        savedStateHandle = savedStateHandle,
         traktApi = traktApi,
         tokenProxy = proxy,
         buildConfigClientId = buildClientId,
@@ -353,6 +359,82 @@ class OnboardingViewModelTest {
 
             // Should succeed because the HTTP 400 reset the failure counter before we hit 3
             assertTrue(vm.state.value is OnboardingState.Success)
+        }
+    }
+
+    @Nested
+    @DisplayName("Process death survival")
+    inner class ProcessDeathSurvival {
+
+        private val json = Json { ignoreUnknownKeys = true }
+
+        private fun savedStateWithCode(
+            response: DeviceCodeResponse = deviceCodeResponse,
+            timestamp: Long = System.currentTimeMillis()
+        ): SavedStateHandle = SavedStateHandle(
+            mapOf(
+                "device_code_json" to json.encodeToString(response),
+                "device_code_timestamp" to timestamp
+            )
+        )
+
+        @Test
+        fun `restores saved device code instead of requesting a new one`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+
+            val handle = savedStateWithCode()
+            val vm = createViewModel(savedStateHandle = handle)
+            vm.requestDeviceCode()
+
+            val state = vm.state.value
+            assertTrue(state is OnboardingState.WaitingForPin)
+            assertEquals("ABC123", (state as OnboardingState.WaitingForPin).userCode)
+            coVerify(exactly = 0) { traktApi.requestDeviceCode(any()) }
+        }
+
+        @Test
+        fun `requests new code when saved code has expired`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+
+            val expiredTimestamp = System.currentTimeMillis() - 700_000L // 700s ago, code was 600s
+            val handle = savedStateWithCode(timestamp = expiredTimestamp)
+            val vm = createViewModel(savedStateHandle = handle)
+            vm.requestDeviceCode()
+
+            val state = vm.state.value
+            assertTrue(state is OnboardingState.WaitingForPin)
+            coVerify(exactly = 1) { traktApi.requestDeviceCode(any()) }
+        }
+
+        @Test
+        fun `clears saved state on successful authentication`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+            coEvery { tokenProxy.exchangeDeviceCode(any()) } returns ProxyTokenResponse(
+                access_token = "acc",
+                refresh_token = "ref",
+                expires_in = 7776000,
+                token_type = "Bearer",
+                scope = "public"
+            )
+            coEvery { traktApi.getProfile(any()) } returns TraktUserProfile(username = "user1")
+
+            val handle = SavedStateHandle()
+            val vm = createViewModel(savedStateHandle = handle)
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            assertTrue(vm.state.value is OnboardingState.Success)
+            assertNull(handle.get<String>("device_code_json"))
+            assertNull(handle.get<Long>("device_code_timestamp"))
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes three bugs in the Trakt device code authentication flow that made it nearly unusable:

- **Clickable activation URL**: `trakt.tv/activate` is now an underlined, tappable link that opens the browser directly (uses `LocalUriHandler`, same pattern as `TmdbHelperLink` in Settings)
- **Copyable device code**: Tapping the PIN box copies the code to clipboard with a Toast confirmation (all 4 languages: EN, DE, FR, ES)
- **Survive process death**: When the user leaves the app to open the browser, Android may kill the process. Previously this would generate a new device code on return, invalidating what the user already entered. Now `SavedStateHandle` persists the code + timestamp across process death and resumes countdown/polling with adjusted remaining time

Closes #176

## Test plan

- [ ] Verify `trakt.tv/activate` opens the browser when tapped
- [ ] Verify tapping the code box copies it to clipboard and shows a Toast
- [ ] Verify the auth flow completes successfully after returning from the browser
- [ ] Verify code expiration still works correctly (countdown reaches 0 → error state)
- [ ] Verify new unit tests pass: restore saved code, expired code fallback, state cleanup on success
- [ ] CI build passes (`build-android.yml`)

https://claude.ai/code/session_01WKyVpCVUemLwcuCpk9ZB2W