### PR TITLE
fix: resolve issues #187, #192, #193 — settings UX and build warnings

### DIFF
--- a/app-phone/proguard-rules.pro
+++ b/app-phone/proguard-rules.pro
@@ -55,6 +55,12 @@
 -keep class com.google.ai.edge.aicore.** { *; }
 -dontwarn com.google.ai.edge.aicore.**
 
+# ── Reactor / BlockHound (transitive via Ktor Netty) ─────────────────────────
+# Ktor's Netty engine bundles a META-INF/services descriptor that references
+# reactor.blockhound.integration.BlockHoundIntegration, but BlockHound itself
+# is not on the classpath.  Suppress the R8 missing-service-class warning.
+-dontwarn reactor.blockhound.integration.BlockHoundIntegration
+
 # ── Coil ─────────────────────────────────────────────────────────────────────
 -dontwarn coil.**
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
@@ -45,6 +45,18 @@ object AppModule {
     @Named("defaultTmdbApiKey")
     fun provideDefaultTmdbApiKey(): String = BuildConfig.DEFAULT_TMDB_API_KEY
 
+    /**
+     * True when the managed Trakt backend is fully configured in this build
+     * (both TOKEN_BACKEND_URL and TRAKT_CLIENT_ID are non-blank).
+     * Used by SettingsViewModel to disable the MANAGED auth mode option and
+     * auto-expand advanced settings when bundled options are unavailable.
+     */
+    @Provides
+    @Singleton
+    @Named("managedBackendAvailable")
+    fun provideManagedBackendAvailable(): Boolean =
+        BuildConfig.TOKEN_BACKEND_URL.isNotBlank() && BuildConfig.TRAKT_CLIENT_ID.isNotBlank()
+
     /** Debug flag for NetworkModule (controls HTTP logging level). */
     @Provides
     @Singleton

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingScreen.kt
@@ -1,6 +1,8 @@
 package com.justb81.watchbuddy.phone.ui.onboarding
 
+import android.content.ClipData
 import android.widget.Toast
+import kotlinx.coroutines.launch
 import androidx.compose.animation.*
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -11,14 +13,15 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Warning
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.platform.ClipEntry
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -192,7 +195,8 @@ private fun NotConfiguredCard(
 @Composable
 private fun PinCard(userCode: String, verificationUrl: String, expiresIn: Int) {
     val uriHandler = LocalUriHandler.current
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val scope = rememberCoroutineScope()
     val context = LocalContext.current
     val copiedMessage = stringResource(R.string.onboarding_code_copied)
 
@@ -236,7 +240,11 @@ private fun PinCard(userCode: String, verificationUrl: String, expiresIn: Int) {
                 )
                 .padding(horizontal = 32.dp, vertical = 16.dp)
                 .clickable {
-                    clipboardManager.setText(AnnotatedString(userCode))
+                    scope.launch {
+                        clipboard.setClipEntry(
+                            ClipEntry(ClipData.newPlainText("code", userCode))
+                        )
+                    }
                     Toast.makeText(context, copiedMessage, Toast.LENGTH_SHORT).show()
                 },
             contentAlignment = Alignment.Center

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -28,7 +28,9 @@ fun SettingsScreen(
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    var showAdvanced by remember { mutableStateOf(false) }
+    // forceShowAdvanced is true when a bundled option is unavailable and the user must
+    // configure it manually.  In that case advanced settings are always expanded.
+    var showAdvanced by remember(uiState.forceShowAdvanced) { mutableStateOf(uiState.forceShowAdvanced) }
     var showDisconnectDialog by remember { mutableStateOf(false) }
     val snackbarHostState = remember { SnackbarHostState() }
     val savedMessage = stringResource(R.string.settings_saved)
@@ -98,96 +100,19 @@ fun SettingsScreen(
             SettingsSectionHeader(stringResource(R.string.settings_tmdb))
 
             SettingsCard {
-                when {
-                    uiState.tmdbConnected -> {
-                        // User has saved their own API key
-                        SettingsRow(
-                            label    = stringResource(R.string.settings_tmdb_account),
-                            value    = stringResource(R.string.settings_tmdb_connected),
-                            showDivider = true
-                        )
-                        TextButton(
-                            onClick  = { viewModel.disconnectTmdb() },
-                            modifier = Modifier.padding(horizontal = 8.dp)
-                        ) {
-                            Text(
-                                stringResource(R.string.settings_disconnect),
-                                color = MaterialTheme.colorScheme.error
-                            )
-                        }
-                    }
-                    uiState.defaultTmdbApiKeyAvailable -> {
-                        // No user key, but a built-in key is available
-                        SettingsRow(
-                            label    = stringResource(R.string.settings_tmdb_account),
-                            value    = stringResource(R.string.settings_tmdb_default_key_active),
-                            showDivider = true
-                        )
-                        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                            Text(
-                                text  = stringResource(R.string.settings_tmdb_default_key_hint),
-                                style = MaterialTheme.typography.bodySmall,
-                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                            )
-                            Spacer(Modifier.height(8.dp))
-                            OutlinedTextField(
-                                value         = uiState.tmdbApiKey,
-                                onValueChange = viewModel::setTmdbApiKey,
-                                label         = { Text(stringResource(R.string.settings_tmdb_api_key)) },
-                                modifier      = Modifier.fillMaxWidth(),
-                                singleLine    = true,
-                                visualTransformation = PasswordVisualTransformation()
-                            )
-                            Spacer(Modifier.height(4.dp))
-                            TmdbHelperLink()
-                            Spacer(Modifier.height(8.dp))
-                            Button(
-                                onClick  = { viewModel.saveTmdbApiKey() },
-                                modifier = Modifier.fillMaxWidth(),
-                                enabled  = uiState.tmdbApiKey.isNotBlank()
-                            ) {
-                                Text(stringResource(R.string.settings_save))
-                            }
-                            Spacer(Modifier.height(4.dp))
-                        }
-                    }
-                    else -> {
-                        // No key at all — user must enter one
-                        SettingsRow(
-                            label    = stringResource(R.string.settings_tmdb_account),
-                            value    = stringResource(R.string.settings_not_connected),
-                            showDivider = true
-                        )
-                        Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)) {
-                            OutlinedTextField(
-                                value         = uiState.tmdbApiKey,
-                                onValueChange = viewModel::setTmdbApiKey,
-                                label         = { Text(stringResource(R.string.settings_tmdb_api_key)) },
-                                modifier      = Modifier.fillMaxWidth(),
-                                singleLine    = true,
-                                visualTransformation = PasswordVisualTransformation()
-                            )
-                            Spacer(Modifier.height(4.dp))
-                            TmdbHelperLink()
-                            Spacer(Modifier.height(8.dp))
-                            Button(
-                                onClick  = { viewModel.saveTmdbApiKey() },
-                                modifier = Modifier.fillMaxWidth(),
-                                enabled  = uiState.tmdbApiKey.isNotBlank()
-                            ) {
-                                Text(stringResource(R.string.settings_save))
-                            }
-                            Spacer(Modifier.height(4.dp))
-                        }
-                    }
+                // Status row only — key management lives in Advanced settings.
+                val tmdbStatusValue = when {
+                    uiState.tmdbConnected -> stringResource(R.string.settings_tmdb_connected)
+                    uiState.defaultTmdbApiKeyAvailable -> stringResource(R.string.settings_tmdb_default_key_active)
+                    else -> stringResource(R.string.settings_not_connected)
                 }
+                SettingsRow(
+                    label       = stringResource(R.string.settings_tmdb_account),
+                    value       = tmdbStatusValue,
+                    showDivider = true
+                )
 
                 // TMDB attribution (always visible)
-                HorizontalDivider(
-                    color     = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
-                    thickness = 0.5.dp,
-                    modifier  = Modifier.padding(horizontal = 16.dp)
-                )
                 Text(
                     text     = stringResource(R.string.settings_tmdb_attribution),
                     style    = MaterialTheme.typography.labelSmall,
@@ -323,8 +248,15 @@ fun SettingsScreen(
                         style = MaterialTheme.typography.bodyLarge,
                         color = MaterialTheme.colorScheme.onSurface
                     )
-                    TextButton(onClick = { showAdvanced = !showAdvanced }) {
-                        Text(if (showAdvanced) stringResource(R.string.settings_advanced_hide) else stringResource(R.string.settings_advanced_show))
+                    // Hide the toggle when advanced settings must always be shown
+                    // because a bundled option is not configured in this build.
+                    if (!uiState.forceShowAdvanced) {
+                        TextButton(onClick = { showAdvanced = !showAdvanced }) {
+                            Text(
+                                if (showAdvanced) stringResource(R.string.settings_advanced_hide)
+                                else stringResource(R.string.settings_advanced_show)
+                            )
+                        }
                     }
                 }
 
@@ -375,25 +307,39 @@ private fun AdvancedAuthSettings(uiState: SettingsUiState, viewModel: SettingsVi
         )
         Spacer(Modifier.height(4.dp))
 
-        // Auth mode selector
+        // Auth mode selector — MANAGED is disabled when the backend is not configured in the build.
         AuthMode.entries.forEach { mode ->
+            val isManagedUnavailable = mode == AuthMode.MANAGED && !uiState.managedTraktAvailable
             Row(
                 verticalAlignment = Alignment.CenterVertically,
                 modifier = Modifier.fillMaxWidth()
             ) {
                 RadioButton(
                     selected = uiState.authMode == mode,
-                    onClick  = { viewModel.setAuthMode(mode) }
+                    onClick  = { if (!isManagedUnavailable) viewModel.setAuthMode(mode) },
+                    enabled  = !isManagedUnavailable
                 )
-                Text(
-                    text  = when (mode) {
-                        AuthMode.MANAGED     -> stringResource(R.string.settings_auth_managed)
-                        AuthMode.SELF_HOSTED -> stringResource(R.string.settings_auth_self_hosted)
-                        AuthMode.DIRECT      -> stringResource(R.string.settings_auth_direct)
-                    },
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface
-                )
+                Column {
+                    Text(
+                        text  = when (mode) {
+                            AuthMode.MANAGED     -> stringResource(R.string.settings_auth_managed)
+                            AuthMode.SELF_HOSTED -> stringResource(R.string.settings_auth_self_hosted)
+                            AuthMode.DIRECT      -> stringResource(R.string.settings_auth_direct)
+                        },
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = if (isManagedUnavailable)
+                            MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        else
+                            MaterialTheme.colorScheme.onSurface
+                    )
+                    if (isManagedUnavailable) {
+                        Text(
+                            text  = stringResource(R.string.settings_auth_managed_unavailable),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+                        )
+                    }
+                }
             }
         }
 
@@ -437,6 +383,73 @@ private fun AdvancedAuthSettings(uiState: SettingsUiState, viewModel: SettingsVi
                 )
             }
             else -> {}
+        }
+
+        Spacer(Modifier.height(12.dp))
+        HorizontalDivider(
+            color     = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+            thickness = 0.5.dp
+        )
+        Spacer(Modifier.height(12.dp))
+
+        // ── TMDB API key group ────────────────────────────────────────────────
+        Text(
+            text  = stringResource(R.string.settings_tmdb_key_section),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Spacer(Modifier.height(4.dp))
+
+        // "Bundled key" option — disabled when no built-in key was baked into this build.
+        val bundledAvailable = uiState.buildHasBundledTmdbKey
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            RadioButton(
+                selected = uiState.useBundledTmdbKey,
+                onClick  = { viewModel.setUseBundledTmdbKey(true) },
+                enabled  = bundledAvailable
+            )
+            Text(
+                text  = stringResource(R.string.settings_tmdb_key_bundled),
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (bundledAvailable)
+                    MaterialTheme.colorScheme.onSurface
+                else
+                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+            )
+        }
+
+        // "Own key" option — always enabled.
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            RadioButton(
+                selected = !uiState.useBundledTmdbKey,
+                onClick  = { viewModel.setUseBundledTmdbKey(false) }
+            )
+            Text(
+                text  = stringResource(R.string.settings_tmdb_key_own),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface
+            )
+        }
+
+        // Text field + helper shown only when "Own key" is selected.
+        if (!uiState.useBundledTmdbKey) {
+            Spacer(Modifier.height(4.dp))
+            OutlinedTextField(
+                value         = uiState.tmdbApiKey,
+                onValueChange = viewModel::setTmdbApiKey,
+                label         = { Text(stringResource(R.string.settings_tmdb_api_key)) },
+                modifier      = Modifier.fillMaxWidth(),
+                singleLine    = true,
+                visualTransformation = PasswordVisualTransformation()
+            )
+            Spacer(Modifier.height(4.dp))
+            TmdbHelperLink()
         }
 
         Spacer(Modifier.height(12.dp))

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Named
 
 enum class AuthMode { MANAGED, SELF_HOSTED, DIRECT }
 
@@ -35,6 +36,10 @@ data class SettingsUiState(
     val tmdbApiKey: String         = "",
     /** True when the build ships a default TMDB API key and the user has not set a custom one. */
     val defaultTmdbApiKeyAvailable: Boolean = false,
+    /** True when the build includes a bundled TMDB key (regardless of whether it is currently active). */
+    val buildHasBundledTmdbKey: Boolean = false,
+    /** True when the user has selected the "bundled key" radio in advanced settings. */
+    val useBundledTmdbKey: Boolean = true,
     val companionRunning: Boolean  = false,
     val authMode: AuthMode         = AuthMode.MANAGED,
     val customBackendUrl: String   = "",
@@ -48,7 +53,14 @@ data class SettingsUiState(
     val modelDownloadUrl: String   = "",
     val modelDownloadUrlError: Boolean = false,
     val freeRamMb: Int             = 0,
-    val saveSuccess: Boolean       = false
+    val saveSuccess: Boolean       = false,
+    /** True when the managed Trakt backend is configured in this build. */
+    val managedTraktAvailable: Boolean = true,
+    /**
+     * True when advanced settings must always be visible (i.e. at least one bundled option
+     * is not configured in this build so the user must configure it manually).
+     */
+    val forceShowAdvanced: Boolean = false
 )
 
 @HiltViewModel
@@ -59,12 +71,19 @@ class SettingsViewModel @Inject constructor(
     private val traktApi: TraktApiService,
     private val tokenRepository: TokenRepository,
     private val deviceCapabilityProvider: DeviceCapabilityProvider,
-    private val settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository,
+    @Named("managedBackendAvailable") private val managedBackendAvailable: Boolean
 ) : AndroidViewModel(application) {
+
+    private val hasBundledTmdb = settingsRepository.hasDefaultTmdbApiKey()
 
     private val _uiState = MutableStateFlow(SettingsUiState(
         llmBackend = application.getString(R.string.settings_llm_detecting),
-        llmReady = settingsRepository.modelReady.value
+        llmReady = settingsRepository.modelReady.value,
+        managedTraktAvailable = managedBackendAvailable,
+        buildHasBundledTmdbKey = hasBundledTmdb,
+        useBundledTmdbKey = hasBundledTmdb,  // start with bundled if available, corrected after load
+        forceShowAdvanced = !managedBackendAvailable || !hasBundledTmdb
     ))
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
@@ -93,8 +112,16 @@ class SettingsViewModel @Inject constructor(
             try {
                 val saved = settingsRepository.settings.first()
                 val clientSecret = settingsRepository.getClientSecret()
+                // If managed backend is unavailable in this build but was previously stored,
+                // fall back to DIRECT so the user is not stuck on a non-functional mode.
+                val resolvedAuthMode = if (!managedBackendAvailable && saved.authMode == AuthMode.MANAGED) {
+                    AuthMode.DIRECT
+                } else {
+                    saved.authMode
+                }
+                val buildHasBundled = saved.defaultTmdbApiKeyAvailable  // true = build has a key
                 _uiState.value = _uiState.value.copy(
-                    authMode = saved.authMode,
+                    authMode = resolvedAuthMode,
                     customBackendUrl = saved.backendUrl,
                     directClientId = saved.directClientId,
                     directClientSecret = clientSecret,
@@ -102,7 +129,10 @@ class SettingsViewModel @Inject constructor(
                     modelDownloadUrl = saved.modelDownloadUrl,
                     tmdbApiKey = saved.tmdbApiKey,
                     tmdbConnected = saved.tmdbApiKey.isNotBlank(),
-                    defaultTmdbApiKeyAvailable = saved.defaultTmdbApiKeyAvailable && saved.tmdbApiKey.isBlank()
+                    defaultTmdbApiKeyAvailable = buildHasBundled && saved.tmdbApiKey.isBlank(),
+                    buildHasBundledTmdbKey = buildHasBundled,
+                    useBundledTmdbKey = saved.tmdbApiKey.isBlank() && buildHasBundled,
+                    forceShowAdvanced = !managedBackendAvailable || !buildHasBundled
                 )
             } catch (_: Exception) {
                 // Settings failed to load (e.g. Keystore unavailable) — keep defaults.
@@ -228,18 +258,35 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             val state = _uiState.value
             val current = settingsRepository.settings.first()
+            // When "bundled" is selected the key is stored as empty (repository falls back to
+            // the build-time default); when "own" is selected we persist whatever the user typed.
+            val tmdbKeyToSave = if (state.useBundledTmdbKey) "" else state.tmdbApiKey
             settingsRepository.saveSettings(
                 current.copy(
                     authMode = state.authMode,
                     backendUrl = state.customBackendUrl,
                     directClientId = state.directClientId,
                     companionEnabled = state.companionRunning,
-                    modelDownloadUrl = state.modelDownloadUrl
+                    modelDownloadUrl = state.modelDownloadUrl,
+                    tmdbApiKey = tmdbKeyToSave
                 )
             )
             settingsRepository.saveClientSecret(state.directClientSecret)
-            _uiState.value = _uiState.value.copy(saveSuccess = true)
+            _uiState.value = _uiState.value.copy(
+                tmdbConnected = tmdbKeyToSave.isNotBlank(),
+                defaultTmdbApiKeyAvailable = tmdbKeyToSave.isBlank() && current.defaultTmdbApiKeyAvailable,
+                saveSuccess = true
+            )
         }
+    }
+
+    /** Toggles whether to use the build-in bundled TMDB key or a user-supplied key. */
+    fun setUseBundledTmdbKey(useBundled: Boolean) {
+        _uiState.value = _uiState.value.copy(
+            useBundledTmdbKey = useBundled,
+            // Clear the text-field value when switching to bundled so the save picks up "".
+            tmdbApiKey = if (useBundled) "" else _uiState.value.tmdbApiKey
+        )
     }
 
     fun clearSaveSuccess() {

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -73,11 +73,15 @@
     <string name="settings_advanced">Erweiterte Einstellungen</string>
     <string name="settings_auth_mode">Trakt-Authentifizierung</string>
     <string name="settings_auth_managed">Verwaltetes Backend (Standard)</string>
+    <string name="settings_auth_managed_unavailable">In diesem Build nicht konfiguriert</string>
     <string name="settings_auth_self_hosted">Eigener Server</string>
     <string name="settings_auth_direct">Eigene Zugangsdaten</string>
     <string name="settings_auth_backend_url">Backend-URL</string>
     <string name="settings_auth_client_id">Client ID</string>
     <string name="settings_auth_client_secret">Client Secret</string>
+    <string name="settings_tmdb_key_section">TMDB-API-Schlüssel</string>
+    <string name="settings_tmdb_key_bundled">Integrierter Schlüssel (eingebaut)</string>
+    <string name="settings_tmdb_key_own">Eigener Schlüssel</string>
     <string name="settings_model_url_section">Modell-Download</string>
     <string name="settings_model_url">Eigene Download-URL</string>
     <string name="settings_llm_validation_failed">Download fehlgeschlagen: Datei scheint ungültig zu sein</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -73,11 +73,15 @@
     <string name="settings_advanced">Ajustes avanzados</string>
     <string name="settings_auth_mode">Autenticación de Trakt</string>
     <string name="settings_auth_managed">Backend gestionado (por defecto)</string>
+    <string name="settings_auth_managed_unavailable">No configurado en esta compilación</string>
     <string name="settings_auth_self_hosted">Servidor propio</string>
     <string name="settings_auth_direct">Credenciales propias</string>
     <string name="settings_auth_backend_url">URL del backend</string>
     <string name="settings_auth_client_id">Client ID</string>
     <string name="settings_auth_client_secret">Client Secret</string>
+    <string name="settings_tmdb_key_section">Clave API de TMDB</string>
+    <string name="settings_tmdb_key_bundled">Clave integrada (incorporada)</string>
+    <string name="settings_tmdb_key_own">Clave propia</string>
     <string name="settings_model_url_section">Descarga del modelo</string>
     <string name="settings_model_url">URL de descarga personalizada</string>
     <string name="settings_llm_validation_failed">Error de descarga: el archivo parece inválido</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -73,11 +73,15 @@
     <string name="settings_advanced">Paramètres avancés</string>
     <string name="settings_auth_mode">Authentification Trakt</string>
     <string name="settings_auth_managed">Backend géré (par défaut)</string>
+    <string name="settings_auth_managed_unavailable">Non configuré dans cette version</string>
     <string name="settings_auth_self_hosted">Serveur auto-hébergé</string>
     <string name="settings_auth_direct">Identifiants personnels</string>
     <string name="settings_auth_backend_url">URL du backend</string>
     <string name="settings_auth_client_id">Client ID</string>
     <string name="settings_auth_client_secret">Client Secret</string>
+    <string name="settings_tmdb_key_section">Clé API TMDB</string>
+    <string name="settings_tmdb_key_bundled">Clé intégrée (incluse)</string>
+    <string name="settings_tmdb_key_own">Clé personnelle</string>
     <string name="settings_model_url_section">Téléchargement du modèle</string>
     <string name="settings_model_url">URL de téléchargement personnalisée</string>
     <string name="settings_llm_validation_failed">Échec du téléchargement : le fichier semble invalide</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -75,11 +75,15 @@
     <string name="settings_advanced">Advanced settings</string>
     <string name="settings_auth_mode">Trakt authentication</string>
     <string name="settings_auth_managed">Managed backend (default)</string>
+    <string name="settings_auth_managed_unavailable">Not configured in this build</string>
     <string name="settings_auth_self_hosted">Self-hosted server</string>
     <string name="settings_auth_direct">Own credentials</string>
     <string name="settings_auth_backend_url">Backend URL</string>
     <string name="settings_auth_client_id">Client ID</string>
     <string name="settings_auth_client_secret">Client Secret</string>
+    <string name="settings_tmdb_key_section">TMDB API key</string>
+    <string name="settings_tmdb_key_bundled">Bundled key (built-in)</string>
+    <string name="settings_tmdb_key_own">Own key</string>
     <string name="settings_model_url_section">Model download</string>
     <string name="settings_model_url">Custom download URL</string>
     <string name="settings_llm_validation_failed">Download failed: file appears invalid</string>

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
@@ -59,6 +59,7 @@ class SettingsViewModelTest {
         every { settingsRepository.settings } returns flowOf(AppSettings())
         every { settingsRepository.getClientSecret() } returns ""
         every { settingsRepository.modelReady } returns MutableStateFlow(false)
+        every { settingsRepository.hasDefaultTmdbApiKey() } returns false
         every { tokenRepository.getAccessToken() } returns null
         every { llmOrchestrator.selectConfig() } returns LlmOrchestrator.LlmConfig(
             backend = LlmBackend.NONE,
@@ -67,15 +68,17 @@ class SettingsViewModelTest {
         )
     }
 
-    private fun createViewModel(): SettingsViewModel = SettingsViewModel(
-        application = application,
-        workManager = workManager,
-        llmOrchestrator = llmOrchestrator,
-        traktApi = traktApi,
-        tokenRepository = tokenRepository,
-        deviceCapabilityProvider = deviceCapabilityProvider,
-        settingsRepository = settingsRepository
-    )
+    private fun createViewModel(managedBackendAvailable: Boolean = true): SettingsViewModel =
+        SettingsViewModel(
+            application = application,
+            workManager = workManager,
+            llmOrchestrator = llmOrchestrator,
+            traktApi = traktApi,
+            tokenRepository = tokenRepository,
+            deviceCapabilityProvider = deviceCapabilityProvider,
+            settingsRepository = settingsRepository,
+            managedBackendAvailable = managedBackendAvailable
+        )
 
     @Nested
     @DisplayName("Download progress observation")
@@ -569,6 +572,262 @@ class SettingsViewModelTest {
             advanceUntilIdle()
 
             assertTrue(vm.uiState.value.saveSuccess)
+        }
+
+        @Test
+        fun `saveAdvancedSettings saves empty TMDB key when bundled is selected`() = runTest {
+            // Build has a bundled key; user has not set their own.
+            every { settingsRepository.hasDefaultTmdbApiKey() } returns true
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(tmdbApiKey = "", defaultTmdbApiKeyAvailable = true)
+            )
+            coEvery { settingsRepository.saveSettings(any()) } returns Unit
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // useBundledTmdbKey is true (no custom key, bundled available)
+            assertTrue(vm.uiState.value.useBundledTmdbKey)
+
+            vm.saveAdvancedSettings()
+            advanceUntilIdle()
+
+            coVerify {
+                settingsRepository.saveSettings(withArg { saved ->
+                    assertEquals("", saved.tmdbApiKey)
+                })
+            }
+        }
+
+        @Test
+        fun `saveAdvancedSettings saves own key when own is selected`() = runTest {
+            every { settingsRepository.hasDefaultTmdbApiKey() } returns true
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(tmdbApiKey = "", defaultTmdbApiKeyAvailable = true)
+            )
+            coEvery { settingsRepository.saveSettings(any()) } returns Unit
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.setUseBundledTmdbKey(false)
+            vm.setTmdbApiKey("my-custom-key")
+            vm.saveAdvancedSettings()
+            advanceUntilIdle()
+
+            coVerify {
+                settingsRepository.saveSettings(withArg { saved ->
+                    assertEquals("my-custom-key", saved.tmdbApiKey)
+                })
+            }
+        }
+
+        @Test
+        fun `saveAdvancedSettings updates tmdbConnected after saving own key`() = runTest {
+            every { settingsRepository.hasDefaultTmdbApiKey() } returns true
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(tmdbApiKey = "", defaultTmdbApiKeyAvailable = true)
+            )
+            coEvery { settingsRepository.saveSettings(any()) } returns Unit
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.setUseBundledTmdbKey(false)
+            vm.setTmdbApiKey("my-key")
+            vm.saveAdvancedSettings()
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.tmdbConnected)
+        }
+
+        @Test
+        fun `saveAdvancedSettings clears tmdbConnected when switching back to bundled`() = runTest {
+            every { settingsRepository.hasDefaultTmdbApiKey() } returns true
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(tmdbApiKey = "old-key", defaultTmdbApiKeyAvailable = true)
+            )
+            coEvery { settingsRepository.saveSettings(any()) } returns Unit
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // Switch from own key to bundled
+            vm.setUseBundledTmdbKey(true)
+            vm.saveAdvancedSettings()
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.tmdbConnected)
+        }
+    }
+
+    @Nested
+    @DisplayName("Managed backend availability")
+    inner class ManagedBackendAvailability {
+
+        @Test
+        fun `managedTraktAvailable is true when managedBackendAvailable is true`() = runTest {
+            val vm = createViewModel(managedBackendAvailable = true)
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.managedTraktAvailable)
+        }
+
+        @Test
+        fun `managedTraktAvailable is false when managedBackendAvailable is false`() = runTest {
+            val vm = createViewModel(managedBackendAvailable = false)
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.managedTraktAvailable)
+        }
+
+        @Test
+        fun `forceShowAdvanced is true when managed backend is unavailable`() = runTest {
+            val vm = createViewModel(managedBackendAvailable = false)
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.forceShowAdvanced)
+        }
+
+        @Test
+        fun `forceShowAdvanced is false when managed is available and bundled TMDB key exists`() = runTest {
+            every { settingsRepository.hasDefaultTmdbApiKey() } returns true
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(defaultTmdbApiKeyAvailable = true)
+            )
+
+            val vm = createViewModel(managedBackendAvailable = true)
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.forceShowAdvanced)
+        }
+
+        @Test
+        fun `forceShowAdvanced is true when no bundled TMDB key is available`() = runTest {
+            every { settingsRepository.hasDefaultTmdbApiKey() } returns false
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(defaultTmdbApiKeyAvailable = false)
+            )
+
+            val vm = createViewModel(managedBackendAvailable = true)
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.forceShowAdvanced)
+        }
+
+        @Test
+        fun `authMode is auto-corrected to DIRECT when managed is unavailable and stored MANAGED`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+
+            val vm = createViewModel(managedBackendAvailable = false)
+            advanceUntilIdle()
+
+            assertEquals(AuthMode.DIRECT, vm.uiState.value.authMode)
+        }
+
+        @Test
+        fun `authMode is not changed when managed is available and stored MANAGED`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+
+            val vm = createViewModel(managedBackendAvailable = true)
+            advanceUntilIdle()
+
+            assertEquals(AuthMode.MANAGED, vm.uiState.value.authMode)
+        }
+
+        @Test
+        fun `authMode is not changed to DIRECT when stored SELF_HOSTED even if managed unavailable`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.SELF_HOSTED)
+            )
+
+            val vm = createViewModel(managedBackendAvailable = false)
+            advanceUntilIdle()
+
+            assertEquals(AuthMode.SELF_HOSTED, vm.uiState.value.authMode)
+        }
+    }
+
+    @Nested
+    @DisplayName("setUseBundledTmdbKey")
+    inner class SetUseBundledTmdbKey {
+
+        @Test
+        fun `switching to bundled sets useBundledTmdbKey true and clears tmdbApiKey`() = runTest {
+            every { settingsRepository.hasDefaultTmdbApiKey() } returns true
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(tmdbApiKey = "existing-key", defaultTmdbApiKeyAvailable = true)
+            )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.setUseBundledTmdbKey(true)
+
+            assertTrue(vm.uiState.value.useBundledTmdbKey)
+            assertEquals("", vm.uiState.value.tmdbApiKey)
+        }
+
+        @Test
+        fun `switching to own key sets useBundledTmdbKey false and preserves tmdbApiKey`() = runTest {
+            every { settingsRepository.hasDefaultTmdbApiKey() } returns true
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(tmdbApiKey = "", defaultTmdbApiKeyAvailable = true)
+            )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.setTmdbApiKey("new-key")
+            vm.setUseBundledTmdbKey(false)
+
+            assertFalse(vm.uiState.value.useBundledTmdbKey)
+            assertEquals("new-key", vm.uiState.value.tmdbApiKey)
+        }
+    }
+
+    @Nested
+    @DisplayName("buildHasBundledTmdbKey")
+    inner class BuildHasBundledTmdbKey {
+
+        @Test
+        fun `buildHasBundledTmdbKey is false when hasDefaultTmdbApiKey returns false`() = runTest {
+            every { settingsRepository.hasDefaultTmdbApiKey() } returns false
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.buildHasBundledTmdbKey)
+        }
+
+        @Test
+        fun `buildHasBundledTmdbKey is true when build has default key even with custom key set`() = runTest {
+            every { settingsRepository.hasDefaultTmdbApiKey() } returns true
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(tmdbApiKey = "custom-key", defaultTmdbApiKeyAvailable = true)
+            )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertTrue(vm.uiState.value.buildHasBundledTmdbKey)
+        }
+
+        @Test
+        fun `useBundledTmdbKey is false when user has custom key even if build has bundled`() = runTest {
+            every { settingsRepository.hasDefaultTmdbApiKey() } returns true
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(tmdbApiKey = "user-key", defaultTmdbApiKeyAvailable = true)
+            )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.useBundledTmdbKey)
         }
     }
 }


