### PR TITLE
fix(phone): prevent settings force-close via CoroutineExceptionHandler safety net

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -1,6 +1,7 @@
 package com.justb81.watchbuddy.phone.ui.settings
 
 import android.app.Application
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.Constraints
@@ -20,9 +21,13 @@ import com.justb81.watchbuddy.phone.server.DeviceCapabilityProvider
 import com.justb81.watchbuddy.phone.settings.AppSettings
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -87,6 +92,24 @@ class SettingsViewModel @Inject constructor(
     ))
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
+    /**
+     * Safety-net exception handler for every coroutine launched from this ViewModel.
+     *
+     * Three previous force-close bugs (#168, #177, #196) were all caused by a single
+     * unguarded [viewModelScope.launch] in the Settings flow.  Each fix added a try/catch
+     * to the specific offender, which works until the next coroutine is added and someone
+     * forgets the pattern.  This handler ensures that *any* uncaught exception in a
+     * coroutine launched via [launchSafe] is logged and swallowed instead of propagating
+     * to the JVM's default uncaught exception handler (which force-closes the app).
+     */
+    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        Log.e(TAG, "Uncaught exception in SettingsViewModel coroutine", throwable)
+    }
+
+    /** Launch a coroutine under [viewModelScope] guarded by [coroutineExceptionHandler]. */
+    private fun launchSafe(block: suspend CoroutineScope.() -> Unit): Job =
+        viewModelScope.launch(coroutineExceptionHandler, block = block)
+
     init {
         loadPersistedSettings()
         loadTraktUsername()
@@ -96,9 +119,9 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun loadTraktUsername() {
-        viewModelScope.launch {
+        launchSafe {
             try {
-                val accessToken = tokenRepository.getAccessToken() ?: return@launch
+                val accessToken = tokenRepository.getAccessToken() ?: return@launchSafe
                 val profile = traktApi.getProfile("Bearer $accessToken")
                 _uiState.value = _uiState.value.copy(traktUsername = profile.username)
             } catch (_: Exception) {
@@ -108,7 +131,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun loadPersistedSettings() {
-        viewModelScope.launch {
+        launchSafe {
             try {
                 val saved = settingsRepository.settings.first()
                 val clientSecret = settingsRepository.getClientSecret()
@@ -142,7 +165,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun detectLlm() {
-        viewModelScope.launch {
+        launchSafe {
             try {
                 val config = llmOrchestrator.selectConfig()
                 _uiState.value = _uiState.value.copy(
@@ -157,16 +180,22 @@ class SettingsViewModel @Inject constructor(
     }
 
     private fun observeModelReadyState() {
-        viewModelScope.launch {
-            settingsRepository.modelReady.collect { ready ->
-                _uiState.value = _uiState.value.copy(llmReady = ready)
-            }
+        launchSafe {
+            settingsRepository.modelReady
+                .catch { /* DataStore IO error — keep existing llmReady value */ }
+                .collect { ready ->
+                    _uiState.value = _uiState.value.copy(llmReady = ready)
+                }
         }
     }
 
     private fun observeDownloadProgress() {
-        viewModelScope.launch {
+        launchSafe {
+            // WorkManager's flow can throw at subscription (WM not yet initialized,
+            // SQLite IO error) or mid-stream.  .catch {} contains the failure so the
+            // Settings screen still opens even when the WorkManager backend is broken.
             workManager.getWorkInfosForUniqueWorkFlow(ModelDownloadWorker.UNIQUE_WORK_NAME)
+                .catch { /* WorkManager unavailable — no download progress UI */ }
                 .collect { workInfoList ->
                     val workInfo = workInfoList.firstOrNull() ?: return@collect
                     when (workInfo.state) {
@@ -230,53 +259,65 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun saveTmdbApiKey() {
-        viewModelScope.launch {
-            val current = settingsRepository.settings.first()
-            val key = _uiState.value.tmdbApiKey
-            settingsRepository.saveSettings(current.copy(tmdbApiKey = key))
-            _uiState.value = _uiState.value.copy(
-                tmdbConnected = key.isNotBlank(),
-                defaultTmdbApiKeyAvailable = key.isBlank() && current.defaultTmdbApiKeyAvailable,
-                saveSuccess = true
-            )
+        launchSafe {
+            try {
+                val current = settingsRepository.settings.first()
+                val key = _uiState.value.tmdbApiKey
+                settingsRepository.saveSettings(current.copy(tmdbApiKey = key))
+                _uiState.value = _uiState.value.copy(
+                    tmdbConnected = key.isNotBlank(),
+                    defaultTmdbApiKeyAvailable = key.isBlank() && current.defaultTmdbApiKeyAvailable,
+                    saveSuccess = true
+                )
+            } catch (_: Exception) {
+                // Persistence failed (DataStore IO, Keystore) — user can retry; no crash.
+            }
         }
     }
 
     fun disconnectTmdb() {
-        viewModelScope.launch {
-            val current = settingsRepository.settings.first()
-            settingsRepository.saveSettings(current.copy(tmdbApiKey = ""))
-            _uiState.value = _uiState.value.copy(
-                tmdbApiKey = "",
-                tmdbConnected = false,
-                defaultTmdbApiKeyAvailable = current.defaultTmdbApiKeyAvailable
-            )
+        launchSafe {
+            try {
+                val current = settingsRepository.settings.first()
+                settingsRepository.saveSettings(current.copy(tmdbApiKey = ""))
+                _uiState.value = _uiState.value.copy(
+                    tmdbApiKey = "",
+                    tmdbConnected = false,
+                    defaultTmdbApiKeyAvailable = current.defaultTmdbApiKeyAvailable
+                )
+            } catch (_: Exception) {
+                // Persistence failed — user can retry; no crash.
+            }
         }
     }
 
     fun saveAdvancedSettings() {
-        viewModelScope.launch {
-            val state = _uiState.value
-            val current = settingsRepository.settings.first()
-            // When "bundled" is selected the key is stored as empty (repository falls back to
-            // the build-time default); when "own" is selected we persist whatever the user typed.
-            val tmdbKeyToSave = if (state.useBundledTmdbKey) "" else state.tmdbApiKey
-            settingsRepository.saveSettings(
-                current.copy(
-                    authMode = state.authMode,
-                    backendUrl = state.customBackendUrl,
-                    directClientId = state.directClientId,
-                    companionEnabled = state.companionRunning,
-                    modelDownloadUrl = state.modelDownloadUrl,
-                    tmdbApiKey = tmdbKeyToSave
+        launchSafe {
+            try {
+                val state = _uiState.value
+                val current = settingsRepository.settings.first()
+                // When "bundled" is selected the key is stored as empty (repository falls back to
+                // the build-time default); when "own" is selected we persist whatever the user typed.
+                val tmdbKeyToSave = if (state.useBundledTmdbKey) "" else state.tmdbApiKey
+                settingsRepository.saveSettings(
+                    current.copy(
+                        authMode = state.authMode,
+                        backendUrl = state.customBackendUrl,
+                        directClientId = state.directClientId,
+                        companionEnabled = state.companionRunning,
+                        modelDownloadUrl = state.modelDownloadUrl,
+                        tmdbApiKey = tmdbKeyToSave
+                    )
                 )
-            )
-            settingsRepository.saveClientSecret(state.directClientSecret)
-            _uiState.value = _uiState.value.copy(
-                tmdbConnected = tmdbKeyToSave.isNotBlank(),
-                defaultTmdbApiKeyAvailable = tmdbKeyToSave.isBlank() && current.defaultTmdbApiKeyAvailable,
-                saveSuccess = true
-            )
+                settingsRepository.saveClientSecret(state.directClientSecret)
+                _uiState.value = _uiState.value.copy(
+                    tmdbConnected = tmdbKeyToSave.isNotBlank(),
+                    defaultTmdbApiKeyAvailable = tmdbKeyToSave.isBlank() && current.defaultTmdbApiKeyAvailable,
+                    saveSuccess = true
+                )
+            } catch (_: Exception) {
+                // Persistence or Keystore failure — leave state unchanged; user can retry.
+            }
         }
     }
 
@@ -294,17 +335,24 @@ class SettingsViewModel @Inject constructor(
     }
 
     fun toggleCompanionService() {
-        val newState = !_uiState.value.companionRunning
+        val previousState = _uiState.value.companionRunning
+        val newState = !previousState
         _uiState.value = _uiState.value.copy(companionRunning = newState)
-        viewModelScope.launch {
-            val current = settingsRepository.settings.first()
-            settingsRepository.saveSettings(current.copy(companionEnabled = newState))
-        }
-        val context = getApplication<Application>()
-        if (newState) {
-            CompanionService.start(context)
-        } else {
-            CompanionService.stop(context)
+        launchSafe {
+            try {
+                val current = settingsRepository.settings.first()
+                settingsRepository.saveSettings(current.copy(companionEnabled = newState))
+                val context = getApplication<Application>()
+                if (newState) {
+                    CompanionService.start(context)
+                } else {
+                    CompanionService.stop(context)
+                }
+            } catch (_: Exception) {
+                // Persistence or service start failed — revert optimistic toggle so
+                // the UI reflects reality and the user can retry.
+                _uiState.value = _uiState.value.copy(companionRunning = previousState)
+            }
         }
     }
 
@@ -350,4 +398,7 @@ class SettingsViewModel @Inject constructor(
         // Progress is tracked by observeDownloadProgress() running since init
     }
 
+    private companion object {
+        const val TAG = "SettingsViewModel"
+    }
 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModelTest.kt
@@ -22,6 +22,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import java.io.IOException
 import java.security.GeneralSecurityException
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -828,6 +830,194 @@ class SettingsViewModelTest {
             advanceUntilIdle()
 
             assertFalse(vm.uiState.value.useBundledTmdbKey)
+        }
+    }
+
+    /**
+     * Issue #224 — settings screen must not force-close even if the WorkManager-backed
+     * download-progress flow or the model-ready state flow throws.  Regression coverage
+     * for the two init-time collectors that `2962ca0` left unguarded.
+     */
+    @Nested
+    @DisplayName("Flow observer resilience (issue #224)")
+    inner class FlowObserverResilience {
+
+        @Test
+        fun `ViewModel creation does not throw when workManager flow throws at subscription`() = runTest {
+            // Simulates WorkManager not being fully initialized on a cold start —
+            // the Flow throws the moment it's collected.
+            every { workManager.getWorkInfosForUniqueWorkFlow(any()) } returns flow {
+                throw IllegalStateException("WorkManager not initialized")
+            }
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // Screen still opens; download-progress UI stays at initial state.
+            assertNull(vm.uiState.value.llmDownloadProgress)
+        }
+
+        @Test
+        fun `ViewModel creation does not throw when workManager flow emits error mid-stream`() = runTest {
+            every { workManager.getWorkInfosForUniqueWorkFlow(any()) } returns flow {
+                emit(emptyList())
+                throw IOException("SQLite read failed")
+            }
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertNull(vm.uiState.value.llmDownloadProgress)
+        }
+
+        @Test
+        fun `ViewModel creation does not throw with no Trakt token and managedBackendAvailable false`() = runTest {
+            // Exactly the scenario reported in issue #224: user has skipped Trakt login
+            // and is on a build where the managed backend is not configured.
+            every { tokenRepository.getAccessToken() } returns null
+            every { settingsRepository.hasDefaultTmdbApiKey() } returns false
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED, tmdbApiKey = "", defaultTmdbApiKeyAvailable = false)
+            )
+
+            val vm = createViewModel(managedBackendAvailable = false)
+            advanceUntilIdle()
+
+            assertNull(vm.uiState.value.traktUsername)
+            assertTrue(vm.uiState.value.forceShowAdvanced)
+            // Auto-correction of auth mode when MANAGED was stored but backend unavailable.
+            assertEquals(AuthMode.DIRECT, vm.uiState.value.authMode)
+        }
+    }
+
+    /**
+     * Issue #224 — every user-action site that does blocking work (`.first()`, `saveSettings`,
+     * Keystore writes, service start/stop) must not crash the app on failure.
+     */
+    @Nested
+    @DisplayName("User-action resilience (issue #224)")
+    inner class UserActionResilience {
+
+        @Test
+        fun `saveAdvancedSettings does not crash when settings flow throws`() = runTest {
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // After successful init, swap in a settings flow that throws on subsequent .first()
+            every { settingsRepository.settings } returns flow { throw IOException("DataStore corrupted") }
+
+            vm.saveAdvancedSettings()
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.saveSuccess)
+        }
+
+        @Test
+        fun `saveAdvancedSettings does not crash when saveClientSecret throws SecurityException`() = runTest {
+            coEvery { settingsRepository.saveSettings(any()) } returns Unit
+            every { settingsRepository.saveClientSecret(any()) } throws
+                SecurityException("Keystore operation failed")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.saveAdvancedSettings()
+            advanceUntilIdle()
+            // No crash — that alone is the contract.
+            assertFalse(vm.uiState.value.saveSuccess)
+        }
+
+        @Test
+        fun `saveTmdbApiKey does not crash when saveSettings throws`() = runTest {
+            coEvery { settingsRepository.saveSettings(any()) } throws
+                RuntimeException("DataStore write failed")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.setTmdbApiKey("new-key")
+            vm.saveTmdbApiKey()
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.saveSuccess)
+        }
+
+        @Test
+        fun `disconnectTmdb does not crash when settings flow throws`() = runTest {
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            every { settingsRepository.settings } returns flow { throw IOException("DataStore corrupted") }
+
+            vm.disconnectTmdb()
+            advanceUntilIdle()
+            // No crash — UI remains usable.
+        }
+
+        @Test
+        fun `toggleCompanionService reverts optimistic state when settings flow throws`() = runTest {
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // ViewModel was created with companionRunning = false (default).
+            val beforeToggle = vm.uiState.value.companionRunning
+            assertFalse(beforeToggle)
+
+            // Swap in a throwing flow so the save path fails.
+            every { settingsRepository.settings } returns flow { throw IOException("DataStore corrupted") }
+
+            vm.toggleCompanionService()
+            advanceUntilIdle()
+
+            // After failure, the optimistic flip must be reverted so the UI matches reality.
+            assertEquals(beforeToggle, vm.uiState.value.companionRunning)
+        }
+
+        @Test
+        fun `toggleCompanionService reverts optimistic state when saveSettings throws`() = runTest {
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val beforeToggle = vm.uiState.value.companionRunning
+            coEvery { settingsRepository.saveSettings(any()) } throws
+                RuntimeException("DataStore write failed")
+
+            vm.toggleCompanionService()
+            advanceUntilIdle()
+
+            assertEquals(beforeToggle, vm.uiState.value.companionRunning)
+        }
+    }
+
+    /**
+     * Safety net: even if a future refactor accidentally bypasses every try/catch, the
+     * CoroutineExceptionHandler installed on viewModelScope must swallow the crash so the
+     * Settings screen still opens.  This test class guards against a fourth "settings
+     * force-close" regression.
+     */
+    @Nested
+    @DisplayName("Coroutine exception handler safety net (issue #224)")
+    inner class CoroutineHandlerSafetyNet {
+
+        @Test
+        fun `ViewModel creation does not propagate exceptions from multiple broken init paths`() = runTest {
+            // Simulate a catastrophic device state: Keystore broken, DataStore broken, WorkManager
+            // broken, LLM detection broken — but the app must still show the Settings screen.
+            every { settingsRepository.getClientSecret() } throws SecurityException("Keystore")
+            every { settingsRepository.settings } returns flow { throw IOException("DataStore") }
+            every { workManager.getWorkInfosForUniqueWorkFlow(any()) } returns flow {
+                throw IllegalStateException("WorkManager")
+            }
+            every { llmOrchestrator.selectConfig() } throws RuntimeException("LLM")
+            every { tokenRepository.getAccessToken() } throws SecurityException("Token")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // All recovered to safe defaults — and crucially, no crash.
+            assertNull(vm.uiState.value.traktUsername)
+            assertNull(vm.uiState.value.llmDownloadProgress)
+            assertFalse(vm.uiState.value.tmdbConnected)
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #224 — the phone app force-closes when opening Settings without a Trakt connection. This is the **fourth** relapse of the same class of bug (prior fixes: #170, #177, #196). Instead of adding another targeted `try/catch`, this PR installs a structural safety net so the bug cannot recur.

## Root-cause analysis

Commit `2962ca0` (PR #202, released in `0.13.8` ~30 minutes before #224 was filed) reworked Settings and introduced two new unguarded `viewModelScope.launch { }` sites plus four user-action methods doing blocking work without `try/catch`:

| Site | File:line | Was guarded? |
|---|---|---|
| `observeModelReadyState()` | SettingsViewModel:159 | ❌ |
| `observeDownloadProgress()` | SettingsViewModel:167 | ❌ |
| `saveTmdbApiKey()` | SettingsViewModel:232 | ❌ |
| `disconnectTmdb()` | SettingsViewModel:245 | ❌ |
| `saveAdvancedSettings()` | SettingsViewModel:257 | ❌ |
| `toggleCompanionService()` | SettingsViewModel:296 | ❌ |

The most plausible crash on "open Settings" is `observeDownloadProgress()`: `workManager.getWorkInfosForUniqueWorkFlow(...)` is a cold Flow that subscribes to WorkManager's internal Room DB and can throw `IllegalStateException` at subscribe time (WorkManager not yet initialised via `Configuration.Provider`) or surface an IO error mid-stream. Without `.catch {}`, the exception escapes `viewModelScope` and the process's default `UncaughtExceptionHandler` force-closes the app. The "no Trakt connected" framing in #224 is incidental — users with Trakt connected are less likely to hit this collector in the same race window.

## Fix — three layers so it cannot recur

### 1. Safety net — `CoroutineExceptionHandler` on `viewModelScope`

```kotlin
private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
    Log.e(TAG, "Uncaught exception in SettingsViewModel coroutine", throwable)
}
private fun launchSafe(block: suspend CoroutineScope.() -> Unit): Job =
    viewModelScope.launch(coroutineExceptionHandler, block = block)
```

Every `viewModelScope.launch { }` in `SettingsViewModel` is replaced with `launchSafe { }`. Any future-added coroutine that forgets a `try/catch` now logs a diagnostic instead of crashing the app — closing the class of bug.

### 2. `.catch {}` on Flow collectors

`observeModelReadyState()` and `observeDownloadProgress()` now chain `.catch {}` before `.collect` — the idiomatic way to contain upstream flow exceptions without swallowing `CancellationException`.

### 3. `try/catch` on user-action methods

`saveTmdbApiKey`, `disconnectTmdb`, `saveAdvancedSettings`, `toggleCompanionService` each wrap their body. `toggleCompanionService` **reverts** the optimistic `companionRunning` flip on failure so the Switch reflects reality.

## Regression tests

Three new `@Nested` classes in `SettingsViewModelTest`:

- **`FlowObserverResilience`** — WorkManager flow throws at subscription / mid-stream; the exact "no Trakt + `managedBackendAvailable=false`" repro from #224.
- **`UserActionResilience`** — save/disconnect/toggle all stay crash-free when the persistence layer throws; toggle reverts on failure.
- **`CoroutineHandlerSafetyNet`** — a catastrophic device state (Keystore + DataStore + WorkManager + LLM + Token all broken) still opens the screen.

## Test plan

- [x] `./gradlew :app-phone:testDebugUnitTest --tests "com.justb81.watchbuddy.phone.ui.settings.SettingsViewModelTest"` — **CI only; the local sandbox has no Android SDK.** Awaiting `build-android.yml` green before handoff.
- [ ] Manual repro on device without Trakt token:
  - Fresh install → Onboarding → **Skip** → Home → tap Settings → screen renders.
  - Fresh install → Onboarding → advanced link → Settings → screen renders.
  - From Settings: toggle "I am watching TV" → no crash.
  - From Settings: switch auth mode, save advanced → no crash.

https://claude.ai/code/session_015dSeH6cB5HCqah2VunV7me