### PR TITLE
fix(tv): remove broken service declarations that block app launch

### DIFF
--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -7,14 +7,6 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
 
-    <!-- MediaSession listener (scrobbling) -->
-    <uses-permission android:name="android.permission.MEDIA_CONTENT_CONTROL" />
-
-    <!-- Background sync -->
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
-
     <!-- Play Store: TV app — no touchscreen, leanback required for correct
          multi-APK device targeting (prevents phone devices from receiving the
          TV AAB which has a higher versionCode). -->
@@ -74,24 +66,6 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
         </provider>
-
-        <!-- MediaSession scrobbler service -->
-        <service
-            android:name=".service.MediaSessionScrobblerService"
-            android:enabled="true"
-            android:exported="true"
-            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
-            <intent-filter>
-                <action android:name="android.service.notification.NotificationListenerService" />
-            </intent-filter>
-        </service>
-
-        <!-- NSD discovery + phone coordinator -->
-        <service
-            android:name=".service.PhoneDiscoveryService"
-            android:enabled="true"
-            android:exported="false"
-            android:foregroundServiceType="dataSync" />
 
     </application>
 </manifest>


### PR DESCRIPTION
## Summary

Fixes #238 — the TV app's `AndroidManifest.xml` declared two `<service>` components pointing at classes that don't exist anywhere in the TV module. On some Android TV builds, a missing `NotificationListenerService` class suppresses the app from the launcher entirely, which matches the "TV app does not start" symptom.

Removed:

- `<service android:name=".service.MediaSessionScrobblerService">` — no such class. Closest match `com.justb81.watchbuddy.tv.scrobbler.MediaSessionScrobbler` is a plain Hilt `@Singleton`, not a `NotificationListenerService`.
- `<service android:name=".service.PhoneDiscoveryService">` — no such class. Closest match `com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager` is a plain `@Singleton`, not a foreground `Service`.
- Orphaned permissions that only existed for these services: `MEDIA_CONTENT_CONTROL`, `RECEIVE_BOOT_COMPLETED`, `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`.

The `com.justb81.watchbuddy.service` package does not exist in `app-tv/` at all, and nothing calls `startService` / `startForegroundService` anywhere in the module (verified via grep), so these entries were fully dead.

## Follow-up (not in this PR)

Scrobbling on TV is separately broken because nothing invokes `MediaSessionScrobbler.startListening(...)`. Restoring that feature needs real `NotificationListenerService` + foreground discovery service classes, which is a larger change and should land in its own PR informed by the diagnostic crash report (issue #238).

## Test plan

- [ ] CI `build-android.yml` passes
- [ ] Install TV debug APK on Android TV / emulator — app appears in launcher
- [ ] Launch app — Home screen renders without crash

https://claude.ai/code/session_01NPSmwjzS3oARBvC5WsSnuU