### PR TITLE
fix(backend): validate Trakt credentials at startup and improve error logging

### DIFF
--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -34,11 +34,19 @@ function buildApp(fetchFn, overrides = {}) {
 // ── Health endpoint ─────────────────────────────────────────────────────────
 
 describe('GET /health', () => {
-  it('returns 200 with status ok', async () => {
+  it('returns 503 with status starting before verification', async () => {
     const app = buildApp(mockFetch(200, {}));
     const res = await request(app).get('/health');
+    expect(res.status).toBe(503);
+    expect(res.body).toEqual({ status: 'starting', trakt: 'pending' });
+  });
+
+  it('returns 200 with status ok after successful verification', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    await app.verifyCredentials();
+    const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ok' });
+    expect(res.body).toEqual({ status: 'ok', trakt: 'connected' });
   });
 });
 
@@ -401,6 +409,181 @@ describe('Unknown routes', () => {
   });
 });
 
+// ── Credential verification ────────────────────────────────────────────────
+
+describe('Credential verification', () => {
+  let logSpy;
+  let errorSpy;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('exposes verifyCredentials as a function on the app', () => {
+    const app = buildApp(mockFetch(200, {}));
+    expect(typeof app.verifyCredentials).toBe('function');
+  });
+
+  it('sends correct headers to Trakt /languages/shows', async () => {
+    const fetchFn = mockFetch(200, []);
+    const app = buildApp(fetchFn);
+    await app.verifyCredentials();
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://api.trakt.tv/languages/shows',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'trakt-api-key': 'test-client-id',
+          'trakt-api-version': '2',
+        }),
+      }),
+    );
+  });
+
+  it('health returns 200 connected after successful verification', async () => {
+    const app = buildApp(mockFetch(200, []));
+    await app.verifyCredentials();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok', trakt: 'connected' });
+  });
+
+  it('health returns 503 invalid_client_id when Trakt returns 403', async () => {
+    const app = buildApp(mockFetch(403, { error: 'invalid_api_key' }));
+    await app.verifyCredentials();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('unhealthy');
+    expect(res.body.trakt).toBe('invalid_client_id');
+    expect(res.body.error).toMatch(/TRAKT_CLIENT_ID/);
+  });
+
+  it('health returns 503 with trakt_http_500 on server error', async () => {
+    const app = buildApp(mockFetch(500, {}));
+    await app.verifyCredentials();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('unhealthy');
+    expect(res.body.trakt).toBe('trakt_http_500');
+  });
+
+  it('health returns 503 timeout when verification times out', async () => {
+    const hangingFetch = vi.fn().mockImplementation((_url, options) => {
+      return new Promise((_resolve, reject) => {
+        if (options?.signal) {
+          options.signal.addEventListener('abort', () => {
+            const err = new Error('The operation was aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }
+      });
+    });
+    const app = buildApp(hangingFetch, { fetchTimeoutMs: 50 });
+    await app.verifyCredentials();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('unhealthy');
+    expect(res.body.trakt).toBe('timeout');
+  });
+
+  it('health returns 503 network_error when fetch rejects', async () => {
+    const failFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const app = buildApp(failFetch);
+    await app.verifyCredentials();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('unhealthy');
+    expect(res.body.trakt).toBe('network_error');
+    expect(res.body.error).toBe('ECONNREFUSED');
+  });
+
+  it('logs success message on valid credentials', async () => {
+    const app = buildApp(mockFetch(200, []));
+    await app.verifyCredentials();
+    expect(logSpy).toHaveBeenCalledWith('Trakt credential verification: OK');
+  });
+
+  it('logs error with TRAKT_CLIENT_ID hint on 403', async () => {
+    const app = buildApp(mockFetch(403, {}));
+    await app.verifyCredentials();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('TRAKT_CLIENT_ID'),
+    );
+  });
+});
+
+// ── Error logging ──────────────────────────────────────────────────────────
+
+describe('Error logging improvements', () => {
+  let errorSpy;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('logs body snippet when Trakt returns non-OK on token exchange', async () => {
+    const app = buildApp(mockFetch(403, { error: 'invalid_api_key' }));
+    await request(app).post('/trakt/token').send({ code: 'test-code' });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('HTTP 403'),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('invalid_api_key'),
+    );
+  });
+
+  it('logs TRAKT_CLIENT_ID hint on 403 for token exchange', async () => {
+    const app = buildApp(mockFetch(403, { error: 'invalid_api_key' }));
+    await request(app).post('/trakt/token').send({ code: 'test-code' });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('TRAKT_CLIENT_ID'),
+    );
+  });
+
+  it('logs TRAKT_CLIENT_ID hint on 403 for token refresh', async () => {
+    const app = buildApp(mockFetch(403, { error: 'invalid_api_key' }));
+    await request(app).post('/trakt/token/refresh').send({ refresh_token: 'old-token' });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('TRAKT_CLIENT_ID'),
+    );
+  });
+
+  it('logs network error code on ECONNREFUSED for token exchange', async () => {
+    const err = new Error('connect ECONNREFUSED');
+    err.code = 'ECONNREFUSED';
+    const failFetch = vi.fn().mockRejectedValue(err);
+    const app = buildApp(failFetch);
+    await request(app).post('/trakt/token').send({ code: 'test-code' });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('network error (ECONNREFUSED)'),
+      expect.any(String),
+    );
+  });
+
+  it('logs network error code on ECONNREFUSED for token refresh', async () => {
+    const err = new Error('connect ECONNREFUSED');
+    err.code = 'ECONNREFUSED';
+    const failFetch = vi.fn().mockRejectedValue(err);
+    const app = buildApp(failFetch);
+    await request(app).post('/trakt/token/refresh').send({ refresh_token: 'old-token' });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('network error (ECONNREFUSED)'),
+      expect.any(String),
+    );
+  });
+});
+
 // ── Debug logging ───────────────────────────────────────────────────────────
 
 describe('Debug logging (debug: true)', () => {
@@ -416,6 +599,7 @@ describe('Debug logging (debug: true)', () => {
 
   it('logs a debug line for GET /health when debug is enabled', async () => {
     const app = buildApp(mockFetch(200, {}), { debug: true });
+    await app.verifyCredentials();
     await request(app).get('/health');
     expect(debugSpy).toHaveBeenCalledOnce();
     expect(debugSpy.mock.calls[0][0]).toMatch(/\[DEBUG\].*GET.*\/health.*200/);

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -58,6 +58,53 @@ export function createApp(config) {
     }
   }
 
+  // Credential verification state
+  let traktStatus = 'pending';
+  let traktError = null;
+  let credentialsVerified = false;
+
+  async function verifyCredentials() {
+    try {
+      const res = await fetchWithTimeout(`${traktApi}/languages/shows`, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          'trakt-api-key': clientId,
+          'trakt-api-version': '2',
+        },
+      });
+
+      if (res.ok) {
+        traktStatus = 'connected';
+        traktError = null;
+        credentialsVerified = true;
+        console.log('Trakt credential verification: OK');
+      } else if (res.status === 403) {
+        traktStatus = 'invalid_client_id';
+        traktError = 'Trakt returned 403 Forbidden — check that TRAKT_CLIENT_ID is correct.';
+        credentialsVerified = false;
+        console.error('Trakt credential verification failed: HTTP 403 — TRAKT_CLIENT_ID may be invalid.');
+      } else {
+        traktStatus = `trakt_http_${res.status}`;
+        traktError = `Trakt returned HTTP ${res.status} during credential check`;
+        credentialsVerified = false;
+        console.error(`Trakt credential verification failed: HTTP ${res.status}`);
+      }
+    } catch (err) {
+      if (err.name === 'AbortError') {
+        traktStatus = 'timeout';
+        traktError = 'Trakt API did not respond within timeout';
+        credentialsVerified = false;
+        console.error('Trakt credential verification failed: timeout');
+      } else {
+        traktStatus = 'network_error';
+        traktError = err.message;
+        credentialsVerified = false;
+        console.error('Trakt credential verification failed: network error:', err.message);
+      }
+    }
+  }
+
   const app = express();
   app.use(helmet());
   app.use(express.json());
@@ -114,6 +161,11 @@ export function createApp(config) {
       }
 
       if (!traktRes.ok) {
+        const bodySnippet = JSON.stringify(data).slice(0, 200);
+        console.error(`Token exchange: Trakt returned HTTP ${traktRes.status}: ${bodySnippet}`);
+        if (traktRes.status === 403) {
+          console.error('Hint: HTTP 403 from Trakt usually means TRAKT_CLIENT_ID is invalid or revoked.');
+        }
         return res.status(traktRes.status).json(data);
       }
 
@@ -127,10 +179,13 @@ export function createApp(config) {
       });
     } catch (err) {
       if (err.name === 'AbortError') {
-        console.error('Token exchange timeout');
+        console.error('Token exchange: upstream timeout after', fetchTimeoutMs, 'ms');
         return res.status(504).json({ error: 'Upstream timeout' });
       }
-      console.error('Token exchange error:', err);
+      const category = err.code
+        ? `network error (${err.code})`
+        : `unexpected error (${err.name})`;
+      console.error(`Token exchange: ${category}:`, err.message);
       return res.status(502).json({ error: 'Upstream error' });
     }
   });
