### PR TITLE
fix(backend): fix token refresh, credential verification, and device flow handling

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
@@ -255,22 +255,55 @@ class OnboardingViewModel @Inject constructor(
                     _state.value = OnboardingState.Success(profile.username)
                     return@launch
                 } catch (e: Exception) {
-                    // HTTP 400 = PIN not yet confirmed — this is expected, keep polling.
-                    // Any other exception (network error, HTTP 410/418/429, etc.) counts as a failure.
-                    val isPinPending = e is HttpException && e.code() == 400
-                    if (isPinPending) {
-                        consecutiveNetworkFailures = 0
-                    } else {
-                        consecutiveNetworkFailures++
-                        if (consecutiveNetworkFailures >= 3) {
+                    val httpCode = (e as? HttpException)?.code()
+                    when (httpCode) {
+                        400 -> {
+                            // Pending — user hasn't authorized yet, keep polling
+                            consecutiveNetworkFailures = 0
+                        }
+                        410 -> {
+                            // Expired — stop immediately
                             countdownJob?.cancel()
                             clearSavedDeviceCode()
                             _state.value = OnboardingState.Error(
-                                getApplication<Application>().getString(
-                                    R.string.onboarding_error_polling_network
-                                )
+                                getApplication<Application>().getString(R.string.onboarding_code_expired)
                             )
                             return@launch
+                        }
+                        418 -> {
+                            // Denied — user explicitly refused
+                            countdownJob?.cancel()
+                            clearSavedDeviceCode()
+                            _state.value = OnboardingState.Error(
+                                getApplication<Application>().getString(R.string.onboarding_error_denied)
+                            )
+                            return@launch
+                        }
+                        409 -> {
+                            // Already used — code was consumed elsewhere
+                            countdownJob?.cancel()
+                            clearSavedDeviceCode()
+                            _state.value = OnboardingState.Error(
+                                getApplication<Application>().getString(R.string.onboarding_code_expired)
+                            )
+                            return@launch
+                        }
+                        429 -> {
+                            // Slow down — increase delay, don't count as failure
+                            delay(response.interval * 1_000L)
+                        }
+                        else -> {
+                            consecutiveNetworkFailures++
+                            if (consecutiveNetworkFailures >= 3) {
+                                countdownJob?.cancel()
+                                clearSavedDeviceCode()
+                                _state.value = OnboardingState.Error(
+                                    getApplication<Application>().getString(
+                                        R.string.onboarding_error_polling_network
+                                    )
+                                )
+                                return@launch
+                            }
                         }
                     }
                 }

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -17,6 +17,7 @@
     <string name="onboarding_code_expires">Code läuft ab in %1$d Sekunden</string>
     <string name="onboarding_error_loading_code">Fehler beim Laden des Codes: %1$s</string>
     <string name="onboarding_code_expired">Code abgelaufen. Bitte erneut versuchen.</string>
+    <string name="onboarding_error_denied">Die Autorisierung wurde abgelehnt. Bitte versuche es erneut.</string>
     <string name="onboarding_not_configured">Trakt ist noch nicht konfiguriert. Du kannst deine Zugangsdaten in den Einstellungen einrichten.</string>
     <string name="onboarding_not_configured_managed_no_client_id">Dieses Build enthält keine Trakt-Client-ID. Öffne Einstellungen → Erweitert und wähle \"Eigene Zugangsdaten\".</string>
     <string name="onboarding_not_configured_managed_no_backend">Das Token-Backend ist nicht konfiguriert. Öffne Einstellungen → Erweitert, um den Authentifizierungsmodus zu wechseln.</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -17,6 +17,7 @@
     <string name="onboarding_code_expires">El código expira en %1$d segundos</string>
     <string name="onboarding_error_loading_code">Error al cargar el código: %1$s</string>
     <string name="onboarding_code_expired">Código expirado. Por favor, inténtalo de nuevo.</string>
+    <string name="onboarding_error_denied">La autorización fue denegada. Por favor, inténtalo de nuevo.</string>
     <string name="onboarding_not_configured">Trakt aún no está configurado. Puedes configurar tus credenciales en los ajustes.</string>
     <string name="onboarding_not_configured_managed_no_client_id">Este build no tiene Client ID de Trakt. Abre Ajustes → Avanzado y selecciona \"Propias credenciales\".</string>
     <string name="onboarding_not_configured_managed_no_backend">El backend de tokens no está configurado. Abre Ajustes → Avanzado para cambiar el modo de autenticación.</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -17,6 +17,7 @@
     <string name="onboarding_code_expires">Le code expire dans %1$d secondes</string>
     <string name="onboarding_error_loading_code">Erreur lors du chargement du code : %1$s</string>
     <string name="onboarding_code_expired">Code expiré. Veuillez réessayer.</string>
+    <string name="onboarding_error_denied">L\'autorisation a été refusée. Veuillez réessayer.</string>
     <string name="onboarding_not_configured">Trakt n\'est pas encore configuré. Vous pouvez configurer vos identifiants dans les paramètres.</string>
     <string name="onboarding_not_configured_managed_no_client_id">Ce build ne contient pas de Client ID Trakt. Ouvrez Paramètres → Avancé et choisissez \"Propres identifiants\".</string>
     <string name="onboarding_not_configured_managed_no_backend">Le backend de jetons n\'est pas configuré. Ouvrez Paramètres → Avancé pour changer de mode d\'authentification.</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="onboarding_code_expires">Code expires in %1$d seconds</string>
     <string name="onboarding_error_loading_code">Error loading code: %1$s</string>
     <string name="onboarding_code_expired">Code expired. Please try again.</string>
+    <string name="onboarding_error_denied">Authorization was denied. Please try again.</string>
     <string name="onboarding_not_configured">Trakt is not configured yet. You can set up your credentials in Settings.</string>
     <string name="onboarding_not_configured_managed_no_client_id">This build has no Trakt Client ID. Open Settings → Advanced and switch to \"Own credentials\".</string>
     <string name="onboarding_not_configured_managed_no_backend">Token backend is not configured. Open Settings → Advanced to switch authentication mode.</string>

--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -48,7 +48,7 @@ describe('GET /health', () => {
     await app.verifyCredentials();
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ok', trakt: 'connected', validated: 'client_id_only' });
+    expect(res.body).toEqual({ status: 'ok', trakt: 'connected', validated: 'client_id_via_oauth' });
   });
 });
 
