### PR TITLE
fix(phone): prevent force close when opening settings screen

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -77,13 +77,13 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun loadTraktUsername() {
-        val accessToken = tokenRepository.getAccessToken() ?: return
         viewModelScope.launch {
             try {
+                val accessToken = tokenRepository.getAccessToken() ?: return@launch
                 val profile = traktApi.getProfile("Bearer $accessToken")
                 _uiState.value = _uiState.value.copy(traktUsername = profile.username)
             } catch (_: Exception) {
-                // Token may be expired or network unavailable — keep showing "Not connected"
+                // Keystore unavailable, token expired, or network error — keep "Not connected"
             }
         }
     }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
@@ -449,6 +449,21 @@ class SettingsViewModelTest {
         }
 
         @Test
+        fun `ViewModel creation does not throw when getAccessToken throws SecurityException`() = runTest {
+            // Simulates Keystore unavailability during loadTraktUsername().
+            // getAccessToken() was previously called outside the try/catch block,
+            // so a SecurityException would propagate and crash the app.
+            every { tokenRepository.getAccessToken() } throws
+                SecurityException("Keystore operation failed")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // Username stays null (not connected); no crash.
+            assertNull(vm.uiState.value.traktUsername)
+        }
+
+        @Test
         fun `loadPersistedSettings exception does not affect tmdb key state from previous load`() = runTest {
             // First load succeeds — sets a TMDB key.
             val settings = AppSettings(tmdbApiKey = "existing-key", defaultTmdbApiKeyAvailable = false)


### PR DESCRIPTION
## Summary

- Move `tokenRepository.getAccessToken()` inside the coroutine's try/catch in `loadTraktUsername()` — on devices where the Android Keystore is unavailable (encryption state change, factory reset, or biometric re-enroll), `EncryptedSharedPreferences.getString()` throws `SecurityException`. This call was outside the existing try/catch block, so the exception propagated through the `init` block and crashed the ViewModel on creation.
- Add test for `getAccessToken()` throwing `SecurityException` during init

The previous fix (PR #170) protected `loadPersistedSettings()` and `detectLlm()` but missed this synchronous call in `loadTraktUsername()`.

Closes #177

## Test plan

- [ ] Open settings screen on a device with a healthy Keystore — settings load normally, username shows
- [ ] Simulate Keystore failure — settings screen shows "Not connected" instead of crashing
- [ ] New unit test passes: `ViewModel creation does not throw when getAccessToken throws SecurityException`
- [ ] CI build passes

https://claude.ai/code/session_01WKyVpCVUemLwcuCpk9ZB2W