### PR TITLE
fix(tv): harden startup path and add early crash capture

### DIFF
--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -121,9 +121,6 @@ dependencies {
     // Image loading
     implementation(libs.coil)
 
-    // WorkManager (background Trakt sync / scrobble history)
-    implementation(libs.work.runtime)
-
     // Error-prone annotations — compileOnly so R8 can resolve references from Tink
     // without bundling the annotation library in the APK.
     compileOnly(libs.errorprone.annotations)

--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Network -->
     <uses-permission android:name="android.permission.INTERNET" />
@@ -65,6 +66,20 @@
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths" />
+        </provider>
+
+        <!-- TV app does not use WorkManager; disable its auto-init so the
+             startup path does not build a Room-backed WorkDatabase for
+             nothing (which can crash under R8 if any keep rule is off). -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
         </provider>
 
     </application>

--- a/app-tv/src/main/java/com/justb81/watchbuddy/WatchBuddyTvApp.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/WatchBuddyTvApp.kt
@@ -1,6 +1,7 @@
 package com.justb81.watchbuddy
 
 import android.app.Application
+import android.content.Context
 import android.os.Build
 import com.justb81.watchbuddy.core.logging.CrashReporter
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
@@ -9,13 +10,29 @@ import dagger.hilt.android.HiltAndroidApp
 @HiltAndroidApp
 class WatchBuddyTvApp : Application() {
 
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(base)
+        // Install the crash reporter as early as possible so failures inside
+        // Application.super.onCreate() (e.g. Hilt component build) and the
+        // first Activity's super.onCreate() are captured. Installing only in
+        // Application.onCreate() is too late — the reporter is still null when
+        // the Hilt singleton graph is assembled.
+        runCatching { CrashReporter.install(base) }
+        DiagnosticLog.event("App", "TV attachBaseContext")
+    }
+
     override fun onCreate() {
-        super.onCreate()
-        CrashReporter.install(this)
-        DiagnosticLog.event(
-            "App",
-            "TV onCreate ${BuildConfig.VERSION_NAME} (vc=${BuildConfig.VERSION_CODE}) " +
-                "device=${Build.MANUFACTURER} ${Build.MODEL} sdk=${Build.VERSION.SDK_INT}"
-        )
+        DiagnosticLog.event("App", "TV onCreate entered")
+        try {
+            super.onCreate()
+            DiagnosticLog.event(
+                "App",
+                "TV onCreate ${BuildConfig.VERSION_NAME} (vc=${BuildConfig.VERSION_CODE}) " +
+                    "device=${Build.MANUFACTURER} ${Build.MODEL} sdk=${Build.VERSION.SDK_INT}"
+            )
+        } catch (t: Throwable) {
+            DiagnosticLog.error("App", "TV onCreate failed", t)
+            throw t
+        }
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.util.Log
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.model.LlmBackend
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -50,7 +51,15 @@ class PhoneDiscoveryManager @Inject constructor(
     private val _discoveredPhones = MutableStateFlow<List<DiscoveredPhone>>(emptyList())
     val discoveredPhones: StateFlow<List<DiscoveredPhone>> = _discoveredPhones
 
-    private val nsdManager = context.getSystemService(Context.NSD_SERVICE) as NsdManager
+    // Nullable + runCatching so that a missing NSD system service on unusual
+    // TV ROMs cannot throw during Hilt singleton construction, which would
+    // otherwise blow up the first hiltViewModel() call and prevent the app
+    // from ever drawing a frame.
+    private val nsdManager: NsdManager? = runCatching {
+        context.getSystemService(Context.NSD_SERVICE) as? NsdManager
+    }.onFailure {
+        DiagnosticLog.error(TAG, "NSD_SERVICE lookup failed", it)
+    }.getOrNull()
     private val heartbeatScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var heartbeatJob: Job? = null
 
@@ -81,8 +90,9 @@ class PhoneDiscoveryManager @Inject constructor(
         override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {}
 
         override fun onServiceFound(service: NsdServiceInfo) {
+            val mgr = nsdManager ?: return
             @Suppress("DEPRECATION")
-            nsdManager.resolveService(service, object : NsdManager.ResolveListener {
+            mgr.resolveService(service, object : NsdManager.ResolveListener {
                 override fun onResolveFailed(serviceInfo: NsdServiceInfo, errorCode: Int) {}
                 override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
                     fetchCapabilityAndAdd(serviceInfo)
@@ -97,13 +107,21 @@ class PhoneDiscoveryManager @Inject constructor(
     }
 
     fun startDiscovery() {
-        nsdManager.discoverServices(SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+        val mgr = nsdManager
+        if (mgr == null) {
+            DiagnosticLog.warn(TAG, "NSD unavailable; discovery disabled")
+            return
+        }
+        runCatching {
+            mgr.discoverServices(SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
+        }.onFailure { DiagnosticLog.error(TAG, "discoverServices failed", it) }
         startHeartbeat()
     }
 
     fun stopDiscovery() {
         heartbeatJob?.cancel()
-        runCatching { nsdManager.stopServiceDiscovery(discoveryListener) }
+        val mgr = nsdManager ?: return
+        runCatching { mgr.stopServiceDiscovery(discoveryListener) }
     }
 
     private fun startHeartbeat() {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/TvMainActivity.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/TvMainActivity.kt
@@ -3,6 +3,31 @@ package com.justb81.watchbuddy.tv.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.logging.CrashReporter
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.core.logging.DiagnosticShare
 import com.justb81.watchbuddy.tv.ui.navigation.TvNavGraph
 import com.justb81.watchbuddy.tv.ui.theme.WatchBuddyTvTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -10,11 +35,71 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class TvMainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        DiagnosticLog.event(TAG, "onCreate entered")
         super.onCreate(savedInstanceState)
+
         setContent {
             WatchBuddyTvTheme {
-                TvNavGraph()
+                // Catch exceptions thrown during initial composition of the real
+                // nav graph and swap in a fallback that lets the user share the
+                // crash report. Without this, a throw inside TvNavGraph() tears
+                // down the window before anything is drawn — and the only symptom
+                // the user sees is "tap icon, nothing happens" (issue #238).
+                var initError by remember { mutableStateOf<Throwable?>(null) }
+                val err = initError
+                if (err == null) {
+                    runCatching { TvNavGraph() }.onFailure { t ->
+                        DiagnosticLog.error(TAG, "TvNavGraph composition failed", t)
+                        runCatching {
+                            CrashReporter.writeManualSnapshot(
+                                this@TvMainActivity,
+                                reason = "TvNavGraph composition failed: ${t.javaClass.simpleName}: ${t.message}"
+                            )
+                        }
+                        initError = t
+                    }
+                } else {
+                    StartupFailedScreen(error = err)
+                }
             }
+        }
+        DiagnosticLog.event(TAG, "onCreate completed")
+    }
+
+    private companion object {
+        const val TAG = "TvMainActivity"
+    }
+}
+
+@Composable
+private fun StartupFailedScreen(error: Throwable) {
+    val context = LocalContext.current
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .padding(48.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+        horizontalAlignment = Alignment.Start
+    ) {
+        Text(
+            text = stringResource(R.string.tv_startup_failed_title),
+            color = Color.White,
+            style = MaterialTheme.typography.headlineMedium
+        )
+        Text(
+            text = "${error.javaClass.name}: ${error.message ?: ""}",
+            color = Color.White,
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Text(
+            text = error.stackTraceToString(),
+            color = Color.White.copy(alpha = 0.7f),
+            style = MaterialTheme.typography.bodySmall
+        )
+        Button(onClick = { DiagnosticShare.launchShare(context) }) {
+            Text(stringResource(R.string.tv_startup_failed_share))
         }
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -2,6 +2,7 @@ package com.justb81.watchbuddy.tv.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.tv.data.TvShowCache
 import com.justb81.watchbuddy.tv.data.UserSessionRepository
@@ -39,6 +40,7 @@ class TvHomeViewModel @Inject constructor(
 
     companion object {
         val PAGE_SIZE = PhoneApiService.PAGE_SIZE
+        private const val TAG = "TvHomeViewModel"
     }
 
     private val _uiState = MutableStateFlow(TvHomeUiState())
@@ -49,7 +51,8 @@ class TvHomeViewModel @Inject constructor(
     private var loadedOffset: Int = 0
 
     init {
-        phoneDiscovery.startDiscovery()
+        runCatching { phoneDiscovery.startDiscovery() }
+            .onFailure { DiagnosticLog.error(TAG, "startDiscovery failed", it) }
         observePhones()
         observeSelectedUsers()
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
@@ -31,10 +31,6 @@ fun TvNavGraph() {
     // Shared state: currently selected show (passed between Home → Detail → Recap)
     var selectedEntry by remember { mutableStateOf<TraktWatchedEntry?>(null) }
 
-    // Scrobble overlay — driven by ScrobbleViewModel (Issue #18)
-    val scrobbleViewModel: ScrobbleViewModel = hiltViewModel()
-    val pendingCandidate by scrobbleViewModel.pendingCandidate.collectAsState()
-
     NavHost(
         navController    = navController,
         startDestination = TvRoute.Home.route
@@ -95,12 +91,24 @@ fun TvNavGraph() {
         }
     }
 
-    // Scrobble overlay — renders on top of everything
-    pendingCandidate?.let { candidate ->
+    // Scrobble overlay — isolated in its own host so ScrobbleViewModel (and its
+    // transitive singletons: MediaSessionScrobbler → PhoneDiscoveryManager) are
+    // only instantiated once the Nav tree is up and running. Previously this
+    // viewModel was requested at the top of TvNavGraph, which meant any
+    // exception inside those singletons' constructors would throw during the
+    // very first composition and prevent the app from ever drawing a frame.
+    ScrobbleOverlayHost()
+}
+
+@Composable
+private fun ScrobbleOverlayHost() {
+    val vm: ScrobbleViewModel = hiltViewModel()
+    val pending by vm.pendingCandidate.collectAsState()
+    pending?.let { candidate ->
         ScrobbleOverlay(
             candidate = candidate,
-            onConfirm = { scrobbleViewModel.confirmScrobble() },
-            onDismiss = { scrobbleViewModel.dismissScrobble() }
+            onConfirm = { vm.confirmScrobble() },
+            onDismiss = { vm.dismissScrobble() }
         )
     }
 }

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -80,4 +80,6 @@
     <string name="diagnostics_banner_share">Teilen</string>
     <string name="diagnostics_banner_dismiss">Verwerfen</string>
     <string name="diagnostics_export">Diagnose exportieren</string>
+    <string name="tv_startup_failed_title">WatchBuddy konnte nicht gestartet werden</string>
+    <string name="tv_startup_failed_share">Diagnosebericht teilen</string>
 </resources>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -80,4 +80,6 @@
     <string name="diagnostics_banner_share">Compartir</string>
     <string name="diagnostics_banner_dismiss">Descartar</string>
     <string name="diagnostics_export">Exportar diagnóstico</string>
+    <string name="tv_startup_failed_title">WatchBuddy no pudo iniciarse</string>
+    <string name="tv_startup_failed_share">Compartir informe de diagnóstico</string>
 </resources>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -80,4 +80,6 @@
     <string name="diagnostics_banner_share">Partager</string>
     <string name="diagnostics_banner_dismiss">Ignorer</string>
     <string name="diagnostics_export">Exporter le diagnostic</string>
+    <string name="tv_startup_failed_title">WatchBuddy n\'a pas pu démarrer</string>
+    <string name="tv_startup_failed_share">Partager le rapport de diagnostic</string>
 </resources>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -51,6 +51,8 @@
     <string name="diagnostics_banner_share">Share</string>
     <string name="diagnostics_banner_dismiss">Dismiss</string>
     <string name="diagnostics_export">Export diagnostics</string>
+    <string name="tv_startup_failed_title">WatchBuddy could not start</string>
+    <string name="tv_startup_failed_share">Share diagnostic report</string>
 
     <!-- Streaming settings -->
     <string name="tv_streaming_settings_button">Services</string>

--- a/app-tv/src/main/res/values/themes.xml
+++ b/app-tv/src/main/res/values/themes.xml
@@ -10,6 +10,5 @@
         <item name="android:windowNoTitle">true</item>
         <item name="android:windowFullscreen">true</item>
         <item name="android:windowContentOverlay">@null</item>
-        <item name="android:windowOverscan">false</item>
     </style>
 </resources>


### PR DESCRIPTION
Follows up #238 and #240. The earlier manifest fix shipped in 0.14.3, but the TV app still fails to launch on Google TV 14 — icon appears, tap does nothing, no crash dialog.

Root cause is invisible because `CrashReporter` was installed inside `Application.onCreate()` — too late for exceptions thrown during `super.onCreate()`, Hilt's `SingletonComponent` build, or `TvMainActivity.super.onCreate()` (where `@AndroidEntryPoint` injection runs). That's why there's no crash report to read.

## Summary

This PR takes two passes at the problem in a single change:

1. **Install crash capture earlier** so the next failure is actionable without adb.
2. **Harden each likely crash site** so the app has a real chance of launching even if one of them would have thrown.

## Changes

| File | Change |
|------|--------|
| `WatchBuddyTvApp.kt` | Install `CrashReporter` from `attachBaseContext()` instead of `onCreate()`. Wrap `onCreate()` in try/catch that records a breadcrumb before re-throwing. |
| `PhoneDiscoveryManager.kt` | `nsdManager` is now nullable with `as?` + `runCatching`. `startDiscovery` / `stopDiscovery` / `onServiceFound` short-circuit if NSD is unavailable. Previously a throw here blew up Hilt singleton construction on the first `hiltViewModel()` call. |
| `AndroidManifest.xml` | Disable WorkManager auto-init via `androidx.startup.InitializationProvider`, mirroring `app-phone`. TV app doesn't use WorkManager. |
| `app-tv/build.gradle.kts` | Drop unused `work.runtime` dependency. |
| `TvNavGraph.kt` | Extract scrobble overlay into `ScrobbleOverlayHost()` — `ScrobbleViewModel` (and its transitive singletons `MediaSessionScrobbler` → `PhoneDiscoveryManager`) now live in an isolated composable scope instead of at the top of the nav tree. |
| `TvHomeViewModel.kt` | Wrap `phoneDiscovery.startDiscovery()` in `runCatching` so a late NSD failure cannot tear down the Home screen. |
| `themes.xml` | Drop deprecated `android:windowOverscan` (no-op since API 21, can confuse decor-view inflation on Google TV 14). |
| `TvMainActivity.kt` | Wrap `TvNavGraph()` composition in `runCatching`. On failure: write a manual snapshot and render a fallback screen with the stack trace + a "Share diagnostic report" button — the only diagnostic path the user has without adb. |
| `values*/strings.xml` | Add `tv_startup_failed_title` / `tv_startup_failed_share` to EN/DE/FR/ES. |

## Test plan

- [ ] CI `build-android.yml` green (compile + R8 + manifest merge).
- [ ] Install resulting APK on Google TV 14.
- [ ] Expected outcome is one of:
  - (a) App launches normally → issue #238 closed.
  - (b) Fallback screen appears with a real stack trace → follow-up PR with a targeted fix informed by the trace.
  - (c) Nothing happens, same as before → escalate (the defensive fixes did not cover the real cause and we need network adb to debug).

Closes #238 (on outcome a); otherwise the issue stays open for the follow-up.

https://claude.ai/code/session_01NPSmwjzS3oARBvC5WsSnuU