@@ -454,18 +454,26 @@ describe('Credential verification', () => {
     expect(typeof app.verifyCredentials).toBe('function');
   });
 
-  it('sends correct headers to Trakt /certifications/shows', async () => {
-    const fetchFn = mockFetch(200, []);
+  it('sends correct POST to Trakt /oauth/device/code', async () => {
+    const fetchFn = mockFetch(200, {
+      device_code: 'mock-device-code',
+      user_code: 'ABCD1234',
+      verification_url: 'https://trakt.tv/activate',
+      expires_in: 600,
+      interval: 5,
+    });
     const app = buildApp(fetchFn);
     await app.verifyCredentials();
     expect(fetchFn).toHaveBeenCalledWith(
-      'https://api.trakt.tv/certifications/shows',
+      'https://api.trakt.tv/oauth/device/code',
       expect.objectContaining({
-        method: 'GET',
+        method: 'POST',
         headers: expect.objectContaining({
+          'Content-Type': 'application/json',
           'trakt-api-key': 'test-client-id',
           'trakt-api-version': '2',
         }),
+        body: JSON.stringify({ client_id: 'test-client-id' }),
       }),
     );
   });
@@ -475,7 +483,7 @@ describe('Credential verification', () => {
     await app.verifyCredentials();
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ok', trakt: 'connected', validated: 'client_id_only' });
+    expect(res.body).toEqual({ status: 'ok', trakt: 'connected', validated: 'client_id_via_oauth' });
   });
 
   it('health returns 503 invalid_client_id when Trakt returns 403', async () => {
@@ -765,6 +773,43 @@ describe('Error logging improvements', () => {
     );
   });
 
+  it('does not log error or warn for HTTP 400 on token exchange (pending during polling)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const app = buildApp(mockFetch(400, { error: 'pending' }));
+    await request(app).post('/trakt/token').send({ code: 'test-code' });
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('logs warn (not error) for device flow status codes 410 and 418', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const app410 = buildApp(mockFetch(410, { error: 'expired' }));
+    await request(app410).post('/trakt/token').send({ code: 'test-code' });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('HTTP 410'));
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockClear();
+    errorSpy.mockClear();
+
+    const app418 = buildApp(mockFetch(418, { error: 'denied' }));
+    await request(app418).post('/trakt/token').send({ code: 'test-code' });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('HTTP 418'));
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('logs warn (not error) for HTTP 429 slow down', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const app = buildApp(mockFetch(429, { error: 'slow_down' }));
+    await request(app).post('/trakt/token').send({ code: 'test-code' });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('HTTP 429'));
+    expect(errorSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
   it('logs network error code on ECONNREFUSED for token exchange', async () => {
     const err = new Error('connect ECONNREFUSED');
     err.code = 'ECONNREFUSED';
@@ -972,7 +1017,13 @@ describe('Debug logging — Trakt API call details (debug: true)', () => {
 
   it('logs response body for credential check when debug is enabled', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const app = buildApp(mockFetch(200, [{ slug: 'tv-pg', name: 'TV-PG' }]), { debug: true });
+    const app = buildApp(mockFetch(200, {
+      device_code: 'mock-device-code',
+      user_code: 'ABCD1234',
+      verification_url: 'https://trakt.tv/activate',
+      expires_in: 600,
+      interval: 5,
+    }), { debug: true });
     await app.verifyCredentials();
     logSpy.mockRestore();
 

--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -254,6 +254,8 @@ describe('POST /trakt/token/refresh', () => {
       access_token: 'new-acc-789',
       refresh_token: 'new-ref-012',
       expires_in: 7776000,
+      token_type: 'Bearer',
+      scope: 'public',
     });
     app = buildApp(fetchFn);
   });
@@ -276,6 +278,8 @@ describe('POST /trakt/token/refresh', () => {
       access_token: 'new-acc-789',
       refresh_token: 'new-ref-012',
       expires_in: 7776000,
+      token_type: 'Bearer',
+      scope: 'public',
     });
   });
 
@@ -487,6 +491,7 @@ describe('Credential verification', () => {
   it('health returns 503 with trakt_http_500 on server error', async () => {
     const app = buildApp(mockFetch(500, {}));
     await app.verifyCredentials();
+    app.clearRetryTimer();
     const res = await request(app).get('/health');
     expect(res.status).toBe(503);
     expect(res.body.status).toBe('unhealthy');
@@ -507,6 +512,7 @@ describe('Credential verification', () => {
     });
     const app = buildApp(hangingFetch, { fetchTimeoutMs: 50 });
     await app.verifyCredentials();
+    app.clearRetryTimer();
     const res = await request(app).get('/health');
     expect(res.status).toBe(503);
     expect(res.body.status).toBe('unhealthy');
@@ -517,6 +523,7 @@ describe('Credential verification', () => {
     const failFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
     const app = buildApp(failFetch);
     await app.verifyCredentials();
+    app.clearRetryTimer();
     const res = await request(app).get('/health');
     expect(res.status).toBe(503);
     expect(res.body.status).toBe('unhealthy');
@@ -562,6 +569,159 @@ describe('Credential verification', () => {
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
     expect(res.body.trakt).toBe('connected');
+  });
+});
+
+// ── Credential verification retry ─────────────────────────────────────────
+
+describe('Credential verification retry', () => {
+  let logSpy;
+  let errorSpy;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('schedules retry after transient HTTP error (e.g. 503)', async () => {
+    const fetchFn = mockFetch(503, {});
+    const app = buildApp(fetchFn);
+
+    await app.verifyCredentials();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // Advance past first retry delay (5s)
+    fetchFn.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([]),
+      headers: { forEach: (cb) => new Map().forEach((v, k) => cb(v, k)) },
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    app.clearRetryTimer();
+  });
+
+  it('does not retry on 401/403 (invalid credentials)', async () => {
+    const fetchFn = mockFetch(403, { error: 'invalid_api_key' });
+    const app = buildApp(fetchFn);
+
+    await app.verifyCredentials();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // Advance well past any retry delay
+    await vi.advanceTimersByTimeAsync(120_000);
+
+    // No retry should have been scheduled
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    app.clearRetryTimer();
+  });
+
+  it('schedules retry after network error', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    const app = buildApp(fetchFn);
+
+    await app.verifyCredentials();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // Advance past first retry delay (5s)
+    fetchFn.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([]),
+      headers: { forEach: (cb) => new Map().forEach((v, k) => cb(v, k)) },
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    app.clearRetryTimer();
+  });
+
+  it('schedules retry after timeout', async () => {
+    const abortErr = new Error('The operation was aborted');
+    abortErr.name = 'AbortError';
+    const fetchFn = vi.fn().mockRejectedValue(abortErr);
+    const app = buildApp(fetchFn);
+
+    await app.verifyCredentials();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // For the retry, return success
+    fetchFn.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([]),
+      headers: { forEach: (cb) => new Map().forEach((v, k) => cb(v, k)) },
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    app.clearRetryTimer();
+  });
+
+  it('recovers to healthy after retry succeeds', async () => {
+    const fetchFn = vi.fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: () => Promise.resolve({}),
+        headers: { forEach: (cb) => new Map().forEach((v, k) => cb(v, k)) },
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([]),
+        headers: { forEach: (cb) => new Map().forEach((v, k) => cb(v, k)) },
+      });
+    const app = buildApp(fetchFn);
+
+    await app.verifyCredentials();
+    let res = await request(app).get('/health');
+    expect(res.status).toBe(503);
+    expect(res.body.trakt).toBe('trakt_http_503');
+
+    // Advance past first retry delay
+    await vi.advanceTimersByTimeAsync(5_000);
+
+    res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.trakt).toBe('connected');
+    app.clearRetryTimer();
+  });
+
+  it('uses increasing retry delays', async () => {
+    // Always return 503 to keep retrying
+    const fetchFn = mockFetch(503, {});
+    const app = buildApp(fetchFn);
+
+    await app.verifyCredentials();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // First retry at 5s
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    // Second retry at 15s
+    await vi.advanceTimersByTimeAsync(15_000);
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+
+    // Third retry at 30s
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(fetchFn).toHaveBeenCalledTimes(4);
+
+    // Fourth retry at 60s
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchFn).toHaveBeenCalledTimes(5);
+
+    app.clearRetryTimer();
   });
 });
 

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -128,8 +128,12 @@ export function createApp(config) {
 
   async function verifyCredentials(attempt = 0) {
     if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
-    const url = `${traktApi}/certifications/shows`;
-    const options = { method: 'GET', headers: traktHeaders };
+    const url = `${traktApi}/oauth/device/code`;
+    const options = {
+      method: 'POST',
+      headers: traktHeaders,
+      body: JSON.stringify({ client_id: clientId }),
+    };
     try {
       const res = await fetchWithTimeout(url, options);
 
@@ -247,9 +251,15 @@ export function createApp(config) {
 
       if (!traktRes.ok) {
         const bodySnippet = JSON.stringify(data).slice(0, 200);
-        console.error(`Token exchange: Trakt returned HTTP ${traktRes.status}: ${bodySnippet}`);
-        if (traktRes.status === 403) {
-          console.error('Hint: HTTP 403 from Trakt usually means TRAKT_CLIENT_ID is invalid or revoked.');
+        if (traktRes.status === 400) {
+          // Expected during device flow polling — user hasn't authorized yet
+        } else if ([409, 410, 418, 429].includes(traktRes.status)) {
+          console.warn(`Token exchange: Trakt returned HTTP ${traktRes.status}: ${bodySnippet}`);
+        } else {
+          console.error(`Token exchange: Trakt returned HTTP ${traktRes.status}: ${bodySnippet}`);
+          if (traktRes.status === 403) {
+            console.error('Hint: HTTP 403 from Trakt usually means TRAKT_CLIENT_ID is invalid or revoked.');
+          }
         }
         return res.status(traktRes.status).json(data);
       }
@@ -346,7 +356,7 @@ export function createApp(config) {
       return res.status(503).json({ status: 'starting', trakt: 'pending' });
     }
     if (credentialsVerified) {
-      return res.json({ status: 'ok', trakt: 'connected', validated: 'client_id_only' });
+      return res.json({ status: 'ok', trakt: 'connected', validated: 'client_id_via_oauth' });
     }
     return res.status(503).json({
       status: 'unhealthy',

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -115,8 +115,19 @@ export function createApp(config) {
   let traktStatus = 'pending';
   let traktError = null;
   let credentialsVerified = false;
+  let retryTimer = null;
 
-  async function verifyCredentials() {
+  // Retry delays: 5s, 15s, 30s, 60s, then stay at 60s
+  const RETRY_DELAYS = [5_000, 15_000, 30_000, 60_000];
+
+  function scheduleRetry(attempt) {
+    const delay = RETRY_DELAYS[Math.min(attempt, RETRY_DELAYS.length - 1)];
+    console.log(`Scheduling credential re-verification in ${delay / 1000}s (attempt ${attempt + 1})…`);
+    retryTimer = setTimeout(() => verifyCredentials(attempt + 1), delay);
+  }
+
+  async function verifyCredentials(attempt = 0) {
+    if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
     const url = `${traktApi}/certifications/shows`;
     const options = { method: 'GET', headers: traktHeaders };
     try {
@@ -145,6 +156,7 @@ export function createApp(config) {
           console.error(`Credential check: Trakt response body: ${bodySnippet}`);
         }
         console.error(`Trakt credential verification failed: HTTP ${res.status} — TRAKT_CLIENT_ID may be invalid.`);
+        // Do not retry on 401/403 — credentials are definitively wrong
       } else {
         traktStatus = `trakt_http_${res.status}`;
         traktError = `Trakt returned HTTP ${res.status} during credential check`;
@@ -154,6 +166,7 @@ export function createApp(config) {
           console.error(`Credential check: Trakt response body: ${bodySnippet}`);
         }
         console.error(`Trakt credential verification failed: HTTP ${res.status}`);
+        scheduleRetry(attempt);
       }
     } catch (err) {
       if (err.name === 'AbortError') {
@@ -167,6 +180,7 @@ export function createApp(config) {
         credentialsVerified = false;
         console.error('Trakt credential verification failed: network error:', err.message);
       }
+      scheduleRetry(attempt);
     }
   }
 
@@ -310,6 +324,8 @@ export function createApp(config) {
         access_token: data.access_token,
         refresh_token: data.refresh_token,
         expires_in: data.expires_in,
+        token_type: data.token_type,
+        scope: data.scope,
       });
     } catch (err) {
       if (err.name === 'AbortError') {
@@ -340,6 +356,7 @@ export function createApp(config) {
   });
 
   app.verifyCredentials = verifyCredentials;
+  app.clearRetryTimer = () => { if (retryTimer) clearTimeout(retryTimer); };
 
   return app;
 }


### PR DESCRIPTION
## Summary

- **Fix token refresh response**: The `/trakt/token/refresh` endpoint was missing `token_type` and `scope` fields, causing `MissingFieldException` on every token refresh in the Android app (the `ProxyTokenResponse` model requires all five fields as non-nullable).
- **Switch credential verification to `/oauth/device/code`**: Replaced `GET /certifications/shows` with `POST /oauth/device/code` so the backend validates the `client_id` through the actual OAuth endpoint it exists to serve. The generated device code is discarded.
- **Add credential verification retry**: Verification now retries automatically with exponential backoff (5s → 15s → 30s → 60s) on transient failures. No retry on 401/403 (invalid credentials).
- **Handle Trakt device flow status codes in backend logging**: HTTP 400 (pending) is now silent instead of `console.error`. Flow-specific codes (409/410/418/429) use `console.warn`. Only actual errors (403, 5xx) use `console.error`.
- **Handle Trakt device flow status codes in Android polling**: `OnboardingViewModel` now handles 410 (expired), 418 (denied), 409 (already used) with immediate stop and appropriate user messages, and 429 (slow down) with increased delay instead of counting as failures.

## Test plan

- [x] All 69 backend tests pass (9 new tests for retry + status code behavior)
- [ ] Verify token refresh returns all 5 expected fields (`access_token`, `refresh_token`, `expires_in`, `token_type`, `scope`)
- [ ] Verify health endpoint shows `validated: 'client_id_via_oauth'` after startup
- [ ] Verify health endpoint recovers after transient Trakt API outage
- [ ] Verify no error logs during normal device flow polling (HTTP 400)
- [ ] Verify Android app stops immediately on 410/418/409 with correct user message
- [ ] Verify Android app slows down on 429 without counting as failure
- [ ] Android build passes CI (`build-android.yml`)

https://claude.ai/code/session_01CRH6M4NdjT7iTBgSujdaYc