### PR TITLE
feat(backend): use runtime env vars instead of .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,6 @@ local.defaults.properties
 # Node.js (backend)
 node_modules/
 dist/
-backend/.env
-backend/.env.local
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ To add a new language, create `values-<locale>/strings.xml` in both `app-phone/s
 ### Backend (Token Proxy)
 ```bash
 cd backend
-cp .env.example .env   # add your Trakt client_secret here
+export TRAKT_CLIENT_ID=your_trakt_client_id_here
+export TRAKT_CLIENT_SECRET=your_trakt_client_secret_here
 docker-compose up -d
 ```
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,7 +1,0 @@
-# Copy this to .env and fill in your values — NEVER commit .env to git!
-TRAKT_CLIENT_ID=your_trakt_client_id_here
-TRAKT_CLIENT_SECRET=your_trakt_client_secret_here
-PORT=3000
-
-# CORS is not enabled — this proxy is called server-to-server from Android apps.
-# ALLOWED_ORIGINS=com.justb81.watchbuddy

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -5,8 +5,11 @@ services:
     restart: unless-stopped
     ports:
       - "3000:3000"
-    env_file:
-      - .env
+    environment:
+      - TRAKT_CLIENT_ID
+      - TRAKT_CLIENT_SECRET
+      - PORT
+      - DEBUG_MODE
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:3000/health"]
       interval: 30s

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,7 +8,6 @@
       "name": "watchbuddy-backend",
       "version": "1.0.0",
       "dependencies": {
-        "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "express-rate-limit": "^7.1.5",
         "helmet": "^8.0.0"
@@ -1337,18 +1336,6 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,6 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-rate-limit": "^7.1.5",
     "helmet": "^8.0.0"

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -14,13 +14,12 @@
  * that injects the server-side client_secret.
  */
 
-import 'dotenv/config';
 import { createApp } from './app.js';
 
 const { TRAKT_CLIENT_ID, TRAKT_CLIENT_SECRET, PORT = 3000, DEBUG_MODE } = process.env;
 
 if (!TRAKT_CLIENT_ID || !TRAKT_CLIENT_SECRET) {
-  console.error('ERROR: TRAKT_CLIENT_ID and TRAKT_CLIENT_SECRET must be set in .env');
+  console.error('ERROR: TRAKT_CLIENT_ID and TRAKT_CLIENT_SECRET must be set as environment variables');
   process.exit(1);
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ Das Gradle-Skript liest diese Variablen via `System.getenv()` und priorisiert si
 
 ## Token-Proxy-Backend (`backend/`)
 
-**Datei:** `backend/.env` (aus `backend/.env.example` kopieren, **nie committen**)
+**Konfiguration:** Umgebungsvariablen werden direkt an den Docker-Container weitergereicht (siehe `backend/docker-compose.yml`).
 
 | Variable              | Beschreibung                                                      |
 |-----------------------|-------------------------------------------------------------------|
@@ -37,10 +37,10 @@ Das Gradle-Skript liest diese Variablen via `System.getenv()` und priorisiert si
 | `PORT`                | HTTP-Port des Backends (Default: `3000`).                         |
 
 ```bash
-# backend/.env (Beispiel)
-TRAKT_CLIENT_ID=your_trakt_client_id_here
-TRAKT_CLIENT_SECRET=your_trakt_client_secret_here
-PORT=3000
+# Umgebungsvariablen auf dem Host setzen (z.B. in der Shell oder in CI/CD)
+export TRAKT_CLIENT_ID=your_trakt_client_id_here
+export TRAKT_CLIENT_SECRET=your_trakt_client_secret_here
+export PORT=3000   # optional, Default: 3000
 ```
 
 ---
@@ -59,5 +59,5 @@ Alle Werte erhältst du unter: **https://trakt.tv/oauth/applications/new**
 - [ ] Trakt-App unter https://trakt.tv/oauth/applications registriert
 - [ ] `TRAKT_CLIENT_ID` in `app-phone/build.gradle.kts` (oder CI-Env) gesetzt
 - [ ] `TOKEN_BACKEND_URL` in `app-phone/build.gradle.kts` (oder CI-Env) gesetzt
-- [ ] `backend/.env` aus `backend/.env.example` erstellt und befüllt
+- [ ] Umgebungsvariablen `TRAKT_CLIENT_ID` und `TRAKT_CLIENT_SECRET` auf dem Host gesetzt
 - [ ] Backend deployed / lokal gestartet (`npm start` in `backend/`)


### PR DESCRIPTION
## Summary

- Replace `env_file: - .env` in `docker-compose.yml` with an `environment:` section that passes host environment variables (`TRAKT_CLIENT_ID`, `TRAKT_CLIENT_SECRET`, `PORT`, `DEBUG_MODE`) directly into the container at runtime
- Remove the `dotenv` npm dependency and its import in `index.js`
- Delete `backend/.env.example` (no longer needed — variables are documented in `docker-compose.yml`)
- Update `README.md`, `docs/configuration.md`, and `.gitignore` to reflect the new workflow

## Test plan

- [x] All 49 backend tests pass (`npm test`)
- [ ] Verify Docker deployment: `export TRAKT_CLIENT_ID=... TRAKT_CLIENT_SECRET=...` then `docker-compose up --build -d` and `curl /health`
- [ ] Verify container exits with clear error when env vars are missing

https://claude.ai/code/session_01TEGaAxbkd9E8mGEMFLb8JN