### PR TITLE
fix(tv): exclude androidx.work and harden Room R8 keeps

### DIFF
--- a/app-phone/proguard-rules.pro
+++ b/app-phone/proguard-rules.pro
@@ -68,17 +68,23 @@
 -keep class androidx.security.crypto.** { *; }
 
 # ── Room / WorkManager ──────────────────────────────────────────────────────
-# Room 2.7+ instantiates generated _Impl classes via reflection
-# (Class.getDeclaredConstructor().newInstance()), so the no-arg constructor
-# must survive R8 shrinking.  Without this rule, the first call to
-# WorkManager.getInstance() in a release build throws
-# "NoSuchMethodException: androidx.work.impl.WorkDatabase_Impl.<init>[]".
-# Reported in issue #232 — the crash that opening Settings produced because
-# SettingsViewModel has an @Inject WorkManager dependency.
--keepclassmembers class * extends androidx.room.RoomDatabase {
-    public <init>();
+# Room 2.7+ reflectively invokes a no-arg constructor on generated _Impl
+# classes (see androidx.room.Room.getGeneratedImplementation).  R8 full mode
+# in AGP 9 strips constructors that have no static callers even under
+# `-keep class X { *; }` — issue #232 traced to this pathway on the phone
+# (SettingsViewModel has an @Inject WorkManager dependency).  Kept the
+# constructor explicitly; matches the TV module for consistency.
+-keep,includedescriptorclasses class * extends androidx.room.RoomDatabase {
+    <init>();
+    *;
 }
--keep class androidx.work.impl.WorkDatabase_Impl { *; }
+-keepclassmembers class * extends androidx.room.RoomDatabase {
+    <init>();
+}
+-keep class androidx.work.impl.WorkDatabase_Impl {
+    <init>();
+    *;
+}
 
 # ── Coroutines ───────────────────────────────────────────────────────────────
 -keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -148,3 +148,14 @@ kotlin {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+// The TV app does not use WorkManager. If a transitive dep brings in
+// androidx.work:work-runtime, its InitializationProvider auto-init crashes
+// pre-Application.onCreate on release builds (Room reflectively invokes the
+// no-arg constructor on WorkDatabase_Impl, which R8 full mode strips — see
+// issue #232 and the 0.12.0 trace on #244). Dropping the group removes both
+// the DEX classes and the merged-manifest contribution, so WorkManager cannot
+// be registered as an androidx.startup initializer in the first place.
+configurations.all {
+    exclude(group = "androidx.work")
+}

--- a/app-tv/proguard-rules.pro
+++ b/app-tv/proguard-rules.pro
@@ -48,18 +48,30 @@
 -keep class androidx.security.crypto.** { *; }
 -dontwarn com.google.errorprone.annotations.**
 
-# ── Room / WorkManager ──────────────────────────────────────────────────────
-# Room 2.7+ instantiates generated _Impl classes via reflection
-# (Class.getDeclaredConstructor().newInstance()), so the no-arg constructor
-# must survive R8 shrinking.  Without this rule, the first call to
-# WorkManager.getInstance() in a release build throws
-# "NoSuchMethodException: androidx.work.impl.WorkDatabase_Impl.<init>[]".
-# Reported in issue #232 — the crash that opening Settings produced because
-# SettingsViewModel has an @Inject WorkManager dependency.
--keepclassmembers class * extends androidx.room.RoomDatabase {
-    public <init>();
+# ── Room ────────────────────────────────────────────────────────────────────
+# Room 2.7+ reflectively invokes a no-arg constructor on generated _Impl
+# classes (see androidx.room.Room.getGeneratedImplementation).  R8 full mode
+# in AGP 9 strips constructors that have no static callers even under
+# `-keep class X { *; }` — issues #232 and the 0.12.0 trace attached to #244
+# both trace to this pathway.  Kept the constructor explicitly.
+-keep,includedescriptorclasses class * extends androidx.room.RoomDatabase {
+    <init>();
+    *;
 }
--keep class androidx.work.impl.WorkDatabase_Impl { *; }
+-keepclassmembers class * extends androidx.room.RoomDatabase {
+    <init>();
+}
+
+# ── WorkManager (safety net) ────────────────────────────────────────────────
+# androidx.work is excluded from this module's classpath (see
+# app-tv/build.gradle.kts `configurations.all`), so these rules are a safety
+# net in case a future transitive dep re-introduces work-runtime.  `-dontwarn`
+# keeps R8 from failing the build while the classes are absent.
+-keep class androidx.work.impl.WorkDatabase_Impl {
+    <init>();
+    *;
+}
+-dontwarn androidx.work.**
 
 # ── Coroutines ───────────────────────────────────────────────────────────────
 -keepnames class kotlinx.coroutines.internal.MainDispatcherFactory {}


### PR DESCRIPTION
## Summary

Third attempt at closing the "TV app does not start" symptom reported in #238 (and the pre-patch stack trace attached to #244). PR #240 fixed the dangling service declarations, PR #242 added early crash capture and a Compose fallback — the app still does not open on 0.14.4 and Android Vitals has not aggregated a 0.14.4-specific trace yet.

The only concrete failure mode we have ever seen on TV is the one in #244 (captured on 0.12.0): `InitializationProvider` → `WorkManagerInitializer` → `WorkDatabase_Impl` reflective no-arg constructor → `NoSuchMethodException`. Issue #232's keep rule and PR #242's `tools:node="remove"` + dropped `work-runtime` dep were both too weak:

- **AGP 9's R8 full mode** strips constructors that have no static callers even under `-keep class X { *; }`. The no-arg constructor on every Room `_Impl` subclass must be kept **explicitly** (`<init>();`).
- **`work-runtime` can still be pulled in transitively** even after removing the direct dependency, which re-introduces the manifest `<meta-data>` contribution that `tools:node="remove"` is supposed to strip.

The TV app does not use WorkManager. This PR closes the pathway at three independent barriers:

1. **`app-tv/build.gradle.kts`** — `configurations.all { exclude(group = "androidx.work") }` removes the library from the TV APK (DEX + merged manifest).
2. **`app-tv/proguard-rules.pro`** — explicit `<init>();` keeps for Room subclasses; `WorkDatabase_Impl` rule retained as a safety net, `-dontwarn androidx.work.**` so R8 does not fail the build with the class absent.
3. **Manifest `tools:node="remove"`** from PR #242 stays in place as the third barrier.

Drive-by: `app-phone/proguard-rules.pro` gets the same explicit-constructor keep pattern for consistency (no behaviour change on the phone — WorkManager is actively used there and the constructor is kept via the live-caller path, but the rule pattern is now identical across modules).

## Rationale

The #244 stack trace is pre-fix (0.12.0), not a live 0.14.4 reproduction. We cannot distinguish between "that pathway still crashes on 0.14.4" and "0.14.4 has a different failure we do not yet see a trace for". Hardening this pathway is a necessary step either way:

- If the WorkManager pathway **is** still the live cause, 0.14.5 launches.
- If it is **not**, Vitals will now surface a non-WorkManager trace on 0.14.5, which drives the next PR.

## Test plan

- [x] CI `build-android.yml` passes (validates R8 + manifest merge with the exclusion in place)
- [x] After build: `./gradlew :app-tv:dependencies --configuration releaseRuntimeClasspath | grep -i work` → no results
- [x] After build: merged TV manifest at `app-tv/build/intermediates/merged_manifests/release/AndroidManifest.xml` contains no `androidx.work` references
- [ ] After 0.14.5 ships: install on Google TV 14 and confirm app launches (or, if not, capture the new Vitals trace)

Refs #238, #244. Builds on #242.

https://claude.ai/code/session_01NPSmwjzS3oARBvC5WsSnuU