### PR DESCRIPTION
## Summary

Resolves three open issues in a single PR:

### Issue #193 — BlockHound R8 warning
- Adds `-dontwarn reactor.blockhound.integration.BlockHoundIntegration` to `app-phone/proguard-rules.pro`. Ktor's Netty engine bundles a `META-INF/services` descriptor that references `BlockHoundIntegration`, but the class is not on the classpath, producing a spurious R8 warning during release builds.

### Issue #192 — `LocalClipboardManager` deprecation
- Replaces the deprecated `LocalClipboardManager` with `LocalClipboard` (Compose 1.8+) in `OnboardingScreen.kt`'s `PinCard`. The new `setClipEntry()` API is a suspend function, so a `rememberCoroutineScope` is used and the clipboard write is moved into a coroutine.

### Issue #187 — Bundled API key handling
- **AppModule**: exposes `@Named("managedBackendAvailable") Boolean` — `true` when both `TOKEN_BACKEND_URL` and `TRAKT_CLIENT_ID` are present in the build.
- **SettingsViewModel**: injects the flag; adds `managedTraktAvailable`, `buildHasBundledTmdbKey`, `useBundledTmdbKey`, and `forceShowAdvanced` to `SettingsUiState`. Auto-corrects a stored `MANAGED` auth mode to `DIRECT` when the managed backend is not available. `saveAdvancedSettings()` now also persists the TMDB key selection.
- **SettingsScreen**: the TMDB section now shows status only (Connected / Built-in active / Not connected); TMDB key management is moved to Advanced settings with Bundled/Own radio buttons. Advanced settings auto-expand when `forceShowAdvanced` is true. The MANAGED Trakt radio button is disabled with a note when the build lacks a backend.
- **Strings**: adds `settings_auth_managed_unavailable`, `settings_tmdb_key_section`, `settings_tmdb_key_bundled`, `settings_tmdb_key_own` in EN/DE/FR/ES.

## Test plan

- [ ] Existing `SettingsViewModelTest` tests still pass (no regressions in TMDB key state, download progress, resilience)
- [ ] New test cases cover: `forceShowAdvanced` logic, auth mode auto-correction, TMDB key radio selection, `saveAdvancedSettings` TMDB key persistence, `setUseBundledTmdbKey` behavior, `buildHasBundledTmdbKey` state
- [ ] CI build passes (`build-android.yml`)

Resolve #187, #192, #193

https://claude.ai/code/session_01CFS8tZgmv1GbcWRxBkgPNU