@@ -163,7 +218,14 @@ export function createApp(config) {
           error: `Upstream returned non-JSON response (HTTP ${traktRes.status})`,
         });
       }
-      if (!traktRes.ok) return res.status(traktRes.status).json(data);
+      if (!traktRes.ok) {
+        const bodySnippet = JSON.stringify(data).slice(0, 200);
+        console.error(`Token refresh: Trakt returned HTTP ${traktRes.status}: ${bodySnippet}`);
+        if (traktRes.status === 403) {
+          console.error('Hint: HTTP 403 from Trakt usually means TRAKT_CLIENT_ID is invalid or revoked.');
+        }
+        return res.status(traktRes.status).json(data);
+      }
 
       return res.json({
         access_token: data.access_token,
@@ -172,16 +234,33 @@ export function createApp(config) {
       });
     } catch (err) {
       if (err.name === 'AbortError') {
-        console.error('Token refresh timeout');
+        console.error('Token refresh: upstream timeout after', fetchTimeoutMs, 'ms');
         return res.status(504).json({ error: 'Upstream timeout' });
       }
-      console.error('Token refresh error:', err);
+      const category = err.code
+        ? `network error (${err.code})`
+        : `unexpected error (${err.name})`;
+      console.error(`Token refresh: ${category}:`, err.message);
       return res.status(502).json({ error: 'Upstream error' });
     }
   });
 
   // ── GET /health ─────────────────────────────────────────────────────────────
