### PR TITLE
fix(backend): fix Trakt API 403 errors and add debug logging

### DIFF
--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -3,11 +3,12 @@ import request from 'supertest';
 import { createApp } from '../app.js';
 
 /** Helper: build a mock fetch that resolves with the given status and body. */
-function mockFetch(status, body) {
+function mockFetch(status, body, headers = new Map()) {
   return vi.fn().mockResolvedValue({
     ok: status >= 200 && status < 300,
     status,
     json: () => Promise.resolve(body),
+    headers: { forEach: (cb) => headers.forEach((v, k) => cb(v, k)) },
   });
 }
 
@@ -17,6 +18,7 @@ function mockFetchHtml(status) {
     ok: status >= 200 && status < 300,
     status,
     json: () => Promise.reject(new SyntaxError("Unexpected token '<', \"<html>...\" is not valid JSON")),
+    headers: { forEach: (cb) => new Map().forEach((v, k) => cb(v, k)) },
   });
 }
 
@@ -109,7 +111,11 @@ describe('POST /trakt/token', () => {
       'https://api.trakt.tv/oauth/device/token',
       expect.objectContaining({
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'trakt-api-key': 'test-client-id',
+          'trakt-api-version': '2',
+        },
         body: JSON.stringify({
           code: 'device-code-abc',
           client_id: 'test-client-id',
@@ -282,15 +288,29 @@ describe('POST /trakt/token/refresh', () => {
       'https://api.trakt.tv/oauth/token',
       expect.objectContaining({
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'trakt-api-key': 'test-client-id',
+          'trakt-api-version': '2',
+        },
         body: JSON.stringify({
           refresh_token: 'old-ref-token',
           client_id: 'test-client-id',
           client_secret: 'test-client-secret',
+          redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
           grant_type: 'refresh_token',
         }),
       }),
     );
+  });
+
+  it('includes redirect_uri in the refresh payload', async () => {
+    await request(app)
+      .post('/trakt/token/refresh')
+      .send({ refresh_token: 'old-ref-token' });
+
+    const callBody = JSON.parse(fetchFn.mock.calls[0][1].body);
+    expect(callBody.redirect_uri).toBe('urn:ietf:wg:oauth:2.0:oob');
   });
 
   it('does not leak client_secret in response', async () => {
@@ -601,27 +621,29 @@ describe('Debug logging (debug: true)', () => {
     const app = buildApp(mockFetch(200, {}), { debug: true });
     await app.verifyCredentials();
     await request(app).get('/health');
-    expect(debugSpy).toHaveBeenCalledOnce();
-    expect(debugSpy.mock.calls[0][0]).toMatch(/\[DEBUG\].*GET.*\/health.*200/);
+    const healthLog = debugSpy.mock.calls.find(([msg]) =>
+      /\[DEBUG\].*GET.*\/health.*200/.test(msg),
+    );
+    expect(healthLog).toBeDefined();
   });
 
   it('log line includes method, path, status, and timing', async () => {
     const app = buildApp(mockFetch(200, {}), { debug: true });
     await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
-    expect(debugSpy).toHaveBeenCalledOnce();
-    const msg = debugSpy.mock.calls[0][0];
-    expect(msg).toMatch(/\[DEBUG\]/);
-    expect(msg).toMatch(/POST/);
-    expect(msg).toMatch(/\/trakt\/token/);
-    expect(msg).toMatch(/200/);
-    expect(msg).toMatch(/\d+ms/);
+    // The debug middleware logs request timing; logTraktCall also logs Trakt API details
+    const requestLog = debugSpy.mock.calls.find(([msg]) =>
+      /\[DEBUG\].*POST.*\/trakt\/token.*\d+ms/.test(msg),
+    );
+    expect(requestLog).toBeDefined();
   });
 
   it('logs debug line even when the endpoint returns an error status', async () => {
     const app = buildApp(mockFetch(400, { error: 'invalid_grant' }), { debug: true });
     await request(app).post('/trakt/token').send({ code: 'bad-code' });
-    expect(debugSpy).toHaveBeenCalledOnce();
-    expect(debugSpy.mock.calls[0][0]).toMatch(/400/);
+    const requestLog = debugSpy.mock.calls.find(([msg]) =>
+      /\[DEBUG\].*400.*ms/.test(msg),
+    );
+    expect(requestLog).toBeDefined();
   });
 
   it('logs one line per request for multiple requests', async () => {
@@ -653,5 +675,127 @@ describe('Debug logging (debug: false / default)', () => {
     const app = buildApp(mockFetch(200, {}));
     await request(app).get('/health');
     expect(debugSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ── Trakt API call debug logging ──────────────────────────────────────────
+
+describe('Debug logging — Trakt API call details (debug: true)', () => {
+  let debugSpy;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+  });
+
+  it('logs outgoing request details for token exchange', async () => {
+    const app = buildApp(mockFetch(200, {
+      access_token: 'acc-123',
+      refresh_token: 'ref-456',
+      expires_in: 7776000,
+      token_type: 'Bearer',
+      scope: 'public',
+    }), { debug: true });
+
+    await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
+
+    const allLogs = debugSpy.mock.calls.map(c => c.join(' '));
+    expect(allLogs.some(l => l.includes('Token exchange') && l.includes('/oauth/device/token'))).toBe(true);
+    expect(allLogs.some(l => l.includes('Token exchange') && l.includes('request body'))).toBe(true);
+    expect(allLogs.some(l => l.includes('Token exchange') && l.includes('response status') && l.includes('200'))).toBe(true);
+    expect(allLogs.some(l => l.includes('Token exchange') && l.includes('response body'))).toBe(true);
+  });
+
+  it('logs outgoing request details for token refresh', async () => {
+    const app = buildApp(mockFetch(200, {
+      access_token: 'new-acc-789',
+      refresh_token: 'new-ref-012',
+      expires_in: 7776000,
+    }), { debug: true });
+
+    await request(app).post('/trakt/token/refresh').send({ refresh_token: 'old-ref-token' });
+
+    const allLogs = debugSpy.mock.calls.map(c => c.join(' '));
+    expect(allLogs.some(l => l.includes('Token refresh') && l.includes('/oauth/token'))).toBe(true);
+    expect(allLogs.some(l => l.includes('Token refresh') && l.includes('request body'))).toBe(true);
+    expect(allLogs.some(l => l.includes('Token refresh') && l.includes('response status') && l.includes('200'))).toBe(true);
+  });
+
+  it('masks client_secret in debug logs', async () => {
+    const app = buildApp(mockFetch(200, {
+      access_token: 'acc-123',
+      refresh_token: 'ref-456',
+      expires_in: 7776000,
+      token_type: 'Bearer',
+      scope: 'public',
+    }), { debug: true });
+
+    await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
+
+    const allLogs = debugSpy.mock.calls.map(c => c.join(' '));
+    const bodyLog = allLogs.find(l => l.includes('request body'));
+    expect(bodyLog).toBeDefined();
+    expect(bodyLog).not.toContain('test-client-secret');
+    expect(bodyLog).toContain('test***');
+  });
+
+  it('masks access_token and refresh_token in response body debug logs', async () => {
+    const app = buildApp(mockFetch(200, {
+      access_token: 'acc-full-secret-token',
+      refresh_token: 'ref-full-secret-token',
+      expires_in: 7776000,
+      token_type: 'Bearer',
+      scope: 'public',
+    }), { debug: true });
+
+    await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
+
+    const allLogs = debugSpy.mock.calls.map(c => c.join(' '));
+    const bodyLog = allLogs.find(l => l.includes('response body'));
+    expect(bodyLog).toBeDefined();
+    expect(bodyLog).not.toContain('acc-full-secret-token');
+    expect(bodyLog).not.toContain('ref-full-secret-token');
+    expect(bodyLog).toContain('acc-***');
+    expect(bodyLog).toContain('ref-***');
+  });
+
+  it('logs response headers when present', async () => {
+    const headers = new Map([
+      ['x-ratelimit-limit', '1000'],
+      ['content-type', 'application/json'],
+    ]);
+    const app = buildApp(mockFetch(200, {
+      access_token: 'acc-123',
+      refresh_token: 'ref-456',
+      expires_in: 7776000,
+      token_type: 'Bearer',
+      scope: 'public',
+    }, headers), { debug: true });
+
+    await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
+
+    const allLogs = debugSpy.mock.calls.map(c => c.join(' '));
+    const headerLog = allLogs.find(l => l.includes('response headers'));
+    expect(headerLog).toBeDefined();
+    expect(headerLog).toContain('x-ratelimit-limit');
+    expect(headerLog).toContain('1000');
+  });
+
+  it('does not log Trakt API call details when debug is false', async () => {
+    const app = buildApp(mockFetch(200, {
+      access_token: 'acc-123',
+      refresh_token: 'ref-456',
+      expires_in: 7776000,
+      token_type: 'Bearer',
+      scope: 'public',
+    }));
+
+    await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
+
+    const allLogs = debugSpy.mock.calls.map(c => c.join(' '));
+    expect(allLogs.some(l => l.includes('Token exchange'))).toBe(false);
   });
 });

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -26,6 +26,22 @@ function validateField(value, fieldName) {
   return null;
 }
 
+const SECRET_KEYS = ['client_secret', 'refresh_token', 'access_token'];
+
+/**
+ * Returns a shallow copy of `obj` with sensitive values masked (first 4 chars + "***").
+ */
+function maskSecrets(obj) {
+  if (!obj || typeof obj !== 'object') return obj;
+  const masked = { ...obj };
+  for (const key of SECRET_KEYS) {
+    if (masked[key] && typeof masked[key] === 'string') {
+      masked[key] = masked[key].slice(0, 4) + '***';
+    }
+  }
+  return masked;
+}
+
 /**
  * Creates a configured Express app for the Trakt token proxy.
  *
@@ -48,6 +64,12 @@ export function createApp(config) {
     debug = false,
   } = config;
 
+  const traktHeaders = {
+    'Content-Type': 'application/json',
+    'trakt-api-key': clientId,
+    'trakt-api-version': '2',
+  };
+
   async function fetchWithTimeout(url, options) {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), fetchTimeoutMs);
@@ -58,21 +80,49 @@ export function createApp(config) {
     }
   }
 
+  /**
+   * Logs full request/response details for a Trakt API call when debug mode is on.
+   */
+  function logTraktCall(label, url, options, traktRes, data) {
+    if (!debug) return;
+
+    const outgoingBody = options.body
+      ? maskSecrets(JSON.parse(options.body))
+      : undefined;
+
+    const responseHeaders = {};
+    if (traktRes.headers?.forEach) {
+      traktRes.headers.forEach((value, key) => {
+        responseHeaders[key] = value;
+      });
+    }
+
+    console.debug(`[DEBUG] ${label} → ${options.method} ${url}`);
+    console.debug(`[DEBUG] ${label} request headers:`, JSON.stringify(options.headers));
+    if (outgoingBody) {
+      console.debug(`[DEBUG] ${label} request body:`, JSON.stringify(outgoingBody));
+    }
+    console.debug(`[DEBUG] ${label} response status: ${traktRes.status}`);
+    console.debug(`[DEBUG] ${label} response headers:`, JSON.stringify(responseHeaders));
+    if (data !== undefined) {
+      const maskedData = maskSecrets(data);
+      const snippet = JSON.stringify(maskedData).slice(0, 500);
+      console.debug(`[DEBUG] ${label} response body:`, snippet);
+    }
+  }
+
   // Credential verification state
   let traktStatus = 'pending';
   let traktError = null;
   let credentialsVerified = false;
 
   async function verifyCredentials() {
+    const url = `${traktApi}/languages/shows`;
+    const options = { method: 'GET', headers: traktHeaders };
     try {
-      const res = await fetchWithTimeout(`${traktApi}/languages/shows`, {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-          'trakt-api-key': clientId,
-          'trakt-api-version': '2',
-        },
-      });
+      const res = await fetchWithTimeout(url, options);
+
+      logTraktCall('Credential check', url, options, res);
 
       if (res.ok) {
         traktStatus = 'connected';
@@ -139,26 +189,32 @@ export function createApp(config) {
     const codeError = validateField(code, 'code');
     if (codeError) return res.status(400).json({ error: codeError });
 
+    const url = `${traktApi}/oauth/device/token`;
+    const options = {
+      method: 'POST',
+      headers: traktHeaders,
+      body: JSON.stringify({
+        code,
+        client_id: clientId,
+        client_secret: clientSecret,
+      }),
+    };
+
     try {
-      const traktRes = await fetchWithTimeout(`${traktApi}/oauth/device/token`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          code,
-          client_id: clientId,
-          client_secret: clientSecret,
-        }),
-      });
+      const traktRes = await fetchWithTimeout(url, options);
 
       let data;
       try {
         data = await traktRes.json();
       } catch (_parseErr) {
         console.error(`Token exchange: Trakt returned non-JSON response (HTTP ${traktRes.status})`);
+        logTraktCall('Token exchange (non-JSON)', url, options, traktRes);
         return res.status(502).json({
           error: `Upstream returned non-JSON response (HTTP ${traktRes.status})`,
         });
       }
+
+      logTraktCall('Token exchange', url, options, traktRes, data);
 
       if (!traktRes.ok) {
         const bodySnippet = JSON.stringify(data).slice(0, 200);
@@ -197,27 +253,35 @@ export function createApp(config) {
     const rtError = validateField(refresh_token, 'refresh_token');
     if (rtError) return res.status(400).json({ error: rtError });
 
+    const url = `${traktApi}/oauth/token`;
+    const options = {
+      method: 'POST',
+      headers: traktHeaders,
+      body: JSON.stringify({
+        refresh_token,
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uri: 'urn:ietf:wg:oauth:2.0:oob',
+        grant_type: 'refresh_token',
+      }),
+    };
+
     try {
-      const traktRes = await fetchWithTimeout(`${traktApi}/oauth/token`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          refresh_token,
-          client_id: clientId,
-          client_secret: clientSecret,
-          grant_type: 'refresh_token',
-        }),
-      });
+      const traktRes = await fetchWithTimeout(url, options);
 
       let data;
       try {
         data = await traktRes.json();
       } catch (_parseErr) {
         console.error(`Token refresh: Trakt returned non-JSON response (HTTP ${traktRes.status})`);
+        logTraktCall('Token refresh (non-JSON)', url, options, traktRes);
         return res.status(502).json({
           error: `Upstream returned non-JSON response (HTTP ${traktRes.status})`,
         });
       }
+
+      logTraktCall('Token refresh', url, options, traktRes, data);
+
       if (!traktRes.ok) {
         const bodySnippet = JSON.stringify(data).slice(0, 200);
         console.error(`Token refresh: Trakt returned HTTP ${traktRes.status}: ${bodySnippet}`);


### PR DESCRIPTION
## Summary

- **Fix missing `redirect_uri`** in token refresh requests — Trakt requires this field on `/oauth/token` and its absence can cause 403 errors
- **Fix missing `trakt-api-key` and `trakt-api-version` headers** on the token exchange and refresh endpoints — the credential verification already sent these, but the OAuth endpoints did not, despite Trakt requiring them on all requests
- **Add comprehensive debug logging** (gated behind `DEBUG_MODE=true`) that logs full request/response details for every Trakt API call: outgoing URL, headers, body (secrets masked), response status, response headers (including rate-limit info), and response body (secrets masked, truncated)

### Root causes of 403 errors

1. The `/trakt/token/refresh` handler was calling Trakt's `/oauth/token` without `redirect_uri: 'urn:ietf:wg:oauth:2.0:oob'` in the body
2. Both `/trakt/token` and `/trakt/token/refresh` were sending only `Content-Type` as a header, omitting the required `trakt-api-key` and `trakt-api-version` headers

### Debug logging details

When `DEBUG_MODE=true`, each Trakt API call now logs:
```
[DEBUG] Token exchange → POST https://api.trakt.tv/oauth/device/token
[DEBUG] Token exchange request headers: {"Content-Type":"application/json","trakt-api-key":"...","trakt-api-version":"2"}
[DEBUG] Token exchange request body: {"code":"...","client_id":"...","client_secret":"test***"}
[DEBUG] Token exchange response status: 200
[DEBUG] Token exchange response headers: {"x-ratelimit-limit":"1000",...}
[DEBUG] Token exchange response body: {"access_token":"acc-***","refresh_token":"ref-***",...}
```

Sensitive values (`client_secret`, `access_token`, `refresh_token`) are masked to show only the first 4 characters.

### SDK decision

Investigated the `trakt.tv` npm package but decided against it — the proxy only makes 2 OAuth calls and 1 credential check. An SDK would add a dependency, obscure the HTTP calls (counterproductive for debugging), and fight the existing timeout/secret-masking design.

## Test plan

- [x] All 56 backend tests pass (including 7 new tests for debug logging)
- [ ] Deploy with `DEBUG_MODE=true` and verify full request/response logging appears for token exchange and refresh
- [ ] Verify 403 errors are resolved after the header and `redirect_uri` fixes
- [ ] Confirm `/health` endpoint still reports `connected` status

https://claude.ai/code/session_01BWgtqnGwebGdoQPYjSCoLv