### PR TITLE
feat: refactor watch/checkin process (#188)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ watchbuddy/
 │       │   ├── settings/   SettingsScreen, SettingsViewModel
 │       │   ├── showdetail/ ShowDetailScreen, ShowDetailViewModel
 │       │   └── theme/      Material 3 theme
-│       └── (service/)  CompanionService (foreground NSD server)
+│       └── (service/)  CompanionService, CompanionStateManager (foreground NSD server + shared state)
 ├── app-tv/             Google TV app (Kotlin, Compose for TV)
 │   └── src/main/java/com/justb81/watchbuddy/tv/
 │       ├── data/       StreamingPreferencesRepository, UserSessionRepository, TvShowCache
@@ -185,6 +185,12 @@ The TV ranks connected phones by LLM quality and uses the best one. Failover cha
 
 ## Important Patterns
 
+- **Watching TV toggle:** The phone HomeScreen shows an "I am watching TV" toggle, gated by Trakt + TMDB availability. Toggling starts/stops the `CompanionService`. When the user swipes the app from recents, the service auto-stops via `onTaskRemoved()`.
+- **CompanionStateManager:** Hilt singleton (`service/CompanionStateManager.kt`) that is the shared state hub between `CompanionService`, `CompanionHttpServer`, and `HomeViewModel`. Tracks `lastCapabilityCheck`, `lastScrobbleEvent`, and `isServiceRunning`.
+- **Presence heartbeat (TV):** `PhoneDiscoveryManager` runs a heartbeat every 60s, re-fetching `/capability` for each phone. 3 consecutive failures → phone removed from discovered list. `MediaSessionScrobbler` skips phones with stale presence (> 2 min) before scrobbling.
+- **Presence timeout (phone):** If no TV polls `/capability` for 5 minutes, the companion service auto-deactivates.
+- **Auto-reconnect:** `CompanionService` registers a `ConnectivityManager.NetworkCallback` for Wi-Fi. On network loss, NSD is unregistered; on network available, NSD is re-registered.
+- **Scrobble display:** When a scrobble event is received on the phone, `CompanionStateManager.lastScrobbleEvent` is updated. The phone HomeScreen shows a "Now Watching" card with show/episode details, auto-hidden after 30 minutes.
 - **Scrobbling:** `MediaSessionScrobbler` listens to active media sessions on the TV, extracts package name + title, fuzzy-matches against the local show cache first, then falls back to TMDB title search (using the API key from the best phone's capability). Auto-scrobbles if confidence ≥ 95%, shows overlay confirmation between 70–95%, ignores below 70%. When a scrobble event occurs, `MediaSessionScrobbler` calls `POST /scrobble/{start|pause|stop}` on **every** connected phone in parallel via `PhoneDiscoveryManager` + `PhoneApiClientFactory` — each phone records the episode on its own user's Trakt account using its own stored credentials. A failure for one phone does not block the others. The TV never calls the Trakt API directly for any operation.
 - **LLM selection:** `LlmOrchestrator` checks AICore first, then falls back to LiteRT-LM with a Gemma 4 model (E4B or E2B) sized to available RAM.
 - **Auth modes:** Managed backend (default), self-hosted proxy, or direct Trakt credentials.

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -2,6 +2,8 @@ package com.justb81.watchbuddy.phone.server
 
 import android.util.Log
 import com.justb81.watchbuddy.core.locale.LocaleHelper
+import com.justb81.watchbuddy.core.model.ScrobbleAction
+import com.justb81.watchbuddy.core.model.ScrobbleDisplayEvent
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
@@ -12,6 +14,7 @@ import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.llm.RecapGenerator
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import com.justb81.watchbuddy.service.CompanionStateManager
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -57,7 +60,8 @@ class CompanionHttpServer @Inject constructor(
     private val traktApiService: TraktApiService,
     private val tmdbApiService: TmdbApiService,
     private val tmdbCache: TmdbCache,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    private val stateManager: CompanionStateManager
 ) {
     companion object {
         const val PORT = 8765
@@ -66,10 +70,12 @@ class CompanionHttpServer @Inject constructor(
     private var server: EmbeddedServer<*, *>? = null
 
     fun start() {
+        if (server != null) return
         server = embeddedServer(Netty, port = PORT) {
             configureCompanionRoutes(
                 recapGenerator, capabilityProvider, showRepository,
-                tokenRepository, tokenRefreshManager, traktApiService, tmdbApiService, tmdbCache, settingsRepository
+                tokenRepository, tokenRefreshManager, traktApiService, tmdbApiService, tmdbCache,
+                settingsRepository, stateManager
             )
         }.start(wait = false)
     }
@@ -93,13 +99,15 @@ internal fun Application.configureCompanionRoutes(
     traktApiService: TraktApiService,
     tmdbApiService: TmdbApiService,
     tmdbCache: TmdbCache,
-    settingsRepository: SettingsRepository
+    settingsRepository: SettingsRepository,
+    stateManager: CompanionStateManager
 ) {
     install(ContentNegotiation) {
         json(Json { ignoreUnknownKeys = true })
     }
     routing {
         get("/capability") {
+            stateManager.onCapabilityChecked()
             call.respond(capabilityProvider.getCapability())
         }
 
@@ -214,6 +222,9 @@ internal fun Application.configureCompanionRoutes(
                     bearer = "Bearer $token",
                     body = ScrobbleBody(show = body.show, episode = body.episode, progress = body.progress)
                 )
+                stateManager.onScrobbleEvent(
+                    ScrobbleDisplayEvent(ScrobbleAction.START, body.show, body.episode, body.progress, System.currentTimeMillis())
+                )
                 call.respond(ScrobbleActionResponse(success = true))
             } catch (e: Exception) {
                 Log.e(TAG, "Scrobble start failed", e)
@@ -232,6 +243,9 @@ internal fun Application.configureCompanionRoutes(
                     bearer = "Bearer $token",
                     body = ScrobbleBody(show = body.show, episode = body.episode, progress = body.progress)
                 )
+                stateManager.onScrobbleEvent(
+                    ScrobbleDisplayEvent(ScrobbleAction.PAUSE, body.show, body.episode, body.progress, System.currentTimeMillis())
+                )
                 call.respond(ScrobbleActionResponse(success = true))
             } catch (e: Exception) {
                 Log.e(TAG, "Scrobble pause failed", e)
@@ -249,6 +263,9 @@ internal fun Application.configureCompanionRoutes(
                 traktApiService.scrobbleStop(
                     bearer = "Bearer $token",
                     body = ScrobbleBody(show = body.show, episode = body.episode, progress = body.progress)
+                )
+                stateManager.onScrobbleEvent(
+                    ScrobbleDisplayEvent(ScrobbleAction.STOP, body.show, body.episode, body.progress, System.currentTimeMillis())
                 )
                 call.respond(ScrobbleActionResponse(success = true))
             } catch (e: Exception) {

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
@@ -106,6 +106,13 @@ class SettingsRepository @Inject constructor(
         }
     }
 
+    /** Updates only the companion-enabled flag without touching other settings. */
+    suspend fun setCompanionEnabled(enabled: Boolean) {
+        context.dataStore.edit { prefs ->
+            prefs[Keys.COMPANION_ENABLED] = enabled
+        }
+    }
+
     /** Absolute path where downloaded model files are stored. */
     fun modelDir(): File = File(context.filesDir, "llm_models").also { it.mkdirs() }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
@@ -9,10 +9,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Stop
-import androidx.compose.material.icons.filled.Tv
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -222,7 +220,7 @@ private fun WatchingTvToggle(
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             Icon(
-                Icons.Default.Tv,
+                Icons.Default.PlayArrow,
                 contentDescription = null,
                 tint = if (isWatching)
                     MaterialTheme.colorScheme.onPrimaryContainer
@@ -260,8 +258,8 @@ private fun WatchingTvToggle(
 private fun NowWatchingCard(event: ScrobbleDisplayEvent) {
     val (actionText, actionIcon) = when (event.action) {
         ScrobbleAction.START -> stringResource(R.string.home_scrobble_started) to Icons.Default.PlayArrow
-        ScrobbleAction.PAUSE -> stringResource(R.string.home_scrobble_paused) to Icons.Default.Pause
-        ScrobbleAction.STOP  -> stringResource(R.string.home_scrobble_stopped) to Icons.Default.Stop
+        ScrobbleAction.PAUSE -> stringResource(R.string.home_scrobble_paused) to Icons.Default.PlayArrow
+        ScrobbleAction.STOP  -> stringResource(R.string.home_scrobble_stopped) to Icons.Default.Check
     }
 
     Card(

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
@@ -9,6 +9,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.Tv
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -21,6 +25,8 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.model.ScrobbleAction
+import com.justb81.watchbuddy.core.model.ScrobbleDisplayEvent
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -116,6 +122,23 @@ fun HomeScreen(
                         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
+                        // Watching TV toggle
+                        if (uiState.canWatch) {
+                            item {
+                                WatchingTvToggle(
+                                    isWatching = uiState.isWatchingTv,
+                                    onToggle = { viewModel.toggleWatchingTv(it) }
+                                )
+                            }
+                        }
+
+                        // Now watching card (scrobble event from TV)
+                        uiState.latestScrobbleEvent?.let { event ->
+                            item {
+                                NowWatchingCard(event = event)
+                            }
+                        }
+
                         // Continue watching section
                         val inProgress = uiState.shows.filter { it.seasons.isNotEmpty() }
                         if (inProgress.isNotEmpty()) {
@@ -174,6 +197,117 @@ private fun SectionHeader(title: String) {
         color      = MaterialTheme.colorScheme.onBackground,
         modifier   = Modifier.padding(vertical = 4.dp)
     )
+}
+
+@Composable
+private fun WatchingTvToggle(
+    isWatching: Boolean,
+    onToggle: (Boolean) -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = if (isWatching)
+                MaterialTheme.colorScheme.primaryContainer
+            else
+                MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(
+                Icons.Default.Tv,
+                contentDescription = null,
+                tint = if (isWatching)
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                else
+                    MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.home_watching_tv_toggle),
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (isWatching)
+                        MaterialTheme.colorScheme.onPrimaryContainer
+                    else
+                        MaterialTheme.colorScheme.onSurface
+                )
+                Text(
+                    text = stringResource(R.string.home_watching_tv_description),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (isWatching)
+                        MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f)
+                    else
+                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                )
+            }
+            Switch(
+                checked = isWatching,
+                onCheckedChange = onToggle
+            )
+        }
+    }
+}
+
+@Composable
+private fun NowWatchingCard(event: ScrobbleDisplayEvent) {
+    val (actionText, actionIcon) = when (event.action) {
+        ScrobbleAction.START -> stringResource(R.string.home_scrobble_started) to Icons.Default.PlayArrow
+        ScrobbleAction.PAUSE -> stringResource(R.string.home_scrobble_paused) to Icons.Default.Pause
+        ScrobbleAction.STOP  -> stringResource(R.string.home_scrobble_stopped) to Icons.Default.Stop
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Icon(
+                actionIcon,
+                contentDescription = actionText,
+                tint = MaterialTheme.colorScheme.onTertiaryContainer,
+                modifier = Modifier.size(28.dp)
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.home_now_watching),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f)
+                )
+                Text(
+                    text = event.show.title,
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer
+                )
+                Text(
+                    text = "S%02dE%02d — %s".format(
+                        event.episode.season,
+                        event.episode.number,
+                        actionText
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onTertiaryContainer.copy(alpha = 0.7f)
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.model.ScrobbleDisplayEvent
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.core.tmdb.TmdbImageHelper
@@ -11,6 +12,7 @@ import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import com.justb81.watchbuddy.service.CompanionService
+import com.justb81.watchbuddy.service.CompanionStateManager
 import kotlinx.coroutines.flow.first
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,7 +28,10 @@ data class HomeUiState(
     val shows: List<TraktWatchedEntry> = emptyList(),
     val posterUrls: Map<Int, String?> = emptyMap(),  // key: TMDB ID
     val lastSyncTime: String? = null,
-    val error: String? = null
+    val error: String? = null,
+    val canWatch: Boolean = false,
+    val isWatchingTv: Boolean = false,
+    val latestScrobbleEvent: ScrobbleDisplayEvent? = null
 )
 
 @HiltViewModel
@@ -35,22 +40,63 @@ class HomeViewModel @Inject constructor(
     private val traktApi: TraktApiService,
     private val tokenRepository: TokenRepository,
     private val settingsRepository: SettingsRepository,
-    private val tmdbApiService: TmdbApiService
+    private val tmdbApiService: TmdbApiService,
+    private val companionStateManager: CompanionStateManager
 ) : AndroidViewModel(application) {
+
+    companion object {
+        /** Hide scrobble events older than 30 minutes. */
+        private const val SCROBBLE_DISPLAY_TTL_MS = 30 * 60_000L
+    }
 
     private val _uiState = MutableStateFlow(HomeUiState(isLoading = true))
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     init {
         loadShows()
-        startCompanionIfEnabled()
+        checkServiceConnections()
+        observeCompanionState()
+        observeScrobbleEvents()
     }
 
-    private fun startCompanionIfEnabled() {
+    private fun checkServiceConnections() {
         viewModelScope.launch {
-            val settings = settingsRepository.settings.first()
-            if (settings.companionEnabled) {
+            val traktOk = tokenRepository.isTokenValid()
+            val tmdbOk = settingsRepository.getTmdbApiKey().first().isNotBlank()
+            _uiState.update { it.copy(canWatch = traktOk && tmdbOk) }
+        }
+    }
+
+    private fun observeCompanionState() {
+        viewModelScope.launch {
+            settingsRepository.settings.collect { settings ->
+                val wasWatching = _uiState.value.isWatchingTv
+                _uiState.update { it.copy(isWatchingTv = settings.companionEnabled) }
+                if (settings.companionEnabled && !wasWatching) {
+                    CompanionService.start(getApplication<Application>())
+                }
+            }
+        }
+    }
+
+    private fun observeScrobbleEvents() {
+        viewModelScope.launch {
+            companionStateManager.lastScrobbleEvent.collect { event ->
+                val displayEvent = if (event != null &&
+                    System.currentTimeMillis() - event.timestamp < SCROBBLE_DISPLAY_TTL_MS
+                ) event else null
+                _uiState.update { it.copy(latestScrobbleEvent = displayEvent) }
+            }
+        }
+    }
+
+    fun toggleWatchingTv(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.setCompanionEnabled(enabled)
+            if (enabled) {
                 CompanionService.start(getApplication<Application>())
+            } else {
+                CompanionService.stop(getApplication<Application>())
             }
         }
     }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
@@ -6,6 +6,10 @@ import android.app.NotificationManager
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.os.IBinder
@@ -14,7 +18,15 @@ import androidx.core.app.NotificationCompat
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
 import com.justb81.watchbuddy.phone.server.CompanionHttpServer
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -28,6 +40,11 @@ class CompanionService : Service() {
         private const val NSD_SERVICE_NAME = "watchbuddy-companion"
         private const val NSD_TXT_VERSION = "1"
 
+        /** How often to check whether the TV is still polling us. */
+        private const val PRESENCE_CHECK_INTERVAL_MS = 60_000L
+        /** Auto-deactivate if no TV has polled /capability for this long. */
+        private const val PRESENCE_TIMEOUT_MS = 5 * 60_000L
+
         fun start(context: Context) {
             val intent = Intent(context, CompanionService::class.java)
             context.startForegroundService(intent)
@@ -40,9 +57,14 @@ class CompanionService : Service() {
 
     @Inject lateinit var companionHttpServer: CompanionHttpServer
     @Inject lateinit var llmOrchestrator: LlmOrchestrator
+    @Inject lateinit var stateManager: CompanionStateManager
+    @Inject lateinit var settingsRepository: SettingsRepository
 
     private var nsdManager: NsdManager? = null
     private var nsdRegistrationListener: NsdManager.RegistrationListener? = null
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private var presenceJob: Job? = null
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
 
     override fun onCreate() {
         super.onCreate()
@@ -53,16 +75,85 @@ class CompanionService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         companionHttpServer.start()
         registerNsd()
+        stateManager.setServiceRunning(true)
+        registerNetworkCallback()
+        startPresenceMonitor()
         return START_STICKY
     }
 
     override fun onDestroy() {
+        presenceJob?.cancel()
+        unregisterNetworkCallback()
         unregisterNsd()
         companionHttpServer.stop()
+        stateManager.setServiceRunning(false)
+        serviceScope.cancel()
         super.onDestroy()
     }
 
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        serviceScope.launch {
+            settingsRepository.setCompanionEnabled(false)
+        }
+        stopSelf()
+        super.onTaskRemoved(rootIntent)
+    }
+
     override fun onBind(intent: Intent?): IBinder? = null
+
+    // ── Presence timeout ─────────────────────────────────────────────────────
+
+    private fun startPresenceMonitor() {
+        // Reset the timestamp so the first check doesn't immediately time out
+        stateManager.onCapabilityChecked()
+        presenceJob = serviceScope.launch {
+            while (true) {
+                delay(PRESENCE_CHECK_INTERVAL_MS)
+                val elapsed = System.currentTimeMillis() - stateManager.lastCapabilityCheck.value
+                if (elapsed > PRESENCE_TIMEOUT_MS) {
+                    Log.i(TAG, "No TV polled /capability for ${elapsed / 1000}s — auto-deactivating")
+                    settingsRepository.setCompanionEnabled(false)
+                    stopSelf()
+                    break
+                }
+            }
+        }
+    }
+
+    // ── Network reconnect ────────────────────────────────────────────────────
+
+    private fun registerNetworkCallback() {
+        val cm = getSystemService(ConnectivityManager::class.java) ?: return
+        val request = NetworkRequest.Builder()
+            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+            .build()
+
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onLost(network: Network) {
+                Log.i(TAG, "Wi-Fi lost — unregistering NSD")
+                unregisterNsd()
+            }
+
+            override fun onAvailable(network: Network) {
+                Log.i(TAG, "Wi-Fi available — re-registering NSD")
+                registerNsd()
+            }
+        }
+        networkCallback = callback
+        cm.registerNetworkCallback(request, callback)
+    }
+
+    private fun unregisterNetworkCallback() {
+        networkCallback?.let { cb ->
+            runCatching {
+                val cm = getSystemService(ConnectivityManager::class.java)
+                cm?.unregisterNetworkCallback(cb)
+            }
+        }
+        networkCallback = null
+    }
+
+    // ── Notification ─────────────────────────────────────────────────────────
 
     private fun ensureNotificationChannel() {
         val manager = getSystemService(NotificationManager::class.java)
@@ -85,7 +176,12 @@ class CompanionService : Service() {
             .setOngoing(true)
             .build()
 
+    // ── NSD ──────────────────────────────────────────────────────────────────
+
     private fun registerNsd() {
+        // Avoid double-registration
+        if (nsdRegistrationListener != null) return
+
         val llmConfig = llmOrchestrator.selectConfig()
         val serviceInfo = NsdServiceInfo().apply {
             serviceName = NSD_SERVICE_NAME
@@ -102,6 +198,7 @@ class CompanionService : Service() {
             }
             override fun onRegistrationFailed(info: NsdServiceInfo, errorCode: Int) {
                 Log.e(TAG, "NSD registration failed: error=$errorCode, service=${info.serviceName}")
+                nsdRegistrationListener = null
             }
             override fun onServiceUnregistered(info: NsdServiceInfo) {
                 Log.i(TAG, "NSD service unregistered: ${info.serviceName}")
@@ -119,7 +216,9 @@ class CompanionService : Service() {
 
     private fun unregisterNsd() {
         nsdRegistrationListener?.let { listener ->
-            nsdManager?.unregisterService(listener)
+            nsdManager?.let { mgr ->
+                runCatching { mgr.unregisterService(listener) }
+            }
         }
         nsdRegistrationListener = null
         nsdManager = null

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionStateManager.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionStateManager.kt
@@ -1,0 +1,41 @@
+package com.justb81.watchbuddy.service
+
+import com.justb81.watchbuddy.core.model.ScrobbleDisplayEvent
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Shared state between [CompanionService], [CompanionHttpServer], and the
+ * phone HomeViewModel.  Lives as a Hilt singleton to avoid circular dependencies
+ * between the service, HTTP server, and UI layers.
+ */
+@Singleton
+class CompanionStateManager @Inject constructor() {
+
+    private val _lastCapabilityCheck = MutableStateFlow(0L)
+    /** Epoch millis of the most recent `/capability` request from a TV. */
+    val lastCapabilityCheck: StateFlow<Long> = _lastCapabilityCheck.asStateFlow()
+
+    private val _lastScrobbleEvent = MutableStateFlow<ScrobbleDisplayEvent?>(null)
+    /** Most recent scrobble event received via the companion HTTP server. */
+    val lastScrobbleEvent: StateFlow<ScrobbleDisplayEvent?> = _lastScrobbleEvent.asStateFlow()
+
+    private val _isServiceRunning = MutableStateFlow(false)
+    /** Whether the [CompanionService] foreground service is currently active. */
+    val isServiceRunning: StateFlow<Boolean> = _isServiceRunning.asStateFlow()
+
+    fun onCapabilityChecked() {
+        _lastCapabilityCheck.value = System.currentTimeMillis()
+    }
+
+    fun onScrobbleEvent(event: ScrobbleDisplayEvent) {
+        _lastScrobbleEvent.value = event
+    }
+
+    fun setServiceRunning(running: Boolean) {
+        _isServiceRunning.value = running
+    }
+}

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -42,6 +42,9 @@
     <string name="home_sync_failed">Synchronisierung fehlgeschlagen: %1$s</string>
     <string name="home_cd_sync">Synchronisieren</string>
     <string name="home_cd_settings">Einstellungen</string>
+    <string name="home_watching_tv_toggle">Ich schaue fern</string>
+    <string name="home_watching_tv_description">Mit deinem TV verbinden für Scrobbling</string>
+    <string name="home_watching_tv_disabled_reason">Verbinde dich zuerst mit Trakt und konfiguriere TMDB</string>
 
     <!-- Settings -->
     <string name="settings_title">Einstellungen</string>
@@ -90,6 +93,12 @@
     <string name="settings_not_connected">Nicht verbunden</string>
     <string name="settings_connect_to_trakt">Mit Trakt verbinden</string>
     <string name="settings_llm_detecting">Wird erkannt…</string>
+
+    <string name="home_now_watching">Jetzt läuft</string>
+    <string name="home_scrobble_started">Wiedergabe gestartet</string>
+    <string name="home_scrobble_paused">Pausiert</string>
+    <string name="home_scrobble_stopped">Wiedergabe beendet</string>
+    <string name="companion_auto_deactivated">Companion deaktiviert — TV antwortet nicht</string>
 
     <!-- Companion Service -->
     <string name="companion_channel_name">Companion-Dienst</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -42,6 +42,9 @@
     <string name="home_sync_failed">Error de sincronización: %1$s</string>
     <string name="home_cd_sync">Sincronizar</string>
     <string name="home_cd_settings">Ajustes</string>
+    <string name="home_watching_tv_toggle">Estoy viendo la tele</string>
+    <string name="home_watching_tv_description">Conectar con tu TV para scrobbling</string>
+    <string name="home_watching_tv_disabled_reason">Conéctate primero a Trakt y configura TMDB</string>
 
     <!-- Settings -->
     <string name="settings_title">Ajustes</string>
@@ -90,6 +93,12 @@
     <string name="settings_not_connected">No conectado</string>
     <string name="settings_connect_to_trakt">Conectar con Trakt</string>
     <string name="settings_llm_detecting">Detectando…</string>
+
+    <string name="home_now_watching">Viendo ahora</string>
+    <string name="home_scrobble_started">Reproducción iniciada</string>
+    <string name="home_scrobble_paused">En pausa</string>
+    <string name="home_scrobble_stopped">Reproducción terminada</string>
+    <string name="companion_auto_deactivated">Companion desactivado — TV no responde</string>
 
     <!-- Companion Service -->
     <string name="companion_channel_name">Servicio compañero</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -42,6 +42,9 @@
     <string name="home_sync_failed">Échec de la synchronisation : %1$s</string>
     <string name="home_cd_sync">Synchroniser</string>
     <string name="home_cd_settings">Paramètres</string>
+    <string name="home_watching_tv_toggle">Je regarde la TV</string>
+    <string name="home_watching_tv_description">Se connecter au téléviseur pour le scrobbling</string>
+    <string name="home_watching_tv_disabled_reason">Connectez-vous d\'abord à Trakt et configurez TMDB</string>
 
     <!-- Settings -->
     <string name="settings_title">Paramètres</string>
@@ -90,6 +93,12 @@
     <string name="settings_not_connected">Non connecté</string>
     <string name="settings_connect_to_trakt">Se connecter à Trakt</string>
     <string name="settings_llm_detecting">Détection…</string>
+
+    <string name="home_now_watching">En cours</string>
+    <string name="home_scrobble_started">Lecture démarrée</string>
+    <string name="home_scrobble_paused">En pause</string>
+    <string name="home_scrobble_stopped">Lecture terminée</string>
+    <string name="companion_auto_deactivated">Companion désactivé — TV ne répond pas</string>
 
     <!-- Companion Service -->
     <string name="companion_channel_name">Service compagnon</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -42,6 +42,9 @@
     <string name="home_sync_failed">Sync failed: %1$s</string>
     <string name="home_cd_sync">Sync</string>
     <string name="home_cd_settings">Settings</string>
+    <string name="home_watching_tv_toggle">I am watching TV</string>
+    <string name="home_watching_tv_description">Connect with your TV for scrobbling</string>
+    <string name="home_watching_tv_disabled_reason">Connect to Trakt and configure TMDB first</string>
 
     <!-- Settings -->
     <string name="settings_title">Settings</string>
@@ -92,6 +95,12 @@
     <string name="settings_not_connected">Not connected</string>
     <string name="settings_connect_to_trakt">Connect to Trakt</string>
     <string name="settings_llm_detecting">Detecting…</string>
+
+    <string name="home_now_watching">Now Watching</string>
+    <string name="home_scrobble_started">Started watching</string>
+    <string name="home_scrobble_paused">Paused</string>
+    <string name="home_scrobble_stopped">Finished watching</string>
+    <string name="companion_auto_deactivated">Companion deactivated — TV not responding</string>
 
     <!-- Companion Service -->
     <string name="companion_channel_name">Companion Service</string>

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -18,6 +18,7 @@ import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.llm.RecapGenerator
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import com.justb81.watchbuddy.service.CompanionStateManager
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.*
@@ -44,6 +45,7 @@ class CompanionHttpServerTest {
     private val tmdbApiService: TmdbApiService = mockk()
     private val tmdbCache = TmdbCache()
     private val settingsRepository: SettingsRepository = mockk()
+    private val stateManager = CompanionStateManager()
 
     // ── Shared test fixtures ──────────────────────────────────────────────────
 
@@ -85,7 +87,8 @@ class CompanionHttpServerTest {
         application {
             configureCompanionRoutes(
                 recapGenerator, capabilityProvider, showRepository,
-                tokenRepository, tokenRefreshManager, traktApiService, tmdbApiService, tmdbCache, settingsRepository
+                tokenRepository, tokenRefreshManager, traktApiService, tmdbApiService, tmdbCache, settingsRepository,
+                stateManager
             )
         }
         block()

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModelTest.kt
@@ -8,6 +8,7 @@ import com.justb81.watchbuddy.phone.TestFixtures
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.settings.AppSettings
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import com.justb81.watchbuddy.service.CompanionStateManager
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -37,6 +38,7 @@ class HomeViewModelTest {
     private val tokenRepository: TokenRepository = mockk(relaxed = true)
     private val settingsRepository: SettingsRepository = mockk(relaxed = true)
     private val tmdbApiService: TmdbApiService = mockk(relaxed = true)
+    private val companionStateManager = CompanionStateManager()
 
     @BeforeEach
     fun setUp() {
@@ -50,7 +52,8 @@ class HomeViewModelTest {
         traktApi = traktApi,
         tokenRepository = tokenRepository,
         settingsRepository = settingsRepository,
-        tmdbApiService = tmdbApiService
+        tmdbApiService = tmdbApiService,
+        companionStateManager = companionStateManager
     )
 
     @Nested

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -7,8 +7,14 @@ import android.util.Log
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.model.LlmBackend
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -37,12 +43,16 @@ class PhoneDiscoveryManager @Inject constructor(
         const val SERVICE_TYPE = "_watchbuddy._tcp."
         const val CAPABILITY_PATH = "/capability"
         private const val TAG = "PhoneDiscoveryManager"
+        private const val HEARTBEAT_INTERVAL_MS = 60_000L
+        private const val MAX_FAIL_COUNT = 3
     }
 
     private val _discoveredPhones = MutableStateFlow<List<DiscoveredPhone>>(emptyList())
     val discoveredPhones: StateFlow<List<DiscoveredPhone>> = _discoveredPhones
 
     private val nsdManager = context.getSystemService(Context.NSD_SERVICE) as NsdManager
+    private val heartbeatScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var heartbeatJob: Job? = null
 
     /**
      * Lightweight device info extracted from NSD TXT records.
@@ -59,7 +69,9 @@ class PhoneDiscoveryManager @Inject constructor(
         val txtRecord: PhoneTxtRecord?,
         val capability: DeviceCapability?,
         val score: Int,
-        val baseUrl: String
+        val baseUrl: String,
+        val failCount: Int = 0,
+        val lastSuccessfulCheck: Long = System.currentTimeMillis()
     )
 
     private val discoveryListener = object : NsdManager.DiscoveryListener {
@@ -86,10 +98,52 @@ class PhoneDiscoveryManager @Inject constructor(
 
     fun startDiscovery() {
         nsdManager.discoverServices(SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+        startHeartbeat()
     }
 
     fun stopDiscovery() {
+        heartbeatJob?.cancel()
         runCatching { nsdManager.stopServiceDiscovery(discoveryListener) }
+    }
+
+    private fun startHeartbeat() {
+        heartbeatJob = heartbeatScope.launch {
+            while (true) {
+                delay(HEARTBEAT_INTERVAL_MS)
+                checkAllPhones()
+            }
+        }
+    }
+
+    private fun checkAllPhones() {
+        val phones = _discoveredPhones.value
+        if (phones.isEmpty()) return
+
+        val updated = phones.mapNotNull { phone ->
+            val url = "${phone.baseUrl}${CAPABILITY_PATH}".replace("//capability", "/capability")
+            try {
+                val response = httpClient.newCall(Request.Builder().url(url).build()).execute()
+                val capability = response.body?.string()?.let {
+                    Json.decodeFromString<DeviceCapability>(it)
+                }
+                val newScore = calculateScore(phone.txtRecord, capability)
+                phone.copy(
+                    capability = capability ?: phone.capability,
+                    score = newScore,
+                    failCount = 0,
+                    lastSuccessfulCheck = System.currentTimeMillis()
+                )
+            } catch (e: Exception) {
+                val newFailCount = phone.failCount + 1
+                if (newFailCount >= MAX_FAIL_COUNT) {
+                    Log.i(TAG, "Removing phone ${phone.baseUrl} after $MAX_FAIL_COUNT failed heartbeats")
+                    null
+                } else {
+                    phone.copy(failCount = newFailCount)
+                }
+            }
+        }
+        _discoveredPhones.value = updated.sortedByDescending { it.score }
     }
 
     /**

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt
@@ -47,6 +47,8 @@ class MediaSessionScrobbler @Inject constructor(
         private const val TAG = "MediaSessionScrobbler"
         private const val AUTO_SCROBBLE_THRESHOLD = 0.95f
         private const val OVERLAY_THRESHOLD = 0.70f
+        /** Skip phones whose last successful heartbeat is older than this. */
+        private const val PRESENCE_STALENESS_MS = 2 * 60_000L
     }
 
     private val _pendingConfirmation = MutableSharedFlow<ScrobbleCandidate>()
@@ -226,8 +228,10 @@ class MediaSessionScrobbler @Inject constructor(
      * user confirmation.
      */
     suspend fun autoScrobble(candidate: ScrobbleCandidate) {
+        val now = System.currentTimeMillis()
         val phones = phoneDiscovery.discoveredPhones.value
             .filter { it.capability?.isAvailable == true }
+            .filter { now - it.lastSuccessfulCheck < PRESENCE_STALENESS_MS }
         if (phones.isEmpty()) {
             Log.w(TAG, "No phones available — scrobble skipped")
             return
@@ -255,8 +259,10 @@ class MediaSessionScrobbler @Inject constructor(
     private suspend fun handleScrobblePause(rawTitle: String) {
         if (rawTitle != currentlyScrobbling) return
 
+        val now = System.currentTimeMillis()
         val phones = phoneDiscovery.discoveredPhones.value
             .filter { it.capability?.isAvailable == true }
+            .filter { now - it.lastSuccessfulCheck < PRESENCE_STALENESS_MS }
         if (phones.isEmpty()) return
         val candidate = matchTitle("", rawTitle) ?: return
         val show = candidate.matchedShow ?: return
@@ -280,8 +286,10 @@ class MediaSessionScrobbler @Inject constructor(
     private suspend fun handleScrobbleStop(rawTitle: String) {
         if (rawTitle != currentlyScrobbling) return
 
+        val now = System.currentTimeMillis()
         val phones = phoneDiscovery.discoveredPhones.value
             .filter { it.capability?.isAvailable == true }
+            .filter { now - it.lastSuccessfulCheck < PRESENCE_STALENESS_MS }
         if (phones.isEmpty()) return
         val candidate = matchTitle("", rawTitle) ?: return
         val show = candidate.matchedShow ?: return

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -61,7 +61,7 @@ class TvHomeViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         connectedPhones = phones.size,
-                        bestPhoneName   = best?.capability?.deviceName,
+                        bestPhoneName   = best?.capability?.userName,
                         bestPhoneBackend = best?.capability?.llmBackend?.name
                     )
                 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/userselect/UserSelectScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/userselect/UserSelectScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -22,6 +23,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.graphics.Color
 import androidx.tv.material3.*
+import coil.compose.SubcomposeAsyncImage
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.model.LlmBackend
@@ -139,23 +141,22 @@ private fun UserAvatar(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            // Avatar circle with initials
-            Box(
-                modifier = Modifier
-                    .size(56.dp)
-                    .clip(CircleShape)
-                    .background(
-                        if (isSelected) MaterialTheme.colorScheme.primary
-                        else MaterialTheme.extendedColors.outline
-                    ),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text       = initials,
-                    fontSize   = 22.sp,
-                    fontWeight = FontWeight.Bold,
-                    color      = Color.White
+            // Avatar: Trakt profile image with initials fallback
+            val avatarBackground = if (isSelected) MaterialTheme.colorScheme.primary
+                else MaterialTheme.extendedColors.outline
+            if (user.userAvatarUrl != null) {
+                SubcomposeAsyncImage(
+                    model = user.userAvatarUrl,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier
+                        .size(56.dp)
+                        .clip(CircleShape),
+                    loading = { InitialsCircle(initials, avatarBackground) },
+                    error = { InitialsCircle(initials, avatarBackground) }
                 )
+            } else {
+                InitialsCircle(initials, avatarBackground)
             }
 
             Spacer(Modifier.height(8.dp))
@@ -174,6 +175,24 @@ private fun UserAvatar(
                 color    = llmColor(user.llmBackend)
             )
         }
+    }
+}
+
+@Composable
+private fun InitialsCircle(initials: String, backgroundColor: Color) {
+    Box(
+        modifier = Modifier
+            .size(56.dp)
+            .clip(CircleShape)
+            .background(backgroundColor),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = initials,
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.White
+        )
     }
 }
 

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -104,6 +104,20 @@ data class ScrobbleCandidate(
     val matchedEpisode: TraktEpisode? = null
 )
 
+// ── Scrobble Display ─────────────────────────────────────────────────────────
+
+@Serializable
+enum class ScrobbleAction { START, PAUSE, STOP }
+
+@Serializable
+data class ScrobbleDisplayEvent(
+    val action: ScrobbleAction,
+    val show: TraktShow,
+    val episode: TraktEpisode,
+    val progress: Float,
+    val timestamp: Long
+)
+
 // ── Streaming Deep Links ──────────────────────────────────────────────────────
 
 @Serializable

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,6 +102,50 @@ Multi-user: when multiple phones are connected, each user's watch history is rec
 independently — one `/scrobble/*` call per phone, in parallel. A failure for one user
 does not block the others. The TV never calls the Trakt API directly for any operation.
 
+## Companion Service Lifecycle (Phone)
+
+The phone's companion service is controlled via the "I am watching TV" toggle on the HomeScreen.
+The toggle is visible only when both Trakt and TMDB connections are configured.
+
+**State management:** `CompanionStateManager` (Hilt singleton) is the shared state hub between
+the `CompanionService`, `CompanionHttpServer`, and `HomeViewModel`. It tracks:
+- `lastCapabilityCheck` — timestamp of the most recent `/capability` request from a TV
+- `lastScrobbleEvent` — the latest scrobble event for display on the phone HomeScreen
+- `isServiceRunning` — whether the foreground service is active
+
+**Auto-reconnect:** The service registers a `ConnectivityManager.NetworkCallback` for Wi-Fi.
+When Wi-Fi is lost, NSD is unregistered (HTTP server stays alive). When Wi-Fi returns,
+NSD is re-registered so the TV can rediscover the phone.
+
+**Presence timeout:** A coroutine checks `lastCapabilityCheck` every 60 seconds. If no TV
+has polled `/capability` for 5 minutes, the service auto-deactivates and sets `companionEnabled = false`.
+
+**App close:** `onTaskRemoved()` stops the service and clears `companionEnabled` when the user
+swipes the app from recents.
+
+**Service health sync:** `onStartCommand()` includes a guard to avoid double-starting the HTTP
+server (`if server != null return`).
+
+## Presence Heartbeat (TV)
+
+The TV's `PhoneDiscoveryManager` runs a heartbeat coroutine every 60 seconds that re-fetches
+`GET /capability` for each discovered phone. This serves two purposes:
+
+1. **Presence verification** — if a phone fails 3 consecutive heartbeats, it is removed from
+   the discovered list and excluded from scrobbling.
+2. **Capability refresh** — updated capability data (RAM, LLM backend) is reflected immediately.
+
+The `MediaSessionScrobbler` additionally checks each phone's `lastSuccessfulCheck` timestamp
+before sending scrobble requests. Phones with stale presence (> 2 minutes) are skipped to
+avoid network timeouts during playback.
+
+## Scrobble Event Display (Phone)
+
+When the phone's HTTP server receives a scrobble event (`/scrobble/start|pause|stop`), it
+emits a `ScrobbleDisplayEvent` via `CompanionStateManager`. The phone's HomeScreen observes
+this flow and shows a "Now Watching" card with the show title, episode number, and action
+(started / paused / finished). Events older than 30 minutes are auto-hidden.
+
 ## Secret Storage Strategy
 
 ### Private APK (sideload)


### PR DESCRIPTION
## Summary

Implements the watch/checkin refactoring requested in #188. Users can now check in to the TV directly from the phone via a prominent HomeScreen toggle, with robust presence detection, auto-reconnect, and live scrobble display.

### Changes

- **Phone HomeScreen toggle**: "I am watching TV" toggle gated by Trakt + TMDB availability. Starts/stops the companion service directly from the home screen.
- **CompanionStateManager**: New Hilt singleton as shared state hub between CompanionService, CompanionHttpServer, and HomeViewModel — tracks capability checks, scrobble events, and service running state.
- **Service robustness**: Auto-reconnect via `NetworkCallback` on Wi-Fi changes, 5-minute presence timeout (auto-deactivates if no TV polls), clean shutdown via `onTaskRemoved()` when user swipes app from recents.
- **TV heartbeat**: `PhoneDiscoveryManager` polls `/capability` every 60s per phone. 3 consecutive failures removes the phone. `MediaSessionScrobbler` skips phones with stale presence (>2 min).
- **User display fix**: TV now shows Trakt username instead of device model name (`capability.userName` instead of `capability.deviceName`).
- **Trakt avatars**: `UserSelectScreen` loads Trakt profile images via Coil with initials fallback.
- **Scrobble display**: Phone HomeScreen shows a "Now Watching" card with show title, episode, and action (started/paused/finished). Auto-hides after 30 minutes.
- **Localization**: All new strings translated to EN, DE, FR, ES.
- **Docs**: Updated `architecture.md` and `CLAUDE.md` with new patterns.

## Test plan

- [ ] Verify toggle only appears when Trakt + TMDB are both configured
- [ ] Toggle on → companion service starts, NSD registered; toggle off → service stops
- [ ] Swipe phone app from recents → service stops, toggle resets on next open
- [ ] Toggle Wi-Fi off/on on phone → NSD re-registers, TV re-discovers
- [ ] TV removes phone after ~3 minutes of no network access
- [ ] Phone auto-deactivates after 5 minutes if no TV polls `/capability`
- [ ] TV shows Trakt username (not device model) in home badge and user select
- [ ] User avatars load from Trakt profile URL with initials fallback
- [ ] Play content on TV → phone shows "Now Watching" card with show/episode details
- [ ] Multiple phones connected → TV shows all by username, scrobbles to all present phones
- [ ] CI build passes (`build-android.yml`)

https://claude.ai/code/session_01NHs7m6opREoK5y6VBrCNmY