-  app.get('/health', (_req, res) => res.json({ status: 'ok' }));
+  app.get('/health', (_req, res) => {
+    if (traktStatus === 'pending') {
+      return res.status(503).json({ status: 'starting', trakt: 'pending' });
+    }
+    if (credentialsVerified) {
+      return res.json({ status: 'ok', trakt: 'connected' });
+    }
+    return res.status(503).json({
+      status: 'unhealthy',
+      trakt: traktStatus,
+      error: traktError,
+    });
+  });
+
+  app.verifyCredentials = verifyCredentials;
 
   return app;
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -37,4 +37,7 @@ app.listen(PORT, () => {
   if (debug) {
     console.log('Debug mode enabled — request logging is active');
   }
+  // Verify Trakt credentials in the background — health endpoint
+  // will report "starting" until this completes.
+  app.verifyCredentials();
 });


### PR DESCRIPTION
## Summary

- **Credential verification at startup**: The health endpoint (`GET /health`) now returns `503` until `TRAKT_CLIENT_ID` is validated against the Trakt API (`GET /languages/shows`). Docker healthcheck naturally gates on this — the container won't be marked "healthy" with invalid credentials.
- **Improved error logging for 502/403**: Upstream response bodies are now logged as snippets on non-OK responses. HTTP 403 errors include a hint pointing to `TRAKT_CLIENT_ID` as the likely cause. Network errors are categorized by code (`ECONNREFUSED`, `ENOTFOUND`, etc.) for faster debugging.
- **Three-state health endpoint**: `starting` (pending verification), `ok` (credentials valid), `unhealthy` (with specific error key: `invalid_client_id`, `trakt_http_<status>`, `timeout`, `network_error`).

## Test plan

- [x] All 49 backend tests pass (`npm test`), including 14 new tests covering credential verification states and error logging
- [ ] Manual: start with valid credentials → `curl /health` returns `200 {status: "ok", trakt: "connected"}`
- [ ] Manual: start with bad `TRAKT_CLIENT_ID` → `curl /health` returns `503 {status: "unhealthy", trakt: "invalid_client_id", ...}`
- [ ] Docker: `docker compose up` → container stays "starting" until verification passes

https://claude.ai/code/session_01AdMnZrktn4CBJDuRWHPjjG