### PR TITLE
chore: raise minSdk to API 34 (phone) and API 31 (TV/core)

### DIFF
--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId = "com.justb81.watchbuddy"
-        minSdk = 26
+        minSdk = 34
         targetSdk = 35
 
         // versionCode: CI sets VERSION_CODE (run_number).

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId = "com.justb81.watchbuddy"   // same package as phone app!
-        minSdk = 26
+        minSdk = 31
         targetSdk = 35
 
         // versionCode: CI sets VERSION_CODE (run_number).

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -10,7 +10,7 @@ android {
     compileSdk = 35
 
     defaultConfig {
-        minSdk = 26
+        minSdk = 31
     }
 
     testOptions {


### PR DESCRIPTION
## Summary

- Bumps `app-phone` minSdk from 26 → **34** (Android 14)
- Bumps `app-tv` minSdk from 26 → **31** (Android 12)
- Bumps `core` minSdk from 26 → **31** (matches the lower of the two consumers)

Dropping support for Android 8–13 (phone) and Android 8–11 (TV) allows the build toolchain to strip legacy compatibility shims and dex workarounds, reducing APK/AAB size. On the TV side API 31+ covers virtually all shipping Google TV devices.

## Test plan

- [x] `./gradlew assembleDebug` passes without errors
- [x] CI build (`build-android.yml`) is green
- [x] Verify no `@RequiresApi` / version-check dead code remains in phone or TV sources that can now be simplified

https://claude.ai/code/session_0184gkuPsnJi1Je2TCJHTp1o