### PR TITLE
fix(backend): read User-Agent version from package.json

### DIFF
--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -115,7 +115,7 @@ describe('POST /trakt/token', () => {
           'Content-Type': 'application/json',
           'trakt-api-key': 'test-client-id',
           'trakt-api-version': '2',
-          'User-Agent': 'WatchBuddy/1.0.0',
+          'User-Agent': 'WatchBuddy/0.0.0',
         },
         body: JSON.stringify({
           code: 'device-code-abc',
@@ -297,7 +297,7 @@ describe('POST /trakt/token/refresh', () => {
           'Content-Type': 'application/json',
           'trakt-api-key': 'test-client-id',
           'trakt-api-version': '2',
-          'User-Agent': 'WatchBuddy/1.0.0',
+          'User-Agent': 'WatchBuddy/0.0.0',
         },
         body: JSON.stringify({
           refresh_token: 'old-ref-token',
@@ -474,7 +474,7 @@ describe('Credential verification', () => {
           'Content-Type': 'application/json',
           'trakt-api-key': 'test-client-id',
           'trakt-api-version': '2',
-          'User-Agent': 'WatchBuddy/1.0.0',
+          'User-Agent': 'WatchBuddy/0.0.0',
         }),
         body: JSON.stringify({ client_id: 'test-client-id' }),
       }),

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -61,6 +61,7 @@ export function createApp(config) {
     traktApi = 'https://api.trakt.tv',
     fetchFn = fetch,
     fetchTimeoutMs = 15_000,
+    version = '0.0.0',
     debug = false,
   } = config;
 
@@ -68,7 +69,7 @@ export function createApp(config) {
     'Content-Type': 'application/json',
     'trakt-api-key': clientId,
     'trakt-api-version': '2',
-    'User-Agent': 'WatchBuddy/1.0.0',
+    'User-Agent': `WatchBuddy/${version}`,
   };
 
   async function fetchWithTimeout(url, options) {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -14,7 +14,12 @@
  * that injects the server-side client_secret.
  */
 
+import { readFileSync } from 'fs';
 import { createApp } from './app.js';
+
+const { version } = JSON.parse(
+  readFileSync(new URL('../package.json', import.meta.url), 'utf-8'),
+);
 
 const { TRAKT_CLIENT_ID, TRAKT_CLIENT_SECRET, PORT = 3000, DEBUG_MODE } = process.env;
 
@@ -28,6 +33,7 @@ const debug = DEBUG_MODE === 'true';
 const app = createApp({
   clientId: TRAKT_CLIENT_ID,
   clientSecret: TRAKT_CLIENT_SECRET,
+  version,
   debug,
 });
 


### PR DESCRIPTION
## Summary

- Read `User-Agent` version from `package.json` instead of hardcoding `WatchBuddy/1.0.0`
- `createApp` now accepts an optional `version` config parameter (defaults to `'0.0.0'`)
- `index.js` reads `version` from `../package.json` at startup and passes it through
- Since release-please already bumps `package.json#version`, the User-Agent stays in sync automatically with each release

## Test plan

- [x] All 69 backend tests pass
- [ ] Verify `User-Agent` header contains correct version in Trakt debug logs

https://claude.ai/code/session_01CRH6M4NdjT7iTBgSujdaYc