### PR TITLE
fix(backend): use /certifications/shows for Trakt credential check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,12 @@ watchbuddy/
 - **CI/CD:** GitHub Actions, release-please (Conventional Commits)
 - **Backend:** Node.js, Docker
 
+## External API References
+
+- **Trakt API:** https://github.com/trakt/trakt-api (official, contracts in `projects/api/src/contracts/`)
+  - Do NOT use the outdated Apiary docs (`trakt.docs.apiary.io`) — they reference deprecated endpoints.
+- **TMDB API:** https://developer.themoviedb.org/docs
+
 ## Key Conventions
 
 ### Language — MANDATORY

--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -48,7 +48,7 @@ describe('GET /health', () => {
     await app.verifyCredentials();
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ok', trakt: 'connected' });
+    expect(res.body).toEqual({ status: 'ok', trakt: 'connected', validated: 'client_id_only' });
   });
 });
 
@@ -450,12 +450,12 @@ describe('Credential verification', () => {
     expect(typeof app.verifyCredentials).toBe('function');
   });
 
-  it('sends correct headers to Trakt /languages/shows', async () => {
+  it('sends correct headers to Trakt /certifications/shows', async () => {
     const fetchFn = mockFetch(200, []);
     const app = buildApp(fetchFn);
     await app.verifyCredentials();
     expect(fetchFn).toHaveBeenCalledWith(
-      'https://api.trakt.tv/languages/shows',
+      'https://api.trakt.tv/certifications/shows',
       expect.objectContaining({
         method: 'GET',
         headers: expect.objectContaining({
@@ -471,7 +471,7 @@ describe('Credential verification', () => {
     await app.verifyCredentials();
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ok', trakt: 'connected' });
+    expect(res.body).toEqual({ status: 'ok', trakt: 'connected', validated: 'client_id_only' });
   });
 
   it('health returns 503 invalid_client_id when Trakt returns 403', async () => {
@@ -536,6 +536,32 @@ describe('Credential verification', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('TRAKT_CLIENT_ID'),
     );
+  });
+
+  it('health returns 503 invalid_client_id when Trakt returns 401', async () => {
+    const app = buildApp(mockFetch(401, { error: 'unauthorized' }));
+    await app.verifyCredentials();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe('unhealthy');
+    expect(res.body.trakt).toBe('invalid_client_id');
+    expect(res.body.error).toMatch(/TRAKT_CLIENT_ID/);
+  });
+
+  it('logs response body snippet when credential check fails', async () => {
+    const app = buildApp(mockFetch(403, { error: 'invalid_api_key' }));
+    await app.verifyCredentials();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('invalid_api_key'),
+    );
+  });
+
+  it('handles non-JSON response gracefully during credential check', async () => {
+    const app = buildApp(mockFetchHtml(200));
+    await app.verifyCredentials();
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.trakt).toBe('connected');
   });
 });
 
@@ -782,6 +808,16 @@ describe('Debug logging — Trakt API call details (debug: true)', () => {
     expect(headerLog).toBeDefined();
     expect(headerLog).toContain('x-ratelimit-limit');
     expect(headerLog).toContain('1000');
+  });
+
+  it('logs response body for credential check when debug is enabled', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const app = buildApp(mockFetch(200, [{ slug: 'tv-pg', name: 'TV-PG' }]), { debug: true });
+    await app.verifyCredentials();
+    logSpy.mockRestore();
+
+    const allLogs = debugSpy.mock.calls.map(c => c.join(' '));
+    expect(allLogs.some(l => l.includes('Credential check') && l.includes('response body'))).toBe(true);
   });
 
   it('does not log Trakt API call details when debug is false', async () => {

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -117,27 +117,42 @@ export function createApp(config) {
   let credentialsVerified = false;
 
   async function verifyCredentials() {
-    const url = `${traktApi}/languages/shows`;
+    const url = `${traktApi}/certifications/shows`;
     const options = { method: 'GET', headers: traktHeaders };
     try {
       const res = await fetchWithTimeout(url, options);
 
-      logTraktCall('Credential check', url, options, res);
+      let data;
+      try {
+        data = await res.json();
+      } catch (_parseErr) {
+        data = undefined;
+      }
+
+      logTraktCall('Credential check', url, options, res, data);
 
       if (res.ok) {
         traktStatus = 'connected';
         traktError = null;
         credentialsVerified = true;
         console.log('Trakt credential verification: OK');
-      } else if (res.status === 403) {
+      } else if (res.status === 401 || res.status === 403) {
         traktStatus = 'invalid_client_id';
-        traktError = 'Trakt returned 403 Forbidden — check that TRAKT_CLIENT_ID is correct.';
+        traktError = `Trakt returned ${res.status} — check that TRAKT_CLIENT_ID is correct.`;
         credentialsVerified = false;
-        console.error('Trakt credential verification failed: HTTP 403 — TRAKT_CLIENT_ID may be invalid.');
+        if (data !== undefined) {
+          const bodySnippet = JSON.stringify(data).slice(0, 200);
+          console.error(`Credential check: Trakt response body: ${bodySnippet}`);
+        }
+        console.error(`Trakt credential verification failed: HTTP ${res.status} — TRAKT_CLIENT_ID may be invalid.`);
       } else {
         traktStatus = `trakt_http_${res.status}`;
         traktError = `Trakt returned HTTP ${res.status} during credential check`;
         credentialsVerified = false;
+        if (data !== undefined) {
+          const bodySnippet = JSON.stringify(data).slice(0, 200);
+          console.error(`Credential check: Trakt response body: ${bodySnippet}`);
+        }
         console.error(`Trakt credential verification failed: HTTP ${res.status}`);
       }
     } catch (err) {
@@ -315,7 +330,7 @@ export function createApp(config) {
       return res.status(503).json({ status: 'starting', trakt: 'pending' });
     }
     if (credentialsVerified) {
-      return res.json({ status: 'ok', trakt: 'connected' });
+      return res.json({ status: 'ok', trakt: 'connected', validated: 'client_id_only' });
     }
     return res.status(503).json({
       status: 'unhealthy',

--- a/docs/trakt-flow.md
+++ b/docs/trakt-flow.md
@@ -1,5 +1,7 @@
 # Trakt Connection and Sync — Complete Flow Documentation
 
+> **Trakt API reference:** https://github.com/trakt/trakt-api — the official API repository with ts-rest contract definitions. Do not use the outdated Apiary docs (`trakt.docs.apiary.io`).
+
 This document describes the full user journey and technical flow for connecting to Trakt, syncing watch history, and scrobbling — covering both the phone and TV apps end to end.
 
 ---


### PR DESCRIPTION
## Summary

- **Switch credential check from `GET /languages/shows` to `GET /certifications/shows`** — the `/languages` endpoint is not defined in the official Trakt API contracts ([trakt/trakt-api](https://github.com/trakt/trakt-api)), while `/certifications/shows` is explicitly confirmed active
- **Add response body logging** to `verifyCredentials()` so debug mode actually shows what Trakt returned (matching the pattern already used by token exchange/refresh)
- **Handle HTTP 401 alongside 403** with a clear `TRAKT_CLIENT_ID` hint, since Trakt may return either for invalid API keys
- **Add `validated: "client_id_only"` to health response** to clarify that only the client ID is checked, not the secret
- **Add official Trakt API reference** to `CLAUDE.md` and `docs/trakt-flow.md` to prevent future use of the outdated Apiary docs

## Test plan

- [x] All 60 backend tests pass (`npx vitest run` — 56 updated + 4 new)
- [ ] Deploy backend with `DEBUG_MODE=true` and verify Trakt response body appears in credential check logs
- [ ] Verify `GET /health` returns `{ "status": "ok", "trakt": "connected", "validated": "client_id_only" }` with valid credentials
- [ ] Verify `GET /health` returns 503 with `invalid_client_id` for both 401 and 403 responses

https://claude.ai/code/session_01FqrFenyhfgYGJ6PU9QWf8d