### PR TITLE
docs: add privacy policy (DE/EN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ Please make sure your PR:
 - Builds successfully (`./gradlew assembleDebug`)
 - Includes a clear description of the changes
 
+## Privacy / Datenschutz
+
+WatchBuddy is designed with privacy in mind: no tracking SDKs, no analytics, no WatchBuddy-side user accounts. Trakt tokens stay in the Android Keystore on the phone, LLM recaps are generated entirely on-device, and the only server component (the optional token proxy at `watchbuddy.server.rang.it`) runs on an EU host and does not persist tokens.
+
+The full privacy policy is available in two language versions:
+
+- 🇩🇪 **Deutsch (rechtlich maßgeblich):** [`docs/privacy-policy.de.md`](docs/privacy-policy.de.md)
+- 🇬🇧 **English (translation):** [`docs/privacy-policy.en.md`](docs/privacy-policy.en.md)
+
+> Note: The policy is a carefully researched draft and not legal advice. Before linking it from a public Play Store listing, a qualified IT / data-protection lawyer should review the German version — in particular the third-country transfer clauses for Trakt, TMDB and Hugging Face.
+
 ## Attribution
 
 - This product uses the Trakt API but is not endorsed or certified by Trakt.

--- a/docs/privacy-policy.de.md
+++ b/docs/privacy-policy.de.md
@@ -1,0 +1,330 @@
+# Datenschutzerklärung — WatchBuddy
+
+**Stand:** 16. April 2026
+
+> **Wichtiger Hinweis:** Dieses Dokument ist ein sorgfältig recherchierter Entwurf auf Basis der tatsächlichen Datenflüsse des Open-Source-Projekts WatchBuddy. Es stellt **keine Rechtsberatung** dar. Vor einer produktiven Veröffentlichung (insbesondere im Google Play Store) sollte die deutsche Fassung von einer Fachanwältin oder einem Fachanwalt für IT- und Datenschutzrecht gegengeprüft werden, insbesondere die Klauseln zu Drittstaatentransfers (Trakt, TMDB, Hugging Face).
+>
+> Die deutsche Fassung ist die rechtlich maßgebliche Version. Die [englische Fassung](privacy-policy.en.md) ist eine inhaltsgleiche Übersetzung.
+
+---
+
+## 1. Verantwortlicher
+
+Verantwortlicher im Sinne von Art. 4 Nr. 7 und Art. 13 Abs. 1 lit. a DSGVO:
+
+**Bastian Rang**
+E-Mail: <justb81@gmail.com>
+
+WatchBuddy wird als nicht-kommerzielles Open-Source-Projekt von einer Privatperson entwickelt und bereitgestellt. Der Quellcode ist öffentlich unter <https://github.com/justb81/watchbuddy> einsehbar.
+
+## 2. Geltungsbereich
+
+Diese Datenschutzerklärung gilt für:
+
+- die **WatchBuddy Phone App** (Android-Companion-App)
+- die **WatchBuddy TV App** (Google-TV-App)
+- das **Managed Backend** unter <https://watchbuddy.server.rang.it/> (Token-Proxy für die Trakt-OAuth-Authentifizierung)
+
+Die Datenschutzerklärungen der Distributionskanäle (Google Play Store, GitHub Releases) sowie der angebundenen Drittdienste (siehe Abschnitt 9) sind davon unabhängig und gelten zusätzlich.
+
+**Opt-out-Möglichkeiten:** Nutzer können auf die Nutzung des Managed Backends vollständig verzichten, indem sie in den Einstellungen der Phone App entweder
+1. ein **selbst gehostetes Backend** (eigene URL) konfigurieren, oder
+2. den **Direct-Credentials-Modus** aktivieren und ihren eigenen Trakt-Client-Secret hinterlegen.
+
+In beiden Fällen findet keinerlei Datenverarbeitung durch den Verantwortlichen auf dem Managed Backend statt.
+
+## 3. Privacy by Design
+
+WatchBuddy ist nach dem Grundsatz der Datenminimierung konzipiert (Art. 25 Abs. 1 DSGVO):
+
+- **Kein Tracking, kein Analytics-SDK, kein Crashlytics.** Es sind keine Analyse-, Telemetrie- oder Werbe-SDKs eingebunden.
+- **Keine Nutzerkonten bei WatchBuddy.** Die App verwendet den Trakt-Account der Nutzer direkt; WatchBuddy selbst legt keine eigene Nutzerdatenbank an.
+- **Zugangsdaten nur lokal.** Trakt-Access-Token, Refresh-Token sowie ein optionaler Trakt-Client-Secret werden ausschließlich auf dem Endgerät in einer per **Android Keystore** (AES-256-GCM) verschlüsselten `EncryptedSharedPreferences`-Datei abgelegt und verlassen das Gerät nicht, außer bei Aufrufen der Trakt-API (siehe Abschnitt 9). Quelle: `app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRepository.kt`.
+- **LLM-Inferenz ausschließlich auf dem Gerät.** Recap-Generierung erfolgt lokal über AICore (Gemini Nano) oder LiteRT-LM; es werden keine Prompts an Cloud-LLMs übermittelt.
+
+## 4. Lokal verarbeitete Daten (verlassen das Gerät nicht)
+
+Die folgenden Daten werden ausschließlich auf dem jeweiligen Endgerät gespeichert und nicht an den Verantwortlichen oder Dritte übermittelt:
+
+### 4.1 Android Keystore (Phone App)
+
+Verschlüsselt per `EncryptedSharedPreferences` (Quelle: `TokenRepository.kt`):
+
+| Schlüssel | Inhalt |
+|-----------|--------|
+| `access_token` | Trakt Access Token |
+| `refresh_token` | Trakt Refresh Token |
+| `expires_at` | Ablaufzeitpunkt des Access Tokens (Unix-Timestamp in ms) |
+| `trakt_client_secret` | Optionaler Trakt-Client-Secret (nur im Direct-Credentials-Modus) |
+
+### 4.2 DataStore Preferences (Phone App)
+
+Unverschlüsselte Konfigurationswerte (Quelle: `app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt`):
+
+| Schlüssel | Inhalt |
+|-----------|--------|
+| `auth_mode` | Authentifizierungsmodus (`MANAGED`, `SELF_HOSTED`, `DIRECT`) |
+| `backend_url` | URL des verwendeten Token-Proxy-Backends |
+| `direct_client_id` | Trakt-Client-ID (nur im Direct-Credentials-Modus) |
+| `companion_enabled` | Ein/Aus-Zustand des „I am watching TV"-Schalters |
+| `model_download_url` | Download-URL des ausgewählten LLM-Modells |
+| `model_ready` | Flag: Ist ein LLM-Modell heruntergeladen? |
+| `tmdb_api_key` | Persönlicher TMDB-API-Key (optional, vom Nutzer hinterlegt) |
+
+### 4.3 DataStore Preferences (TV App)
+
+Unverschlüsselte Konfigurationswerte (Quelle: `app-tv/src/main/java/com/justb81/watchbuddy/tv/data/UserSessionRepository.kt`, `StreamingPreferencesRepository.kt`):
+
+| Schlüssel | Inhalt |
+|-----------|--------|
+| `selected_user_ids` | Menge der aktuell ausgewählten verbundenen Phone-Nutzer |
+| `subscribed_service_ids` | Abonnierte Streaming-Dienste (z. B. Netflix, Prime Video) |
+| `service_order` | Anzeigereihenfolge der Streaming-Dienste |
+
+### 4.4 LLM-Modelle im App-Dateisystem (Phone App)
+
+- **Gemma 4 E4B** (ca. 3,4 GB, Qualitätsscore 90) — auf Geräten mit ≥ 5 GB freiem RAM
+- **Gemma 4 E2B** (ca. 2,4 GB, Qualitätsscore 70) — auf Geräten mit ≥ 3 GB freiem RAM
+- **AICore / Gemini Nano** — systemseitig verwaltet, kein separater Download nötig
+
+Quelle: `app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmOrchestrator.kt`.
+
+### 4.5 In-Memory-Caches
+
+- `TvShowCache` (TV App): Liste der Serien des Nutzers, die vom Phone via `/shows` geladen wurden
+- `CompanionStateManager` (Phone App): Zeitpunkt der letzten Capability-Abfrage, letztes Scrobble-Ereignis, Service-Status
+
+Diese Daten werden mit Beendigung des Prozesses gelöscht.
+
+## 5. Lokales Netzwerk (NSD/mDNS, Port 8765)
+
+Die Phone App registriert sich im lokalen Netz per Bonjour/mDNS als auffindbarer Dienst, damit die TV App sie entdecken kann (Quelle: `app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt`).
+
+### 5.1 Per NSD/mDNS gebroadcastete TXT-Records
+
+| Feld | Inhalt |
+|------|--------|
+| `version` | Protokollversion (aktuell `"1"`) |
+| `modelQuality` | LLM-Qualitätsscore (0–150) zur Priorisierung durch die TV App |
+| `llmBackend` | LLM-Backend-Typ (`AICORE`, `LITERT`, `NONE`) |
+
+Servicename: `watchbuddy-companion`, Servicetyp: `_watchbuddy._tcp.`, Port: `8765`.
+
+### 5.2 Über HTTP (`/capability`) lesbare Daten
+
+Wenn die TV App den Dienst entdeckt hat, ruft sie per HTTP `GET /capability` folgende Daten ab (Quelle: `app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt`):
+
+- Android-Build-ID (`deviceId`)
+- Gerätemodell (`deviceName`, z. B. `Pixel 8`)
+- Trakt-Benutzername (`userName`)
+- Trakt-Avatar-URL (`userAvatarUrl`, sofern im Trakt-Profil hinterlegt)
+- LLM-Backend und Qualitätsscore
+- Freier Arbeitsspeicher in MB
+- TMDB-Konfigurationsstatus sowie ggf. der TMDB-API-Key, damit die TV App eigene TMDB-Abfragen durchführen kann
+
+### 5.3 Sicherheitshinweise
+
+- **Intra-LAN-HTTP ist unverschlüsselt.** Der Companion-Server spricht Klartext-HTTP. Der Geltungsbereich ist ausdrücklich auf das eigene Heimnetzwerk beschränkt; die App ist nicht für Nutzung in offenen oder geteilten Netzwerken vorgesehen.
+- Die mDNS-Broadcasts sind nur im jeweils verbundenen LAN sichtbar.
+
+## 6. Scrobbling (Trakt-Forwarding)
+
+Die TV App erkennt automatisch, welche Inhalte auf dem Fernseher abgespielt werden, und meldet sie an das Trakt-Konto des jeweiligen Phone-Nutzers (Quelle: `app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt`).
+
+### 6.1 Aus Android Media Sessions gelesene Felder
+
+- Paketname der abspielenden App (z. B. `com.netflix.ninja`)
+- Medientitel aus `MediaMetadata.METADATA_KEY_TITLE`
+- Wiedergabestatus (`PLAYING`, `PAUSED`, `STOPPED`, `NONE`)
+- Fortschritt in Prozent (0 %, 50 %, 100 %) zur Übermittlung an Trakt
+
+### 6.2 Confidence-Schwellen
+
+- **≥ 0,95** → Auto-Scrobble
+- **0,70 – 0,95** → Bestätigungsoverlay für den Nutzer
+- **< 0,70** → verworfen, kein Scrobble
+
+### 6.3 Forwarding-Fluss
+
+```
+TV-App → POST /scrobble/{start|pause|stop} an alle verbundenen Phones
+        → Phone ruft Trakt-API mit eigenem Access Token
+```
+
+Die TV App ruft die Trakt-API **niemals direkt** auf. Bei mehreren verbundenen Phones wird der Scrobble an jedes einzeln weitergereicht; das Versagen einer Übermittlung blockiert die anderen nicht.
+
+## 7. LLM-Recaps („Was bisher geschah")
+
+Für die Generierung von Episoden-Zusammenfassungen verarbeitet die Phone App lokal die folgenden Eingaben:
+
+- Serientitel (aus dem Trakt-Account des Nutzers)
+- Episoden-Synopsen (aus der TMDB-API, siehe Abschnitt 9.2)
+
+Die Inferenz erfolgt **ausschließlich on-device** (AICore oder LiteRT-LM). Es werden **keine Prompts an Cloud-LLMs** übermittelt. Das generierte HTML-Recap wird der TV App im lokalen Netz über die HTTP-Schnittstelle zur Verfügung gestellt.
+
+## 8. Managed Backend (`watchbuddy.server.rang.it`)
+
+### 8.1 Zweck
+
+Das Managed Backend ist ein schlanker Token-Proxy, der im Trakt-OAuth-Device-Flow den geheimen `client_secret` serverseitig injiziert, damit dieser nicht in der öffentlich verteilten App gespeichert werden muss.
+
+### 8.2 Verarbeitete Daten
+
+Quelle: `backend/src/app.js`.
+
+| Datum | Zweck | Quelle im Code |
+|-------|-------|---------------|
+| `device_code` (max. 256 Zeichen, Regex-validiert) | Zwischenwert im Trakt-OAuth-Device-Flow | `app.js:12` (`TOKEN_PATTERN`), `app.js:227` |
+| `refresh_token` (max. 256 Zeichen, Regex-validiert) | Erneuerung eines abgelaufenen Access Tokens | `app.js:295` |
+| Trakt-Client-ID | Identifikation der App bei Trakt | Umgebungsvariable |
+| IP-Adresse | Rate-Limiting (60 Requests pro Minute pro IP) | `app.js:214-220` (`express-rate-limit`) |
+| Debug-Logs (nur bei `DEBUG=true`) | Fehleranalyse durch den Administrator; umfasst Zeitstempel, Methode, Pfad, IP und HTTP-Status | `app.js:200-212` |
+
+### 8.3 Nicht verarbeitete Daten
+
+- Access Tokens und Refresh Tokens werden vom Backend **nicht persistent gespeichert**. Sie werden ausschließlich im RAM durch den Trakt-Aufruf durchgereicht und anschließend verworfen.
+- Secret-Werte (Client Secret, Refresh Token, Access Token) werden in Debug-Logs nur maskiert (erste 4 Zeichen + `***`, siehe `app.js:29-43`).
+
+### 8.4 Hosting
+
+Das Backend wird bei einem **Hoster in der Europäischen Union** betrieben. Es findet kein Drittstaatentransfer für das Backend selbst statt.
+
+### 8.5 Rechtsgrundlage
+
+Art. 6 Abs. 1 lit. b DSGVO (Vertragserfüllung / vorvertragliche Maßnahmen — die Nutzer wünschen die Durchführung der Trakt-Authentifizierung).
+
+### 8.6 Speicherdauer
+
+- Tokens und Device Codes: **ephemer** — nur für die Dauer der Anfrage (wenige Sekunden).
+- Rate-Limit-Eintrag (IP): maximal 60 Sekunden im RAM des Express-Rate-Limiters.
+- Debug-Logs (nur bei aktiviertem Debug-Modus): so lange, bis der Container neugestartet wird; standardmäßig ist `DEBUG=false`.
+
+### 8.7 Opt-out
+
+Nutzer, die das Managed Backend nicht nutzen möchten, können in den Einstellungen auf Self-Hosting oder Direct-Credentials umschalten (siehe Abschnitt 2).
+
+## 9. Externe Dienste
+
+WatchBuddy bindet die folgenden externen Dienste ein. Für deren Datenverarbeitung ist der jeweilige Anbieter verantwortlich.
+
+### 9.1 Trakt (Trakt LLC, USA)
+
+- **Zweck:** OAuth-Authentifizierung, Abruf der Watch-History, Scrobbling, Profilabfrage
+- **Übermittelte Daten:** Trakt-Login-Daten (nur auf <https://trakt.tv>, nicht in der App), Access-/Refresh-Token, Scrobble-Ereignisse (Show, Episode, Fortschritt), API-Requests inkl. IP-Adresse des Geräts
+- **Rechtsgrundlage:** Art. 6 Abs. 1 lit. b DSGVO (Vertragserfüllung)
+- **Drittstaat:** USA — Angemessenheitsbeschluss EU-US Data Privacy Framework (DPF) bzw. Standardvertragsklauseln (SCC) nach Art. 46 DSGVO
+- **Datenschutzerklärung:** <https://trakt.tv/privacy>
+
+### 9.2 TMDB — The Movie Database, Inc. (USA)
+
+- **Zweck:** Abruf von Metadaten (Titel, Synopsen, Episodeninformationen) und Bildern (Poster, Backdrops)
+- **Übermittelte Daten:** API-Requests mit Suchbegriffen/IDs, API-Key, IP-Adresse des Geräts
+- **Rechtsgrundlage:** Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse an korrekten Medienmetadaten)
+- **Drittstaat:** USA — Standardvertragsklauseln (SCC)
+- **Datenschutzerklärung:** <https://www.themoviedb.org/privacy-policy>
+
+### 9.3 Hugging Face (Hugging Face, Inc., USA)
+
+- **Zweck:** Einmaliger Download der Gemma-4-LLM-Modelldatei von <https://huggingface.co/litert-community>
+- **Übermittelte Daten:** HTTP-Request auf die Modell-URL inklusive IP-Adresse des Geräts
+- **Rechtsgrundlage:** Art. 6 Abs. 1 lit. b DSGVO (Bereitstellung der vom Nutzer angeforderten Recap-Funktion)
+- **Drittstaat:** USA
+- **Datenschutzerklärung:** <https://huggingface.co/privacy>
+
+Der Modell-Download kann umgangen werden, indem das Modell manuell bereitgestellt oder der Recap-Modus deaktiviert wird.
+
+### 9.4 Google AICore / Gemini Nano
+
+- **Zweck:** Optionale on-device-LLM-Inferenz auf AICore-fähigen Android-Geräten (Android 14+)
+- **Übermittelte Daten:** **Keine.** AICore verarbeitet alle Eingaben strikt lokal im Systembereich; es findet keine Übermittlung an Google statt.
+- **Rechtsgrundlage:** Art. 6 Abs. 1 lit. b DSGVO
+- **Datenschutzerklärung:** <https://policies.google.com/privacy>
+
+### 9.5 Google Play Store
+
+- **Zweck:** Distributionskanal für die Android-Apps
+- **Übermittelte Daten:** Die Datenverarbeitung durch Google Play (Installationsstatistiken, Geräte-IDs, Absturzberichte) unterliegt ausschließlich der Kontrolle und der Datenschutzerklärung von Google Ireland Ltd.
+- **Datenschutzerklärung:** <https://policies.google.com/privacy>
+
+## 10. Android-Berechtigungen
+
+### 10.1 Phone App
+
+Quelle: `app-phone/src/main/AndroidManifest.xml`.
+
+| Berechtigung | Zweck | Runtime-Prompt |
+|--------------|-------|----------------|
+| `INTERNET` | Trakt-, TMDB- und Hugging-Face-Aufrufe | nein (Install-time) |
+| `ACCESS_NETWORK_STATE` | Netzwerkverfügbarkeit prüfen, Auto-Reconnect | nein |
+| `ACCESS_WIFI_STATE` | WLAN-Zustand für NSD-Betrieb prüfen | nein |
+| `CHANGE_WIFI_MULTICAST_STATE` | mDNS/Bonjour-Pakete im LAN versenden | nein |
+| `FOREGROUND_SERVICE` | Companion-HTTP-Server / Modell-Download im Vordergrund | nein |
+| `FOREGROUND_SERVICE_DATA_SYNC` | Subtyp des Foreground-Service (Android 14+) | nein |
+| `POST_NOTIFICATIONS` | Anzeige der Foreground-Service-Benachrichtigung | **ja (Android 13+)** |
+
+### 10.2 TV App
+
+Quelle: `app-tv/src/main/AndroidManifest.xml`.
+
+| Berechtigung | Zweck | Runtime-Prompt |
+|--------------|-------|----------------|
+| `INTERNET` | TMDB-Aufrufe, Phone-Server-Aufrufe | nein |
+| `ACCESS_NETWORK_STATE` | Netzwerkverfügbarkeit prüfen | nein |
+| `ACCESS_WIFI_STATE` | WLAN-Zustand für NSD-Discovery prüfen | nein |
+| `CHANGE_WIFI_MULTICAST_STATE` | mDNS-Discovery von Phone-Diensten | nein |
+| `MEDIA_CONTENT_CONTROL` | Lesezugriff auf Media Sessions anderer Apps für Scrobbling | **ja (Notification-Listener-Bestätigung)** |
+| `RECEIVE_BOOT_COMPLETED` | Automatischer Start der Discovery beim TV-Boot | nein |
+| `FOREGROUND_SERVICE` | Phone-Discovery im Vordergrund | nein |
+| `FOREGROUND_SERVICE_DATA_SYNC` | Subtyp des Foreground-Service (Android 14+) | nein |
+
+## 11. Speicherdauer
+
+| Datenkategorie | Ort | Dauer |
+|---------------|-----|-------|
+| Trakt-Access-Token | Keystore (Phone) | Bis zur Abmeldung oder zum Ablauf |
+| Trakt-Refresh-Token | Keystore (Phone) | Bis zur Abmeldung |
+| App-Einstellungen (DataStore) | DataStore (Phone + TV) | Bis zur Deinstallation oder `App-Daten löschen` |
+| LLM-Modelldatei | App-Filesystem (Phone) | Bis zur manuellen Löschung oder Deinstallation |
+| In-Memory-Caches | RAM | Prozesslaufzeit |
+| Managed-Backend: Device-Code / Refresh-Token | RAM des Containers | Anfrageverarbeitung (Sekunden) |
+| Managed-Backend: Rate-Limit-Eintrag (IP) | RAM des Containers | ≤ 60 Sekunden |
+| Managed-Backend: Debug-Logs | STDOUT des Containers | Bis Neustart; standardmäßig deaktiviert |
+| Trakt-Accountdaten | Server von Trakt LLC | Gemäß Trakt-Datenschutzerklärung |
+| TMDB-Request-Logs | Server von TMDB | Gemäß TMDB-Datenschutzerklärung |
+
+## 12. Betroffenenrechte (Art. 15–22 DSGVO)
+
+Als betroffene Person haben Sie die folgenden Rechte:
+
+- **Auskunft** (Art. 15 DSGVO)
+- **Berichtigung** (Art. 16 DSGVO)
+- **Löschung** (Art. 17 DSGVO)
+- **Einschränkung der Verarbeitung** (Art. 18 DSGVO)
+- **Datenübertragbarkeit** (Art. 20 DSGVO)
+- **Widerspruch** (Art. 21 DSGVO)
+- **Widerruf einer Einwilligung** (Art. 7 Abs. 3 DSGVO)
+
+**Durchsetzung in der Praxis:**
+
+- Rechte gegenüber dem Managed Backend: formlose E-Mail an <justb81@gmail.com>. Da das Backend keine persistenten personenbezogenen Daten speichert, beschränkt sich die Auskunft im Regelfall auf die Bestätigung, dass keine Daten über die in Abschnitt 8 genannten hinaus verarbeitet werden.
+- **Lokale Daten auf dem Gerät löschen:** Android-Einstellungen → Apps → WatchBuddy → Speicher → *App-Daten löschen* oder App deinstallieren.
+- **Trakt-seitige Datenlöschung:** über die Kontoeinstellungen auf <https://trakt.tv> möglich.
+- Rechte gegenüber TMDB, Trakt und Hugging Face: direkt beim jeweiligen Anbieter ausüben (siehe Abschnitt 9).
+
+## 13. Beschwerderecht
+
+Sie haben gemäß Art. 77 DSGVO das Recht, sich bei einer Datenschutz-Aufsichtsbehörde zu beschweren, insbesondere bei der Aufsichtsbehörde Ihres gewöhnlichen Aufenthaltsorts, Arbeitsplatzes oder des Orts des mutmaßlichen Verstoßes.
+
+Für Deutschland zuständig: der/die Bundesbeauftragte für den Datenschutz und die Informationsfreiheit (BfDI) bzw. die jeweilige Landesdatenschutzbehörde. Eine Liste der deutschen Aufsichtsbehörden ist unter <https://www.bfdi.bund.de> abrufbar.
+
+## 14. Kinder
+
+WatchBuddy richtet sich nicht an Personen unter 16 Jahren. Es werden wissentlich keine personenbezogenen Daten von Kindern unter 16 Jahren ohne elterliche Einwilligung verarbeitet (Art. 8 DSGVO).
+
+## 15. Änderungen der Datenschutzerklärung
+
+Diese Datenschutzerklärung wird bei relevanten Änderungen der Datenverarbeitung aktualisiert. Die Versionshistorie ist vollständig im Git-Verlauf des Dokuments unter <https://github.com/justb81/watchbuddy/commits/main/docs/privacy-policy.de.md> nachvollziehbar.
+
+## 16. Stand
+
+Letzte Aktualisierung: **16. April 2026**.

--- a/docs/privacy-policy.en.md
+++ b/docs/privacy-policy.en.md
@@ -1,0 +1,330 @@
+# Privacy Policy — WatchBuddy
+
+**Last updated:** 16 April 2026
+
+> **Important note:** This document is a carefully researched draft based on the actual data flows of the WatchBuddy open-source project. It does **not constitute legal advice**. Before any production publication (in particular on the Google Play Store), the German version should be reviewed by a qualified IT / data-protection lawyer, especially the clauses on third-country transfers (Trakt, TMDB, Hugging Face).
+>
+> The German version is the legally authoritative one. This English text is a content-equivalent translation provided for convenience. See [`privacy-policy.de.md`](privacy-policy.de.md).
+
+---
+
+## 1. Controller
+
+Controller within the meaning of Art. 4(7) and Art. 13(1)(a) GDPR:
+
+**Bastian Rang**
+Email: <justb81@gmail.com>
+
+WatchBuddy is developed and provided as a non-commercial open-source project by a private individual. The source code is publicly available at <https://github.com/justb81/watchbuddy>.
+
+## 2. Scope
+
+This privacy policy covers:
+
+- the **WatchBuddy Phone App** (Android companion app)
+- the **WatchBuddy TV App** (Google TV app)
+- the **managed backend** at <https://watchbuddy.server.rang.it/> (token proxy for Trakt OAuth authentication)
+
+The privacy policies of the distribution channels (Google Play Store, GitHub Releases) and of the third-party services (see Section 9) are independent and additionally apply.
+
+**Opt-out options:** Users can fully refrain from using the managed backend by configuring in the phone app settings either
+1. a **self-hosted backend** (custom URL), or
+2. the **direct credentials mode** with their own Trakt client secret.
+
+In both cases, no data is processed by the controller via the managed backend.
+
+## 3. Privacy by Design
+
+WatchBuddy is designed on the principle of data minimisation (Art. 25(1) GDPR):
+
+- **No tracking, no analytics SDK, no Crashlytics.** No analytics, telemetry or advertising SDKs are integrated.
+- **No WatchBuddy user accounts.** The app uses the user's existing Trakt account directly; WatchBuddy itself does not maintain a separate user database.
+- **Credentials stored locally only.** Trakt access tokens, refresh tokens and an optional Trakt client secret are stored exclusively on the device in an `EncryptedSharedPreferences` file backed by the **Android Keystore** (AES-256-GCM). They do not leave the device, except when calling the Trakt API itself (see Section 9). Source: `app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRepository.kt`.
+- **LLM inference is strictly on-device.** Recap generation runs locally via AICore (Gemini Nano) or LiteRT-LM; no prompts are sent to any cloud LLM.
+
+## 4. Locally Processed Data (does not leave the device)
+
+The following data is stored exclusively on the respective device and is not transmitted to the controller or any third party:
+
+### 4.1 Android Keystore (phone app)
+
+Encrypted via `EncryptedSharedPreferences` (source: `TokenRepository.kt`):
+
+| Key | Content |
+|-----|---------|
+| `access_token` | Trakt access token |
+| `refresh_token` | Trakt refresh token |
+| `expires_at` | Access-token expiry (Unix timestamp in ms) |
+| `trakt_client_secret` | Optional Trakt client secret (direct credentials mode only) |
+
+### 4.2 DataStore preferences (phone app)
+
+Unencrypted configuration values (source: `app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt`):
+
+| Key | Content |
+|-----|---------|
+| `auth_mode` | Authentication mode (`MANAGED`, `SELF_HOSTED`, `DIRECT`) |
+| `backend_url` | URL of the token-proxy backend in use |
+| `direct_client_id` | Trakt client ID (direct credentials mode only) |
+| `companion_enabled` | On/off state of the "I am watching TV" toggle |
+| `model_download_url` | Download URL of the selected LLM model |
+| `model_ready` | Flag: is an LLM model downloaded? |
+| `tmdb_api_key` | Personal TMDB API key (optional, set by the user) |
+
+### 4.3 DataStore preferences (TV app)
+
+Unencrypted configuration values (source: `app-tv/src/main/java/com/justb81/watchbuddy/tv/data/UserSessionRepository.kt`, `StreamingPreferencesRepository.kt`):
+
+| Key | Content |
+|-----|---------|
+| `selected_user_ids` | Set of connected phone users currently selected |
+| `subscribed_service_ids` | Subscribed streaming services (e.g. Netflix, Prime Video) |
+| `service_order` | Display order of streaming services |
+
+### 4.4 LLM models in the app file system (phone app)
+
+- **Gemma 4 E4B** (~3.4 GB, quality score 90) — on devices with ≥ 5 GB free RAM
+- **Gemma 4 E2B** (~2.4 GB, quality score 70) — on devices with ≥ 3 GB free RAM
+- **AICore / Gemini Nano** — managed by the system, no separate download required
+
+Source: `app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmOrchestrator.kt`.
+
+### 4.5 In-memory caches
+
+- `TvShowCache` (TV app): user's show list fetched from the phone via `/shows`
+- `CompanionStateManager` (phone app): timestamp of the last capability check, last scrobble event, service state
+
+These data are discarded when the process ends.
+
+## 5. Local Network (NSD/mDNS, port 8765)
+
+The phone app registers itself as a discoverable service in the local network via Bonjour/mDNS so that the TV app can find it (source: `app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt`).
+
+### 5.1 TXT records broadcast via NSD/mDNS
+
+| Field | Content |
+|-------|---------|
+| `version` | Protocol version (currently `"1"`) |
+| `modelQuality` | LLM quality score (0–150) for prioritisation by the TV app |
+| `llmBackend` | LLM backend type (`AICORE`, `LITERT`, `NONE`) |
+
+Service name: `watchbuddy-companion`, service type: `_watchbuddy._tcp.`, port: `8765`.
+
+### 5.2 Data readable via HTTP (`/capability`)
+
+Once the TV app has discovered the service, it calls `GET /capability` over HTTP to fetch (source: `app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt`):
+
+- Android build ID (`deviceId`)
+- Device model (`deviceName`, e.g. `Pixel 8`)
+- Trakt username (`userName`)
+- Trakt avatar URL (`userAvatarUrl`, if present in the Trakt profile)
+- LLM backend and quality score
+- Free RAM in MB
+- TMDB configuration state and, where configured, the TMDB API key so that the TV app can issue its own TMDB requests
+
+### 5.3 Security notes
+
+- **Intra-LAN HTTP is unencrypted.** The companion server speaks plain HTTP. Its scope is explicitly limited to the home network; the app is not intended for use on open or shared networks.
+- The mDNS broadcasts are visible only within the connected LAN.
+
+## 6. Scrobbling (Trakt forwarding)
+
+The TV app automatically detects what is being played on the television and reports it to the Trakt account of each connected phone user (source: `app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobbler.kt`).
+
+### 6.1 Fields read from Android Media Sessions
+
+- Package name of the playing app (e.g. `com.netflix.ninja`)
+- Media title from `MediaMetadata.METADATA_KEY_TITLE`
+- Playback state (`PLAYING`, `PAUSED`, `STOPPED`, `NONE`)
+- Progress as a percentage (0 %, 50 %, 100 %) for forwarding to Trakt
+
+### 6.2 Confidence thresholds
+
+- **≥ 0.95** → auto-scrobble
+- **0.70 – 0.95** → confirmation overlay for the user
+- **< 0.70** → discarded, no scrobble
+
+### 6.3 Forwarding flow
+
+```
+TV app → POST /scrobble/{start|pause|stop} to all connected phones
+       → phone calls the Trakt API using its own access token
+```
+
+The TV app **never calls the Trakt API directly**. When several phones are connected, the scrobble event is forwarded to each of them individually; a failure on one phone does not block the others.
+
+## 7. LLM Recaps ("Previously on…")
+
+To generate episode recaps, the phone app processes the following inputs locally:
+
+- Show title (from the user's Trakt account)
+- Episode synopses (from the TMDB API, see Section 9.2)
+
+Inference is performed **strictly on-device** (AICore or LiteRT-LM). **No prompts are sent to any cloud LLM.** The generated HTML recap is served to the TV app via the local HTTP interface.
+
+## 8. Managed Backend (`watchbuddy.server.rang.it`)
+
+### 8.1 Purpose
+
+The managed backend is a lightweight token proxy that injects the Trakt `client_secret` server-side during the Trakt OAuth device flow, so that this secret does not have to be embedded in the publicly distributed app.
+
+### 8.2 Data processed
+
+Source: `backend/src/app.js`.
+
+| Data | Purpose | Source in code |
+|------|---------|----------------|
+| `device_code` (max. 256 chars, regex-validated) | Intermediate value in the Trakt OAuth device flow | `app.js:12` (`TOKEN_PATTERN`), `app.js:227` |
+| `refresh_token` (max. 256 chars, regex-validated) | Renewal of an expired access token | `app.js:295` |
+| Trakt client ID | App identification towards Trakt | Environment variable |
+| IP address | Rate limiting (60 requests per minute per IP) | `app.js:214-220` (`express-rate-limit`) |
+| Debug logs (only when `DEBUG=true`) | Diagnostics by the administrator; includes timestamp, method, path, IP and HTTP status | `app.js:200-212` |
+
+### 8.3 Data NOT processed
+
+- Access tokens and refresh tokens are **not persistently stored** by the backend. They are held in RAM only for the duration of the upstream Trakt call and then discarded.
+- Secret values (client secret, refresh token, access token) are masked in debug logs (first 4 characters + `***`, see `app.js:29-43`).
+
+### 8.4 Hosting
+
+The backend is operated by a **hosting provider inside the European Union**. No third-country transfer applies to the backend itself.
+
+### 8.5 Legal basis
+
+Art. 6(1)(b) GDPR (performance of a contract / pre-contractual steps — users ask for the Trakt authentication to be carried out).
+
+### 8.6 Retention period
+
+- Tokens and device codes: **ephemeral** — only for the duration of the request (a few seconds).
+- Rate-limit entry (IP): at most 60 seconds in the RAM of the express rate limiter.
+- Debug logs (only when debug mode is enabled): until the container is restarted; the default is `DEBUG=false`.
+
+### 8.7 Opt-out
+
+Users who do not want to use the managed backend can switch to self-hosting or direct credentials in the app settings (see Section 2).
+
+## 9. Third-Party Services
+
+WatchBuddy integrates the following external services. The respective provider is responsible for their data processing.
+
+### 9.1 Trakt (Trakt LLC, USA)
+
+- **Purpose:** OAuth authentication, watch history retrieval, scrobbling, profile lookup
+- **Data transferred:** Trakt login credentials (only on <https://trakt.tv>, not in the app), access/refresh tokens, scrobble events (show, episode, progress), API requests including the device IP address
+- **Legal basis:** Art. 6(1)(b) GDPR (performance of a contract)
+- **Third country:** USA — EU-US Data Privacy Framework (DPF) adequacy decision and/or Standard Contractual Clauses (SCCs) under Art. 46 GDPR
+- **Privacy policy:** <https://trakt.tv/privacy>
+
+### 9.2 TMDB — The Movie Database, Inc. (USA)
+
+- **Purpose:** Retrieval of metadata (titles, synopses, episode details) and images (posters, backdrops)
+- **Data transferred:** API requests with query terms/IDs, API key, device IP address
+- **Legal basis:** Art. 6(1)(f) GDPR (legitimate interest in accurate media metadata)
+- **Third country:** USA — Standard Contractual Clauses (SCCs)
+- **Privacy policy:** <https://www.themoviedb.org/privacy-policy>
+
+### 9.3 Hugging Face (Hugging Face, Inc., USA)
+
+- **Purpose:** One-off download of the Gemma 4 LLM model file from <https://huggingface.co/litert-community>
+- **Data transferred:** HTTP request to the model URL including the device IP address
+- **Legal basis:** Art. 6(1)(b) GDPR (provision of the recap feature requested by the user)
+- **Third country:** USA
+- **Privacy policy:** <https://huggingface.co/privacy>
+
+The model download can be avoided by sideloading the model file manually or by disabling the recap feature.
+
+### 9.4 Google AICore / Gemini Nano
+
+- **Purpose:** Optional on-device LLM inference on AICore-capable Android devices (Android 14+)
+- **Data transferred:** **None.** AICore processes all inputs strictly locally in the system partition; no data is sent to Google.
+- **Legal basis:** Art. 6(1)(b) GDPR
+- **Privacy policy:** <https://policies.google.com/privacy>
+
+### 9.5 Google Play Store
+
+- **Purpose:** Distribution channel for the Android apps
+- **Data transferred:** Any processing by Google Play (installation statistics, device IDs, crash reports) is under Google Ireland Ltd.'s sole control and subject to their own privacy policy.
+- **Privacy policy:** <https://policies.google.com/privacy>
+
+## 10. Android Permissions
+
+### 10.1 Phone app
+
+Source: `app-phone/src/main/AndroidManifest.xml`.
+
+| Permission | Purpose | Runtime prompt |
+|------------|---------|----------------|
+| `INTERNET` | Trakt, TMDB and Hugging Face calls | no (install-time) |
+| `ACCESS_NETWORK_STATE` | Check network availability, auto-reconnect | no |
+| `ACCESS_WIFI_STATE` | Check Wi-Fi state for NSD operation | no |
+| `CHANGE_WIFI_MULTICAST_STATE` | Send mDNS/Bonjour packets on the LAN | no |
+| `FOREGROUND_SERVICE` | Run the companion HTTP server / model download in the foreground | no |
+| `FOREGROUND_SERVICE_DATA_SYNC` | Subtype of the foreground service (Android 14+) | no |
+| `POST_NOTIFICATIONS` | Display the foreground-service notification | **yes (Android 13+)** |
+
+### 10.2 TV app
+
+Source: `app-tv/src/main/AndroidManifest.xml`.
+
+| Permission | Purpose | Runtime prompt |
+|------------|---------|----------------|
+| `INTERNET` | TMDB calls, phone-server calls | no |
+| `ACCESS_NETWORK_STATE` | Check network availability | no |
+| `ACCESS_WIFI_STATE` | Check Wi-Fi state for NSD discovery | no |
+| `CHANGE_WIFI_MULTICAST_STATE` | mDNS discovery of phone services | no |
+| `MEDIA_CONTENT_CONTROL` | Read access to other apps' media sessions for scrobbling | **yes (notification listener consent)** |
+| `RECEIVE_BOOT_COMPLETED` | Automatic start of discovery at TV boot | no |
+| `FOREGROUND_SERVICE` | Phone discovery in the foreground | no |
+| `FOREGROUND_SERVICE_DATA_SYNC` | Subtype of the foreground service (Android 14+) | no |
+
+## 11. Retention Periods
+
+| Data category | Location | Duration |
+|--------------|----------|----------|
+| Trakt access token | Keystore (phone) | Until logout or expiry |
+| Trakt refresh token | Keystore (phone) | Until logout |
+| App settings (DataStore) | DataStore (phone + TV) | Until uninstall or "clear app data" |
+| LLM model file | App file system (phone) | Until manual deletion or uninstall |
+| In-memory caches | RAM | Process lifetime |
+| Managed backend: device code / refresh token | Container RAM | Request processing (seconds) |
+| Managed backend: rate-limit entry (IP) | Container RAM | ≤ 60 seconds |
+| Managed backend: debug logs | Container STDOUT | Until restart; disabled by default |
+| Trakt account data | Trakt LLC servers | Per the Trakt privacy policy |
+| TMDB request logs | TMDB servers | Per the TMDB privacy policy |
+
+## 12. Data Subject Rights (Art. 15–22 GDPR)
+
+As a data subject you have the following rights:
+
+- **Access** (Art. 15 GDPR)
+- **Rectification** (Art. 16 GDPR)
+- **Erasure** (Art. 17 GDPR)
+- **Restriction of processing** (Art. 18 GDPR)
+- **Data portability** (Art. 20 GDPR)
+- **Objection** (Art. 21 GDPR)
+- **Withdrawal of consent** (Art. 7(3) GDPR)
+
+**How to exercise these rights in practice:**
+
+- Rights towards the managed backend: informal email to <justb81@gmail.com>. As the backend does not persistently store personal data, access requests will in general simply confirm that no data beyond what is described in Section 8 is processed.
+- **Delete local data on the device:** Android Settings → Apps → WatchBuddy → Storage → *Clear app data*, or uninstall the app.
+- **Trakt-side data deletion:** via the account settings on <https://trakt.tv>.
+- Rights against TMDB, Trakt and Hugging Face: exercise them directly with the respective provider (see Section 9).
+
+## 13. Right to Lodge a Complaint
+
+Under Art. 77 GDPR you have the right to lodge a complaint with a data-protection supervisory authority, in particular in the Member State of your habitual residence, place of work or the place of the alleged infringement.
+
+For Germany the competent authority is the Federal Commissioner for Data Protection and Freedom of Information (BfDI) or the respective state data-protection authority. A list of German supervisory authorities is available at <https://www.bfdi.bund.de>.
+
+## 14. Children
+
+WatchBuddy is not aimed at persons under the age of 16. No personal data of children under 16 is knowingly processed without parental consent (Art. 8 GDPR).
+
+## 15. Changes to This Privacy Policy
+
+This privacy policy will be updated whenever the data processing changes in a material way. The full revision history is available via the Git log of this document at <https://github.com/justb81/watchbuddy/commits/main/docs/privacy-policy.en.md>.
+
+## 16. Version
+
+Last updated: **16 April 2026**.


### PR DESCRIPTION
## Summary

Adds a comprehensive, GDPR-aligned privacy policy for WatchBuddy. Ships two content-equivalent Markdown files (the German version is the legally authoritative one; the English version is a translation for convenience) and a short "Privacy / Datenschutz" section in the README that links both files via relative paths.

Closes #220.

## Files

- `docs/privacy-policy.de.md` *(new)* — primary, legally authoritative German version
- `docs/privacy-policy.en.md` *(new)* — content-equivalent English translation
- `README.md` — new "Privacy / Datenschutz" section with relative links to both files

## What the policy covers

Every claim is grounded in the actual source code so a reviewer can verify that the policy matches reality:

- **Controller & scope** — Bastian Rang (private individual), phone app + TV app + managed backend, with self-hosting / direct-credentials opt-outs
- **Privacy by Design** — no tracking SDKs, no Crashlytics, no WatchBuddy user accounts; tokens only in Android Keystore (`TokenRepository.kt`)
- **Locally processed data** — Keystore entries, phone DataStore keys (`SettingsRepository.kt`), TV DataStore keys (`UserSessionRepository.kt`, `StreamingPreferencesRepository.kt`), LLM model files (Gemma 4 E2B/E4B), in-memory caches
- **Local network (NSD/mDNS)** — exact TXT records (`version`, `modelQuality`, `llmBackend`), service type `_watchbuddy._tcp.`, port 8765, plus the fields served over HTTP `/capability` (`DeviceCapabilityProvider.kt`); explicit note that intra-LAN HTTP is unencrypted and scoped to the home network
- **Scrobbling** — fields read from Android Media Sessions (`MediaSessionScrobbler.kt`), confidence thresholds (≥ 0.95 auto, 0.70–0.95 confirm, < 0.70 discard), and the forwarding flow TV → phone → Trakt (TV never calls Trakt directly)
- **LLM recaps** — strictly on-device inference via AICore or LiteRT-LM; no prompts leave the device
- **Managed backend** — purpose (OAuth device-flow token exchange), EU hosting, processed data (device code / refresh token / IP / optional debug logs), ephemeral processing, rate limit (`backend/src/app.js:214-220`), debug-log masking (`app.js:29-43`)
- **Third-party services** — Trakt, TMDB, Hugging Face, AICore, Google Play — each with legal basis (Art. 6(1)(b) or (f) GDPR), third-country clause (EU-US DPF / SCCs), and a link to the provider's privacy policy
- **Permission tables** — phone app and TV app, cross-checked against both `AndroidManifest.xml` files
- **Retention periods, data-subject rights (Art. 15–22 GDPR), right to complain, children (Art. 8 GDPR), policy versioning via Git history**

## Legal-review disclaimer (important)

This is a **drafted privacy policy, not legal advice**. A qualified IT / data-protection lawyer must review the German version — especially the third-country transfer clauses for Trakt, TMDB and Hugging Face — before the policy is linked from any public Play Store listing. The disclaimer is repeated prominently at the top of the document and in the README.

## Test plan

- [x] Both files render correctly as Markdown on GitHub (headings, tables, links)
- [x] Section order matches 1:1 between DE and EN
- [x] Every data-flow category from the issue's 9-point inventory appears in the policy
- [x] Every code reference in the policy points at an existing file / line (verified during authoring)
- [x] README links use relative paths (`docs/privacy-policy.de.md`, `docs/privacy-policy.en.md`)
- [x] CI `build-android.yml` passes (expected — docs-only change, no code touched)

_Documentation-only change; no code or CI configuration was modified._