### PR TITLE
fix(build): use whatsnew- filename prefix for Play Store release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,16 +205,25 @@ jobs:
             NOTES="${NOTES:0:497}..."
           fi
 
+          # Fail fast on an empty changelog — refuse to upload blank Play Store notes
+          if [ -z "${NOTES//[[:space:]]/}" ]; then
+            echo "::error::Release body is empty after markdown stripping — refusing to upload blank Play Store notes."
+            exit 1
+          fi
+
           # Write locale files — all locales get the same English text
-          # (matches supported languages: EN, DE, FR, ES)
+          # (matches supported languages: EN, DE, FR, ES). Filenames must use the
+          # `whatsnew-<locale>` convention expected by r0adkll/upload-google-play.
           mkdir -p whatsnew
           for LOCALE in en-US de-DE fr-FR es-ES; do
-            echo "$NOTES" > "whatsnew/${LOCALE}"
+            echo "$NOTES" > "whatsnew/whatsnew-${LOCALE}"
           done
 
           echo "--- Play Store changelog (en-US) ---"
-          cat whatsnew/en-US
+          cat whatsnew/whatsnew-en-US
           echo "--- ${#NOTES} characters ---"
+          echo "--- files in whatsnew/ ---"
+          ls -la whatsnew/
 
       # -- Determine Play Store release status ------------------------------
       - name: Determine Play Store release status
@@ -230,7 +239,7 @@ jobs:
       # -- Publish to Google Play Store ------------------------------------
       - name: Upload to Google Play Store
         if: steps.keystore.outputs.available == 'true' && steps.play-store.outputs.available == 'true'
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@v1.1.3
         with:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.justb81.watchbuddy


### PR DESCRIPTION
## Summary

Fixes #219 — release notes never reach the Play Store "What's New" section.

Root cause (H1 in the issue): `r0adkll/upload-google-play` expects files in the whatsnew directory to be named `whatsnew-<locale>` (e.g. `whatsnew-en-US`). The workflow was writing plain `<locale>` filenames (`en-US`, `de-DE`, …), so the action silently found no matching locale files and uploaded the AAB with an empty release-notes payload. Play Console then falls back to the previous release's notes or leaves the section blank.

## Changes

`.github/workflows/release.yml` — `Generate Play Store changelog` + `Upload to Google Play Store` steps:

- Write to `whatsnew/whatsnew-${LOCALE}` instead of `whatsnew/${LOCALE}`.
- Update the debug `cat` to the new path and add `ls -la whatsnew/` so regressions are obvious in the log.
- Fail fast with a `::error::` annotation if the stripped release body is empty, instead of uploading blank notes.
- Pin `r0adkll/upload-google-play` from `@v1` to `@v1.1.3` so future filename-convention changes surface as an explicit version bump.

Out of scope (per issue): replacing the `sed`-based markdown stripper, and per-locale translation of the notes.

## Test plan

- [ ] `build-android.yml` passes on this PR
- [ ] After merge + next `release-please` release run:
  - [ ] `Generate Play Store changelog` step log shows four non-empty `whatsnew/whatsnew-*` files in `ls -la`
  - [ ] `Upload to Google Play Store` step log has no "whatsnew directory not found / empty" warnings
  - [ ] Play Console → Internal testing shows release notes on all four locales (EN / DE / FR / ES)

https://claude.ai/code/session_01AqReRsaS64J8Wh2sDBQVMq