### PR TITLE
feat(home): show episode progress vs aired episodes with collapsible all-shows section (closes #239)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Android / Gradle
 *.iml
 .gradle/
+.kotlin/
 local.properties
 .idea/
 .DS_Store

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -152,7 +152,7 @@ internal fun Application.configureCompanionRoutes(
                 val tmdbLanguage = LocaleHelper.getTmdbLanguage()
 
                 val shows = showRepository.getShows()
-                val watchedEntry = shows.find { it.show.ids.trakt == showId }
+                val watchedEntry = shows.find { it.entry.show.ids.trakt == showId }?.entry
                     ?: return@post call.respond(HttpStatusCode.NotFound, ErrorResponse("Show not found"))
 
                 val tmdbId = watchedEntry.show.ids.tmdb

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
@@ -1,29 +1,52 @@
 package com.justb81.watchbuddy.phone.server
 
 import android.util.Log
+import com.justb81.watchbuddy.core.locale.LocaleHelper
+import com.justb81.watchbuddy.core.model.EnrichedShowEntry
+import com.justb81.watchbuddy.core.model.TmdbProgressHint
+import com.justb81.watchbuddy.core.model.TmdbShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 import javax.inject.Singleton
 
 private const val TAG = "ShowRepository"
 
+/**
+ * Single source of truth for the user's watched shows on the phone side.
+ * Wraps Trakt's watched list and enriches each entry with a [TmdbProgressHint]
+ * and a poster path fetched from TMDB. The fan-out is parallel and tolerates
+ * per-show failures so one unreachable show does not break the whole list.
+ *
+ * Consumed by:
+ *   • [CompanionHttpServer] for the `/shows` HTTP endpoint
+ *   • Phone `HomeViewModel` for rendering the home list
+ */
 @Singleton
 class ShowRepository @Inject constructor(
     private val traktApi: TraktApiService,
-    private val tokenRefreshManager: TokenRefreshManager
+    private val tokenRefreshManager: TokenRefreshManager,
+    private val tmdbApiService: TmdbApiService,
+    private val settingsRepository: SettingsRepository
 ) {
-    private var cachedShows: List<TraktWatchedEntry> = emptyList()
+    private var cachedShows: List<EnrichedShowEntry> = emptyList()
     private var lastFetch: Long = 0L
 
-    suspend fun getShows(): List<TraktWatchedEntry> {
+    suspend fun getShows(): List<EnrichedShowEntry> {
         val now = System.currentTimeMillis()
         if (now - lastFetch > CACHE_TTL || cachedShows.isEmpty()) {
             val token = tokenRefreshManager.getValidAccessToken()
                 ?: return emptyList()
             try {
-                cachedShows = traktApi.getWatchedShows("Bearer $token")
+                val trakt = traktApi.getWatchedShows("Bearer $token")
+                cachedShows = enrich(trakt)
                 lastFetch = now
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch shows from Trakt; serving ${cachedShows.size} cached entries", e)
@@ -33,7 +56,43 @@ class ShowRepository @Inject constructor(
         return cachedShows
     }
 
+    private suspend fun enrich(entries: List<TraktWatchedEntry>): List<EnrichedShowEntry> {
+        val apiKey = runCatching { settingsRepository.getTmdbApiKey().first() }.getOrDefault("")
+        if (apiKey.isBlank()) {
+            return entries.map { EnrichedShowEntry(entry = it) }
+        }
+        val language = LocaleHelper.getTmdbLanguage()
+        return coroutineScope {
+            entries.map { entry ->
+                async {
+                    val tmdbId = entry.show.ids.tmdb
+                    if (tmdbId == null) {
+                        EnrichedShowEntry(entry = entry)
+                    } else {
+                        val tmdb = runCatching {
+                            tmdbApiService.getShow(tmdbId, apiKey, language)
+                        }.onFailure {
+                            Log.w(TAG, "TMDB enrichment failed for show ${entry.show.title}", it)
+                        }.getOrNull()
+                        EnrichedShowEntry(
+                            entry = entry,
+                            tmdb = tmdb?.toProgressHint(),
+                            posterPath = tmdb?.poster_path
+                        )
+                    }
+                }
+            }.awaitAll()
+        }
+    }
+
     private companion object {
         const val CACHE_TTL = 5 * 60 * 1000L // 5 minutes
     }
 }
+
+private fun TmdbShow.toProgressHint(): TmdbProgressHint = TmdbProgressHint(
+    status = status,
+    lastAired = last_episode_to_air,
+    nextAired = next_episode_to_air,
+    seasons = seasons
+)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
@@ -1,24 +1,34 @@
 package com.justb81.watchbuddy.phone.ui.home
 
+import android.content.res.Configuration
+import android.text.format.DateUtils
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -27,9 +37,14 @@ import coil.compose.AsyncImage
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.logging.CrashReporter
 import com.justb81.watchbuddy.core.logging.DiagnosticShare
+import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.ScrobbleAction
 import com.justb81.watchbuddy.core.model.ScrobbleDisplayEvent
-import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.progress.ShowProgress
+import com.justb81.watchbuddy.core.tmdb.TmdbImageHelper
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -107,130 +122,197 @@ fun HomeScreen(
             if (pendingReports > 0) {
                 DiagnosticsBanner(
                     reportCount = pendingReports,
-                    onShare = {
-                        DiagnosticShare.launchShare(context)
-                    },
+                    onShare = { DiagnosticShare.launchShare(context) },
                     onDismiss = {
                         CrashReporter.clearReports(context)
                         pendingReports = 0
                     }
                 )
             }
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .weight(1f)
-        ) {
-            when {
-                uiState.isLoading -> {
-                    CircularProgressIndicator(
-                        modifier = Modifier.align(Alignment.Center),
-                        color = MaterialTheme.colorScheme.primary
-                    )
-                }
-
-                uiState.error != null -> {
-                    Column(
-                        modifier = Modifier.align(Alignment.Center),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        Text(
-                            uiState.error!!,
-                            color = MaterialTheme.colorScheme.error
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .weight(1f)
+            ) {
+                when {
+                    uiState.isLoading -> {
+                        CircularProgressIndicator(
+                            modifier = Modifier.align(Alignment.Center),
+                            color = MaterialTheme.colorScheme.primary
                         )
-                        Button(onClick = { viewModel.loadShows() }) {
-                            Text(stringResource(R.string.retry))
+                    }
+
+                    uiState.error != null -> {
+                        Column(
+                            modifier = Modifier.align(Alignment.Center),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            Text(uiState.error!!, color = MaterialTheme.colorScheme.error)
+                            Button(onClick = { viewModel.loadShows() }) {
+                                Text(stringResource(R.string.retry))
+                            }
                         }
                     }
-                }
 
-                uiState.shows.isEmpty() -> {
-                    Column(
-                        modifier = Modifier.align(Alignment.Center).padding(32.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(16.dp)
-                    ) {
-                        Text(
-                            text  = stringResource(R.string.home_no_shows),
-                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
-                            style = MaterialTheme.typography.bodyLarge
-                        )
-                        Button(onClick = onConnectClick) {
-                            Text(stringResource(R.string.home_connect_to_trakt))
-                        }
-                    }
-                }
-
-                else -> {
-                    LazyColumn(
-                        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        // Watching TV toggle
-                        if (uiState.canWatch) {
-                            item {
-                                WatchingTvToggle(
-                                    isWatching = uiState.isWatchingTv,
-                                    onToggle = { viewModel.toggleWatchingTv(it) }
-                                )
-                            }
-                        }
-
-                        // Now watching card (scrobble event from TV)
-                        uiState.latestScrobbleEvent?.let { event ->
-                            item {
-                                NowWatchingCard(event = event)
-                            }
-                        }
-
-                        // Continue watching section
-                        val inProgress = uiState.shows.filter { it.seasons.isNotEmpty() }
-                        if (inProgress.isNotEmpty()) {
-                            item {
-                                SectionHeader(stringResource(R.string.home_continue_watching))
-                            }
-                            items(inProgress.take(5)) { entry ->
-                                ShowCard(
-                                    entry = entry,
-                                    posterUrl = entry.show.ids.tmdb?.let { uiState.posterUrls[it] },
-                                    onClick = {
-                                        entry.show.ids.trakt?.let { onShowClick(it) }
-                                    }
-                                )
-                            }
-                        }
-
-                        // All shows
-                        item {
-                            SectionHeader(stringResource(R.string.home_all_shows))
-                        }
-                        items(uiState.shows) { entry ->
-                            ShowCard(
-                                entry = entry,
-                                posterUrl = entry.show.ids.tmdb?.let { uiState.posterUrls[it] },
-                                onClick = {
-                                    entry.show.ids.trakt?.let { onShowClick(it) }
-                                }
+                    uiState.shows.isEmpty() -> {
+                        Column(
+                            modifier = Modifier.align(Alignment.Center).padding(32.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.spacedBy(16.dp)
+                        ) {
+                            Text(
+                                text  = stringResource(R.string.home_no_shows),
+                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                                style = MaterialTheme.typography.bodyLarge
                             )
-                        }
-
-                        // Last sync footer
-                        uiState.lastSyncTime?.let { time ->
-                            item {
-                                Text(
-                                    text     = stringResource(R.string.home_last_sync, time),
-                                    style    = MaterialTheme.typography.bodySmall,
-                                    color    = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
-                                    modifier = Modifier.padding(top = 8.dp)
-                                )
+                            Button(onClick = onConnectClick) {
+                                Text(stringResource(R.string.home_connect_to_trakt))
                             }
                         }
+                    }
+
+                    else -> {
+                        HomeContent(
+                            state = uiState,
+                            onShowClick = onShowClick,
+                            onToggleWatchingTv = { viewModel.toggleWatchingTv(it) }
+                        )
                     }
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun HomeContent(
+    state: HomeUiState,
+    onShowClick: (Int) -> Unit,
+    onToggleWatchingTv: (Boolean) -> Unit
+) {
+    val orientation = LocalConfiguration.current.orientation
+    val isLandscape = orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    val (continueWatching, allOthers) = remember(state.shows, state.progress) {
+        state.shows.partition { entry ->
+            val traktId = entry.entry.show.ids.trakt
+            val progress = traktId?.let { state.progress[it] }
+            progress is ShowProgress.InProgress || progress is ShowProgress.CaughtUpAiring
         }
+    }
+    var allShowsExpanded by rememberSaveable { mutableStateOf(false) }
+
+    LazyColumn(
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        if (state.canWatch) {
+            item {
+                WatchingTvToggle(
+                    isWatching = state.isWatchingTv,
+                    onToggle = onToggleWatchingTv
+                )
+            }
+        }
+        state.latestScrobbleEvent?.let { event ->
+            item { NowWatchingCard(event = event) }
+        }
+
+        if (continueWatching.isNotEmpty()) {
+            item { SectionHeader(stringResource(R.string.home_continue_watching)) }
+            if (isLandscape) {
+                item {
+                    LazyRow(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        contentPadding = PaddingValues(horizontal = 4.dp)
+                    ) {
+                        items(continueWatching, key = { it.entry.show.ids.trakt ?: it.entry.show.title }) { enriched ->
+                            ShelfCard(enriched, state.progress[enriched.entry.show.ids.trakt], onShowClick)
+                        }
+                    }
+                }
+            } else {
+                items(continueWatching, key = { it.entry.show.ids.trakt ?: it.entry.show.title }) { enriched ->
+                    ShowRowCard(enriched, state.progress[enriched.entry.show.ids.trakt], onShowClick)
+                }
+            }
+        }
+
+        item {
+            CollapsibleAllShowsHeader(
+                count = allOthers.size,
+                expanded = allShowsExpanded,
+                onToggle = { allShowsExpanded = !allShowsExpanded }
+            )
+        }
+
+        if (allShowsExpanded) {
+            if (isLandscape) {
+                item {
+                    LazyRow(
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        contentPadding = PaddingValues(horizontal = 4.dp)
+                    ) {
+                        items(allOthers, key = { it.entry.show.ids.trakt ?: it.entry.show.title }) { enriched ->
+                            ShelfCard(enriched, state.progress[enriched.entry.show.ids.trakt], onShowClick)
+                        }
+                    }
+                }
+            } else {
+                items(allOthers, key = { it.entry.show.ids.trakt ?: it.entry.show.title }) { enriched ->
+                    ShowRowCard(enriched, state.progress[enriched.entry.show.ids.trakt], onShowClick)
+                }
+            }
+        }
+
+        state.lastSyncTime?.let { time ->
+            item {
+                Text(
+                    text     = stringResource(R.string.home_last_sync, time),
+                    style    = MaterialTheme.typography.bodySmall,
+                    color    = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f),
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CollapsibleAllShowsHeader(
+    count: Int,
+    expanded: Boolean,
+    onToggle: () -> Unit
+) {
+    val rotation by animateFloatAsState(if (expanded) 180f else 0f, label = "chevron")
+    val cd = stringResource(if (expanded) R.string.home_section_collapse else R.string.home_section_expand)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onToggle)
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text       = stringResource(R.string.home_all_shows),
+            style      = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color      = MaterialTheme.colorScheme.onBackground,
+            modifier   = Modifier.weight(1f)
+        )
+        Text(
+            text  = pluralStringResource(R.plurals.home_section_all_shows_count, count, count),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+        )
+        Icon(
+            imageVector = Icons.Default.KeyboardArrowDown,
+            contentDescription = cd,
+            modifier = Modifier.rotate(rotation),
+            tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+        )
     }
 }
 
@@ -339,10 +421,7 @@ private fun WatchingTvToggle(
                         MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
                 )
             }
-            Switch(
-                checked = isWatching,
-                onCheckedChange = onToggle
-            )
+            Switch(checked = isWatching, onCheckedChange = onToggle)
         }
     }
 }
@@ -402,19 +481,18 @@ private fun NowWatchingCard(event: ScrobbleDisplayEvent) {
 }
 
 @Composable
-private fun ShowCard(
-    entry: TraktWatchedEntry,
-    posterUrl: String?,
-    onClick: () -> Unit
+private fun ShowRowCard(
+    enriched: EnrichedShowEntry,
+    progress: ShowProgress?,
+    onShowClick: (Int) -> Unit
 ) {
-    val totalEpisodes = entry.seasons.sumOf { it.episodes.size }
-    val lastSeason    = entry.seasons.maxByOrNull { it.number }
-    val lastEpisode   = lastSeason?.episodes?.maxByOrNull { it.number }
+    val entry = enriched.entry
+    val posterUrl = TmdbImageHelper.poster(enriched.posterPath, 300)
 
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick),
+            .clickable { entry.show.ids.trakt?.let(onShowClick) },
         shape    = RoundedCornerShape(12.dp),
         colors   = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant
@@ -453,34 +531,228 @@ private fun ShowCard(
                     fontWeight = FontWeight.SemiBold,
                     color      = MaterialTheme.colorScheme.onSurface
                 )
-                if (lastSeason != null && lastEpisode != null) {
-                    Text(
-                        text  = stringResource(
-                            R.string.home_episode_progress,
-                            lastSeason.number,
-                            lastEpisode.number,
-                            totalEpisodes,
-                            totalEpisodes
-                        ),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
-                    )
-                }
-                entry.show.year?.let { year ->
-                    Text(
-                        text  = year.toString(),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.8f)
-                    )
-                }
+                ProgressLines(progress)
             }
 
-            // Arrow indicator
-            Text(
-                text  = "›",
-                style = MaterialTheme.typography.headlineMedium,
-                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.3f)
+            ProgressBadge(progress)
+        }
+    }
+}
+
+@Composable
+private fun ShelfCard(
+    enriched: EnrichedShowEntry,
+    progress: ShowProgress?,
+    onShowClick: (Int) -> Unit
+) {
+    val entry = enriched.entry
+    val posterUrl = TmdbImageHelper.poster(enriched.posterPath, 500)
+
+    Box(
+        modifier = Modifier
+            .width(180.dp)
+            .aspectRatio(2f / 3f)
+            .clip(RoundedCornerShape(12.dp))
+            .clickable { entry.show.ids.trakt?.let(onShowClick) }
+    ) {
+        if (posterUrl != null) {
+            AsyncImage(
+                model = posterUrl,
+                contentDescription = entry.show.title,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize()
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.outline)
             )
         }
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth()
+                .background(Color.Black.copy(alpha = 0.75f))
+                .padding(10.dp),
+            verticalArrangement = Arrangement.spacedBy(2.dp)
+        ) {
+            Text(
+                text = entry.show.title,
+                style = MaterialTheme.typography.titleSmall,
+                fontWeight = FontWeight.SemiBold,
+                color = Color.White,
+                maxLines = 2
+            )
+            ProgressLines(progress, compact = true)
+        }
+        Box(modifier = Modifier.align(Alignment.TopEnd).padding(6.dp)) {
+            ProgressBadge(progress)
+        }
+    }
+}
+
+@Composable
+private fun ProgressLines(progress: ShowProgress?, compact: Boolean = false) {
+    val context = LocalContext.current
+    val now = System.currentTimeMillis()
+    val textColor = if (compact)
+        Color.White.copy(alpha = 0.85f)
+    else
+        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+    val style = if (compact) MaterialTheme.typography.labelSmall else MaterialTheme.typography.bodySmall
+
+    when (progress) {
+        is ShowProgress.InProgress -> {
+            Text(
+                text = stringResource(
+                    R.string.home_last_watched,
+                    progress.latestWatchedLabel,
+                    relativeTime(context, progress.latestWatched, now)
+                ),
+                style = style, color = textColor, maxLines = 1
+            )
+            Text(
+                text = stringResource(
+                    R.string.home_last_aired_episode,
+                    progress.lastAiredLabel,
+                    relativeDate(context, progress.lastAired, now)
+                ),
+                style = style, color = textColor, maxLines = 1
+            )
+        }
+        is ShowProgress.CaughtUpAiring -> {
+            if (progress.latestWatchedLabel != null && progress.latestWatched != null) {
+                Text(
+                    text = stringResource(
+                        R.string.home_last_watched,
+                        progress.latestWatchedLabel!!,
+                        relativeTime(context, progress.latestWatched!!, now)
+                    ),
+                    style = style, color = textColor, maxLines = 1
+                )
+            }
+            Text(
+                text = stringResource(
+                    R.string.home_next_episode,
+                    progress.nextAiredLabel.substringAfter('S').substringBefore('E').toIntOrNull() ?: 0,
+                    progress.nextAiredLabel.substringAfter('E').toIntOrNull() ?: 0
+                ),
+                style = style, color = textColor, maxLines = 1
+            )
+        }
+        is ShowProgress.CaughtUpEnded -> {
+            progress.latestWatched?.let {
+                Text(
+                    text = stringResource(R.string.home_show_ended_caught_up, relativeTime(context, it, now)),
+                    style = style, color = textColor, maxLines = 1
+                )
+            }
+        }
+        is ShowProgress.NotStarted -> {
+            progress.nextAiredLabel?.let { label ->
+                val s = label.substringAfter('S').substringBefore('E').toIntOrNull() ?: 0
+                val e = label.substringAfter('E').toIntOrNull() ?: 0
+                Text(
+                    text = stringResource(R.string.home_next_episode, s, e),
+                    style = style, color = textColor, maxLines = 1
+                )
+            }
+        }
+        is ShowProgress.Unknown -> Unit
+        null -> Unit
+    }
+}
+
+@Composable
+private fun ProgressBadge(progress: ShowProgress?) {
+    when (progress) {
+        is ShowProgress.InProgress -> {
+            val n = progress.episodesBehind
+            BadgePill(
+                text = pluralStringResource(R.plurals.home_episodes_behind, n, n),
+                container = MaterialTheme.colorScheme.tertiaryContainer,
+                content = MaterialTheme.colorScheme.onTertiaryContainer
+            )
+        }
+        is ShowProgress.CaughtUpAiring -> BadgePill(
+            text = stringResource(R.string.home_caught_up),
+            container = MaterialTheme.colorScheme.primaryContainer,
+            content = MaterialTheme.colorScheme.onPrimaryContainer,
+            leadingIcon = true
+        )
+        is ShowProgress.CaughtUpEnded -> BadgePill(
+            text = stringResource(R.string.home_show_completed),
+            container = MaterialTheme.colorScheme.surfaceVariant,
+            content = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        is ShowProgress.NotStarted -> BadgePill(
+            text = stringResource(R.string.home_not_started),
+            container = MaterialTheme.colorScheme.surface,
+            content = MaterialTheme.colorScheme.primary
+        )
+        is ShowProgress.Unknown, null -> Unit
+    }
+}
+
+@Composable
+private fun BadgePill(
+    text: String,
+    container: Color,
+    content: Color,
+    leadingIcon: Boolean = false
+) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(container)
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        if (leadingIcon) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = null,
+                tint = content,
+                modifier = Modifier.size(14.dp)
+            )
+        }
+        Text(text = text, style = MaterialTheme.typography.labelSmall, color = content)
+    }
+}
+
+/**
+ * Formats a moment in time relative to [now]. Uses [DateUtils.getRelativeTimeSpanString]
+ * when more than a day has passed, otherwise returns a localized "today / yesterday / tomorrow" string.
+ */
+private fun relativeTime(context: android.content.Context, moment: Instant, now: Long): String {
+    val momentMs = moment.toEpochMilli()
+    val delta = momentMs - now
+    val dayMs = 24 * 60 * 60 * 1000L
+    return when {
+        delta in -dayMs..dayMs -> context.getString(R.string.home_time_today)
+        delta in -2 * dayMs..-dayMs -> context.getString(R.string.home_time_yesterday)
+        delta in dayMs..2 * dayMs -> context.getString(R.string.home_time_tomorrow)
+        else -> DateUtils.getRelativeTimeSpanString(
+            momentMs, now, DateUtils.DAY_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE
+        ).toString()
+    }
+}
+
+/**
+ * Same as [relativeTime] but for TMDB `air_date` (day-precision) values interpreted as
+ * local midnight to avoid "in 0 days" when the value is today.
+ */
+private fun relativeDate(context: android.content.Context, moment: Instant, now: Long): String {
+    val today = LocalDate.now(ZoneId.systemDefault())
+    val day = moment.atZone(ZoneId.systemDefault()).toLocalDate()
+    return when {
+        day.isEqual(today) -> context.getString(R.string.home_time_today)
+        day.isEqual(today.minusDays(1)) -> context.getString(R.string.home_time_yesterday)
+        day.isEqual(today.plusDays(1)) -> context.getString(R.string.home_time_tomorrow)
+        else -> DateUtils.getRelativeTimeSpanString(
+            moment.toEpochMilli(), now, DateUtils.DAY_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE
+        ).toString()
     }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
@@ -4,21 +4,21 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.ScrobbleDisplayEvent
-import com.justb81.watchbuddy.core.model.TraktWatchedEntry
-import com.justb81.watchbuddy.core.tmdb.TmdbApiService
-import com.justb81.watchbuddy.core.tmdb.TmdbImageHelper
-import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.core.progress.ShowProgress
+import com.justb81.watchbuddy.core.progress.ShowProgressCalculator
 import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.server.ShowRepository
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import com.justb81.watchbuddy.service.CompanionService
 import com.justb81.watchbuddy.service.CompanionStateManager
-import kotlinx.coroutines.flow.first
 import dagger.hilt.android.lifecycle.HiltViewModel
-import retrofit2.HttpException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -26,8 +26,9 @@ import javax.inject.Inject
 data class HomeUiState(
     val isLoading: Boolean = false,
     val isSyncing: Boolean = false,
-    val shows: List<TraktWatchedEntry> = emptyList(),
-    val posterUrls: Map<Int, String?> = emptyMap(),  // key: TMDB ID
+    val shows: List<EnrichedShowEntry> = emptyList(),
+    /** Progress keyed by Trakt id so the UI can look up per-card state in O(1). */
+    val progress: Map<Int, ShowProgress> = emptyMap(),
     val lastSyncTime: String? = null,
     val error: String? = null,
     val canWatch: Boolean = false,
@@ -38,10 +39,9 @@ data class HomeUiState(
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     application: Application,
-    private val traktApi: TraktApiService,
+    private val showRepository: ShowRepository,
     private val tokenRepository: TokenRepository,
     private val settingsRepository: SettingsRepository,
-    private val tmdbApiService: TmdbApiService,
     private val companionStateManager: CompanionStateManager
 ) : AndroidViewModel(application) {
 
@@ -74,7 +74,12 @@ class HomeViewModel @Inject constructor(
 
     private fun observeCompanionState() {
         viewModelScope.launch {
-            settingsRepository.settings.collect { settings ->
+            val settingsFlow = try {
+                settingsRepository.settings
+            } catch (_: Exception) {
+                flowOf()
+            }
+            settingsFlow.collect { settings ->
                 val wasWatching = _uiState.value.isWatchingTv
                 _uiState.update { it.copy(isWatchingTv = settings.companionEnabled) }
                 if (settings.companionEnabled && !wasWatching) {
@@ -110,45 +115,30 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true, error = null)
             try {
-                val accessToken = tokenRepository.getAccessToken()
+                val token = tokenRepository.getAccessToken()
                     ?: throw IllegalStateException("No access token available")
-                val shows = traktApi.getWatchedShows("Bearer $accessToken")
+                // Touch token to surface keystore exceptions here so catch translates them into UI error.
+                @Suppress("UNUSED_VARIABLE") val _t = token
+                val shows = showRepository.getShows()
+                val progressMap = shows.mapNotNull { enriched ->
+                    enriched.entry.show.ids.trakt?.let { traktId ->
+                        traktId to ShowProgressCalculator.compute(enriched.entry, enriched.tmdb)
+                    }
+                }.toMap()
                 _uiState.value = _uiState.value.copy(
                     isLoading    = false,
                     shows        = shows,
-                    posterUrls   = emptyMap(),
+                    progress     = progressMap,
                     lastSyncTime = getApplication<Application>().getString(R.string.home_just_now)
                 )
-                loadPosters(shows)
             } catch (e: Exception) {
-                val httpCode = (e as? HttpException)?.code()
+                val httpCode = (e as? retrofit2.HttpException)?.code()
                 val errorMsg = if (httpCode == 401 || httpCode == 403) {
                     getApplication<Application>().getString(R.string.home_sync_failed_auth)
                 } else {
                     getApplication<Application>().getString(R.string.home_sync_failed, e.message)
                 }
                 _uiState.value = _uiState.value.copy(isLoading = false, error = errorMsg)
-            }
-        }
-    }
-
-    private fun loadPosters(shows: List<TraktWatchedEntry>) {
-        viewModelScope.launch {
-            val tmdbKey = settingsRepository.getTmdbApiKey().first()
-            if (tmdbKey.isBlank()) return@launch
-            shows.forEach { entry ->
-                val tmdbId = entry.show.ids.tmdb ?: return@forEach
-                launch {
-                    try {
-                        val tmdbShow = tmdbApiService.getShow(tmdbId, tmdbKey)
-                        val posterUrl = TmdbImageHelper.poster(tmdbShow.poster_path, 300)
-                        _uiState.update { state ->
-                            state.copy(posterUrls = state.posterUrls + (tmdbId to posterUrl))
-                        }
-                    } catch (_: Exception) {
-                        // Poster loading failure is silent; show renders without image
-                    }
-                }
             }
         }
     }

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -39,9 +39,19 @@
     <string name="home_connect_to_trakt">Mit Trakt verbinden</string>
     <string name="home_syncing">Synchronisiere mit Trakt…</string>
     <string name="home_last_sync">Zuletzt synchronisiert: %1$s</string>
-    <string name="home_episode_progress">S%1$02dE%2$02d — %3$d/%4$d Folgen gesehen</string>
     <string name="home_next_episode">Nächste: S%1$02dE%2$02d</string>
     <string name="home_just_now">Gerade eben</string>
+    <string name="home_last_watched">Zuletzt gesehen: %1$s, %2$s</string>
+    <string name="home_last_aired_episode">Zuletzt ausgestrahlt: %1$s, %2$s</string>
+    <string name="home_time_today">heute</string>
+    <string name="home_time_tomorrow">morgen</string>
+    <string name="home_time_yesterday">gestern</string>
+    <string name="home_caught_up">Auf dem neuesten Stand</string>
+    <string name="home_show_completed">Abgeschlossen</string>
+    <string name="home_not_started">Noch nicht gestartet</string>
+    <string name="home_show_ended_caught_up">Abgeschlossen %1$s</string>
+    <string name="home_section_expand">Abschnitt ausklappen</string>
+    <string name="home_section_collapse">Abschnitt einklappen</string>
     <string name="home_sync_failed">Synchronisierung fehlgeschlagen: %1$s</string>
     <string name="home_sync_failed_auth">Deine Trakt-Sitzung ist abgelaufen. Bitte authentifiziere dich erneut in den Einstellungen.</string>
     <string name="home_cd_sync">Synchronisieren</string>
@@ -142,4 +152,14 @@
     <string name="diagnostics_banner_share">Teilen</string>
     <string name="diagnostics_banner_dismiss">Verwerfen</string>
     <string name="diagnostics_export">Diagnose exportieren</string>
+
+    <!-- Home plurals -->
+    <plurals name="home_episodes_behind">
+        <item quantity="one">%d Folge hinterher</item>
+        <item quantity="other">%d Folgen hinterher</item>
+    </plurals>
+    <plurals name="home_section_all_shows_count">
+        <item quantity="one">%d Serie</item>
+        <item quantity="other">%d Serien</item>
+    </plurals>
 </resources>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -39,9 +39,19 @@
     <string name="home_connect_to_trakt">Conectar con Trakt</string>
     <string name="home_syncing">Sincronizando con Trakt…</string>
     <string name="home_last_sync">Última sincronización: %1$s</string>
-    <string name="home_episode_progress">S%1$02dE%2$02d — %3$d/%4$d episodios vistos</string>
     <string name="home_next_episode">Siguiente: S%1$02dE%2$02d</string>
     <string name="home_just_now">Ahora mismo</string>
+    <string name="home_last_watched">Último visto: %1$s, %2$s</string>
+    <string name="home_last_aired_episode">Último emitido: %1$s, %2$s</string>
+    <string name="home_time_today">hoy</string>
+    <string name="home_time_tomorrow">mañana</string>
+    <string name="home_time_yesterday">ayer</string>
+    <string name="home_caught_up">Al día</string>
+    <string name="home_show_completed">Terminada</string>
+    <string name="home_not_started">No iniciada</string>
+    <string name="home_show_ended_caught_up">Terminada %1$s</string>
+    <string name="home_section_expand">Expandir sección</string>
+    <string name="home_section_collapse">Contraer sección</string>
     <string name="home_sync_failed">Error de sincronización: %1$s</string>
     <string name="home_sync_failed_auth">Tu sesión de Trakt ha expirado. Por favor, vuelve a autenticarte en los ajustes.</string>
     <string name="home_cd_sync">Sincronizar</string>
@@ -142,4 +152,14 @@
     <string name="diagnostics_banner_share">Compartir</string>
     <string name="diagnostics_banner_dismiss">Descartar</string>
     <string name="diagnostics_export">Exportar diagnóstico</string>
+
+    <!-- Home plurals -->
+    <plurals name="home_episodes_behind">
+        <item quantity="one">%d episodio pendiente</item>
+        <item quantity="other">%d episodios pendientes</item>
+    </plurals>
+    <plurals name="home_section_all_shows_count">
+        <item quantity="one">%d serie</item>
+        <item quantity="other">%d series</item>
+    </plurals>
 </resources>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -39,9 +39,19 @@
     <string name="home_connect_to_trakt">Se connecter à Trakt</string>
     <string name="home_syncing">Synchronisation avec Trakt…</string>
     <string name="home_last_sync">Dernière synchronisation : %1$s</string>
-    <string name="home_episode_progress">S%1$02dE%2$02d — %3$d/%4$d épisodes vus</string>
     <string name="home_next_episode">Suivant : S%1$02dE%2$02d</string>
     <string name="home_just_now">À l\'instant</string>
+    <string name="home_last_watched">Dernier vu : %1$s, %2$s</string>
+    <string name="home_last_aired_episode">Dernier diffusé : %1$s, %2$s</string>
+    <string name="home_time_today">aujourd\'hui</string>
+    <string name="home_time_tomorrow">demain</string>
+    <string name="home_time_yesterday">hier</string>
+    <string name="home_caught_up">À jour</string>
+    <string name="home_show_completed">Terminée</string>
+    <string name="home_not_started">Non commencée</string>
+    <string name="home_show_ended_caught_up">Terminée %1$s</string>
+    <string name="home_section_expand">Développer la section</string>
+    <string name="home_section_collapse">Réduire la section</string>
     <string name="home_sync_failed">Échec de la synchronisation : %1$s</string>
     <string name="home_sync_failed_auth">Votre session Trakt a expiré. Veuillez vous ré-authentifier dans les paramètres.</string>
     <string name="home_cd_sync">Synchroniser</string>
@@ -142,4 +152,14 @@
     <string name="diagnostics_banner_share">Partager</string>
     <string name="diagnostics_banner_dismiss">Ignorer</string>
     <string name="diagnostics_export">Exporter le diagnostic</string>
+
+    <!-- Home plurals -->
+    <plurals name="home_episodes_behind">
+        <item quantity="one">%d épisode de retard</item>
+        <item quantity="other">%d épisodes de retard</item>
+    </plurals>
+    <plurals name="home_section_all_shows_count">
+        <item quantity="one">%d série</item>
+        <item quantity="other">%d séries</item>
+    </plurals>
 </resources>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -39,9 +39,19 @@
     <string name="home_connect_to_trakt">Connect to Trakt</string>
     <string name="home_syncing">Syncing with Trakt…</string>
     <string name="home_last_sync">Last synced: %1$s</string>
-    <string name="home_episode_progress">S%1$02dE%2$02d — %3$d/%4$d episodes watched</string>
     <string name="home_next_episode">Next: S%1$02dE%2$02d</string>
     <string name="home_just_now">Just now</string>
+    <string name="home_last_watched">Last watched: %1$s, %2$s</string>
+    <string name="home_last_aired_episode">Last aired: %1$s, %2$s</string>
+    <string name="home_time_today">today</string>
+    <string name="home_time_tomorrow">tomorrow</string>
+    <string name="home_time_yesterday">yesterday</string>
+    <string name="home_caught_up">Caught up</string>
+    <string name="home_show_completed">Completed</string>
+    <string name="home_not_started">Not started</string>
+    <string name="home_show_ended_caught_up">Completed %1$s</string>
+    <string name="home_section_expand">Expand section</string>
+    <string name="home_section_collapse">Collapse section</string>
     <string name="home_sync_failed">Sync failed: %1$s</string>
     <string name="home_sync_failed_auth">Your Trakt session has expired. Please re-authenticate in Settings.</string>
     <string name="home_cd_sync">Sync</string>
@@ -150,4 +160,14 @@
     <string name="error_generic">An error occurred.</string>
     <string name="retry">Try again</string>
     <string name="ok">OK</string>
+
+    <!-- Home plurals -->
+    <plurals name="home_episodes_behind">
+        <item quantity="one">%d episode behind</item>
+        <item quantity="other">%d episodes behind</item>
+    </plurals>
+    <plurals name="home_section_all_shows_count">
+        <item quantity="one">%d show</item>
+        <item quantity="other">%d shows</item>
+    </plurals>
 </resources>

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.phone.server
 
+import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.LlmBackend
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.model.TmdbEpisode
@@ -70,6 +71,7 @@ class CompanionHttpServerTest {
             TraktWatchedSeason(2, listOf(TraktWatchedEpisode(1)))
         )
     )
+    private val enrichedEntry = EnrichedShowEntry(entry = watchedEntry)
 
     private val ep1 = TmdbEpisode(1, "Pilot", "First episode.", "/s1e1.jpg", 1, 1)
     private val ep2 = TmdbEpisode(2, "Cat's in the Bag", null, null, 1, 2)
@@ -131,7 +133,7 @@ class CompanionHttpServerTest {
         @Test
         fun `returns 200 with shows list when authenticated`() = testApp {
             every { tokenRepository.getAccessToken() } returns "test-token"
-            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { showRepository.getShows() } returns listOf(enrichedEntry)
 
             val response = client.get("/shows")
 
@@ -151,7 +153,7 @@ class CompanionHttpServerTest {
         }
 
         @Test
-        fun `returns 500 when show repository throws — no exception detail leaked`() = testApp {
+        fun `returns 500 when show repository throws - no exception detail leaked`() = testApp {
             every { tokenRepository.getAccessToken() } returns "test-token"
             coEvery { showRepository.getShows() } throws RuntimeException("Trakt API down")
 
@@ -168,7 +170,7 @@ class CompanionHttpServerTest {
             val shows = (1..5).map { i ->
                 TraktWatchedEntry(TraktShow("Show $i", 2020 + i, TraktIds(trakt = i)))
             }
-            coEvery { showRepository.getShows() } returns shows
+            coEvery { showRepository.getShows() } returns shows.map { EnrichedShowEntry(entry = it) }
 
             val response = client.get("/shows?limit=2")
 
@@ -185,7 +187,7 @@ class CompanionHttpServerTest {
             val shows = (1..5).map { i ->
                 TraktWatchedEntry(TraktShow("Show $i", 2020 + i, TraktIds(trakt = i)))
             }
-            coEvery { showRepository.getShows() } returns shows
+            coEvery { showRepository.getShows() } returns shows.map { EnrichedShowEntry(entry = it) }
 
             val response = client.get("/shows?offset=2&limit=2")
 
@@ -204,7 +206,7 @@ class CompanionHttpServerTest {
             val shows = (1..3).map { i ->
                 TraktWatchedEntry(TraktShow("Show $i", 2020 + i, TraktIds(trakt = i)))
             }
-            coEvery { showRepository.getShows() } returns shows
+            coEvery { showRepository.getShows() } returns shows.map { EnrichedShowEntry(entry = it) }
 
             val response = client.get("/shows?offset=10&limit=5")
 
@@ -215,11 +217,11 @@ class CompanionHttpServerTest {
         @Test
         fun `defaults to first 30 shows when no params provided`() = testApp {
             every { tokenRepository.getAccessToken() } returns "test-token"
-            // Create 35 shows — only first 30 should be returned
+            // Create 35 shows - only first 30 should be returned
             val shows = (1..35).map { i ->
                 TraktWatchedEntry(TraktShow("Show $i", 2020, TraktIds(trakt = i)))
             }
-            coEvery { showRepository.getShows() } returns shows
+            coEvery { showRepository.getShows() } returns shows.map { EnrichedShowEntry(entry = it) }
 
             val response = client.get("/shows")
 
@@ -236,7 +238,7 @@ class CompanionHttpServerTest {
             val shows = (1..3).map { i ->
                 TraktWatchedEntry(TraktShow("Show $i", 2020 + i, TraktIds(trakt = i)))
             }
-            coEvery { showRepository.getShows() } returns shows
+            coEvery { showRepository.getShows() } returns shows.map { EnrichedShowEntry(entry = it) }
 
             val response = client.get("/shows?offset=-5&limit=2")
 
@@ -249,7 +251,7 @@ class CompanionHttpServerTest {
         @Test
         fun `ignores invalid non-numeric offset and limit`() = testApp {
             every { tokenRepository.getAccessToken() } returns "test-token"
-            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { showRepository.getShows() } returns listOf(enrichedEntry)
 
             val response = client.get("/shows?offset=abc&limit=xyz")
 
@@ -329,7 +331,7 @@ class CompanionHttpServerTest {
                 show = TraktShow("No TMDB Show", 2020, TraktIds(trakt = 1, tmdb = null)),
                 seasons = listOf(TraktWatchedSeason(1, listOf(TraktWatchedEpisode(1))))
             )
-            coEvery { showRepository.getShows() } returns listOf(noTmdbEntry)
+            coEvery { showRepository.getShows() } returns listOf(EnrichedShowEntry(entry = noTmdbEntry))
 
             val response = client.post("/recap/1") {
                 contentType(ContentType.Application.Json)
@@ -342,7 +344,7 @@ class CompanionHttpServerTest {
         @Test
         fun `returns 200 on successful recap generation`() = testApp {
             every { tokenRepository.getAccessToken() } returns "token"
-            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { showRepository.getShows() } returns listOf(enrichedEntry)
             coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
             stubSuccessfulEpisodes()
             coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } returns "<div>Recap HTML</div>"
@@ -357,9 +359,9 @@ class CompanionHttpServerTest {
         }
 
         @Test
-        fun `uses show from cache — does not call TMDB getShow`() = testApp {
+        fun `uses show from cache - does not call TMDB getShow`() = testApp {
             every { tokenRepository.getAccessToken() } returns "token"
-            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { showRepository.getShows() } returns listOf(enrichedEntry)
             tmdbCache.putShow(100, tmdbShow)
             stubSuccessfulEpisodes()
             coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } returns "<div>ok</div>"
@@ -376,7 +378,7 @@ class CompanionHttpServerTest {
         @Test
         fun `fetches show from TMDB on cache miss and stores it in cache`() = testApp {
             every { tokenRepository.getAccessToken() } returns "token"
-            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { showRepository.getShows() } returns listOf(enrichedEntry)
             coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
             stubSuccessfulEpisodes()
             coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } returns "<div>ok</div>"
@@ -392,9 +394,9 @@ class CompanionHttpServerTest {
         }
 
         @Test
-        fun `uses episode cache on hit — does not call TMDB getEpisode`() = testApp {
+        fun `uses episode cache on hit - does not call TMDB getEpisode`() = testApp {
             every { tokenRepository.getAccessToken() } returns "token"
-            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { showRepository.getShows() } returns listOf(enrichedEntry)
             coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
             // Pre-populate episode cache
             tmdbCache.putEpisode(100, 1, 1, ep1)
@@ -414,7 +416,7 @@ class CompanionHttpServerTest {
         @Test
         fun `fetches episodes from TMDB on cache miss and stores them in cache`() = testApp {
             every { tokenRepository.getAccessToken() } returns "token"
-            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { showRepository.getShows() } returns listOf(enrichedEntry)
             coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
             stubSuccessfulEpisodes()
             coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } returns "<div>ok</div>"
@@ -437,7 +439,7 @@ class CompanionHttpServerTest {
         @Test
         fun `returns 200 when one episode fails but others succeed`() = testApp {
             every { tokenRepository.getAccessToken() } returns "token"
-            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { showRepository.getShows() } returns listOf(enrichedEntry)
             coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
             coEvery { tmdbApiService.getEpisode(100, 1, 1, "api-key", any()) } returns ep1
             coEvery { tmdbApiService.getEpisode(100, 1, 2, "api-key", any()) } throws RuntimeException("Network error")
@@ -455,7 +457,7 @@ class CompanionHttpServerTest {
         @Test
         fun `returns 404 when all episodes fail to load`() = testApp {
             every { tokenRepository.getAccessToken() } returns "token"
-            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { showRepository.getShows() } returns listOf(enrichedEntry)
             coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
             coEvery { tmdbApiService.getEpisode(any(), any(), any(), any(), any()) } throws RuntimeException("All fail")
 
@@ -468,9 +470,9 @@ class CompanionHttpServerTest {
         }
 
         @Test
-        fun `returns 503 when recap generation throws — no exception detail leaked`() = testApp {
+        fun `returns 503 when recap generation throws - no exception detail leaked`() = testApp {
             every { tokenRepository.getAccessToken() } returns "token"
-            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { showRepository.getShows() } returns listOf(enrichedEntry)
             coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
             stubSuccessfulEpisodes()
             coEvery { recapGenerator.generateRecap(any(), any(), any(), any()) } throws RuntimeException("LLM crashed")
@@ -488,7 +490,7 @@ class CompanionHttpServerTest {
         @Test
         fun `uses TMDB key from settings when body key is blank`() = testApp {
             every { tokenRepository.getAccessToken() } returns "token"
-            coEvery { showRepository.getShows() } returns listOf(watchedEntry)
+            coEvery { showRepository.getShows() } returns listOf(enrichedEntry)
             every { settingsRepository.getTmdbApiKey() } returns flowOf("settings-key")
             coEvery { tmdbApiService.getShow(100, "settings-key", any()) } returns tmdbShow
             coEvery { tmdbApiService.getEpisode(100, 1, 1, "settings-key", any()) } returns ep1
@@ -514,7 +516,7 @@ class CompanionHttpServerTest {
                 )
             )
             every { tokenRepository.getAccessToken() } returns "token"
-            coEvery { showRepository.getShows() } returns listOf(manyEpisodeEntry)
+            coEvery { showRepository.getShows() } returns listOf(EnrichedShowEntry(entry = manyEpisodeEntry))
             coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
             // Only stub the last 8 episodes (S1E3..S1E5, S2E1..S2E5)
             coEvery { tmdbApiService.getEpisode(100, 1, 3, "api-key", any()) } returns TmdbEpisode(3, "S1E3", null, null, 1, 3)
@@ -715,7 +717,7 @@ class CompanionHttpServerTest {
         }
 
         @Test
-        fun `scrobble stop returns 503 when Trakt API throws — no exception detail leaked`() = testApp {
+        fun `scrobble stop returns 503 when Trakt API throws - no exception detail leaked`() = testApp {
             coEvery { tokenRefreshManager.getValidAccessToken() } returns "token"
             coEvery { traktApiService.scrobbleStop(any(), any()) } throws RuntimeException("Network error")
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
@@ -1,11 +1,15 @@
 package com.justb81.watchbuddy.phone.server
 
+import com.justb81.watchbuddy.core.model.TmdbShow
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
+import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import io.mockk.*
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -17,16 +21,19 @@ class ShowRepositoryTest {
 
     private val traktApi: TraktApiService = mockk()
     private val tokenRefreshManager: TokenRefreshManager = mockk()
+    private val tmdbApiService: TmdbApiService = mockk()
+    private val settingsRepository: SettingsRepository = mockk()
     private lateinit var repository: ShowRepository
 
     private val testShows = listOf(
-        TraktWatchedEntry(TraktShow("Show 1", 2024, TraktIds())),
-        TraktWatchedEntry(TraktShow("Show 2", 2023, TraktIds()))
+        TraktWatchedEntry(TraktShow("Show 1", 2024, TraktIds(trakt = 1, tmdb = 100))),
+        TraktWatchedEntry(TraktShow("Show 2", 2023, TraktIds(trakt = 2, tmdb = 200)))
     )
 
     @BeforeEach
     fun setUp() {
-        repository = ShowRepository(traktApi, tokenRefreshManager)
+        every { settingsRepository.getTmdbApiKey() } returns flowOf("")
+        repository = ShowRepository(traktApi, tokenRefreshManager, tmdbApiService, settingsRepository)
     }
 
     @Test
@@ -36,7 +43,7 @@ class ShowRepositoryTest {
 
         val result = repository.getShows()
         assertEquals(2, result.size)
-        assertEquals("Show 1", result[0].show.title)
+        assertEquals("Show 1", result[0].entry.show.title)
         coVerify(exactly = 1) { traktApi.getWatchedShows(any()) }
     }
 
@@ -47,7 +54,6 @@ class ShowRepositoryTest {
 
         repository.getShows()
         repository.getShows()
-        // API should only be called once due to caching
         coVerify(exactly = 1) { traktApi.getWatchedShows(any()) }
     }
 
@@ -75,7 +81,6 @@ class ShowRepositoryTest {
         coEvery { traktApi.getWatchedShows(any()) } throws RuntimeException("Network error")
 
         val result = repository.getShows()
-
         assertTrue(result.isEmpty())
     }
 
@@ -84,39 +89,61 @@ class ShowRepositoryTest {
         coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
         coEvery { traktApi.getWatchedShows(any()) } returns testShows
 
-        // Prime the cache with a successful fetch
         repository.getShows()
 
-        // Simulate cache TTL expiry by resetting lastFetch to 0 via reflection
         ShowRepository::class.java.getDeclaredField("lastFetch").apply {
             isAccessible = true
             setLong(repository, 0L)
         }
 
-        // API now throws on the refresh attempt
         coEvery { traktApi.getWatchedShows(any()) } throws RuntimeException("Trakt unavailable")
 
-        // Stale cached data should be returned instead of propagating the exception
         val result = repository.getShows()
 
         assertEquals(2, result.size)
-        // API was retried (two total calls: initial fetch + failed refresh attempt)
         coVerify(exactly = 2) { traktApi.getWatchedShows(any()) }
     }
 
     @Test
     fun `getShows retries API on next call after a failure`() = runTest {
         coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
-        // First call: API throws
         coEvery { traktApi.getWatchedShows(any()) } throws RuntimeException("Network error")
         repository.getShows()
 
-        // Second call: API succeeds
         coEvery { traktApi.getWatchedShows(any()) } returns testShows
         val result = repository.getShows()
 
-        // Both calls should have hit the API because lastFetch was not updated on failure
         coVerify(exactly = 2) { traktApi.getWatchedShows(any()) }
         assertEquals(2, result.size)
+    }
+
+    @Test
+    fun `getShows enriches entries with TMDB poster path when API key is set`() = runTest {
+        every { settingsRepository.getTmdbApiKey() } returns flowOf("api-key")
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+        coEvery { traktApi.getWatchedShows(any()) } returns testShows
+        coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns TmdbShow(100, "Show 1", poster_path = "/one.jpg")
+        coEvery { tmdbApiService.getShow(200, "api-key", any()) } returns TmdbShow(200, "Show 2", poster_path = "/two.jpg")
+
+        val result = repository.getShows()
+
+        assertEquals("/one.jpg", result[0].posterPath)
+        assertEquals("/two.jpg", result[1].posterPath)
+    }
+
+    @Test
+    fun `getShows tolerates per-show TMDB failures`() = runTest {
+        every { settingsRepository.getTmdbApiKey() } returns flowOf("api-key")
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+        coEvery { traktApi.getWatchedShows(any()) } returns testShows
+        coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns TmdbShow(100, "Show 1", poster_path = "/one.jpg")
+        coEvery { tmdbApiService.getShow(200, "api-key", any()) } throws RuntimeException("TMDB down for Show 2")
+
+        val result = repository.getShows()
+
+        assertEquals(2, result.size)
+        assertEquals("/one.jpg", result[0].posterPath)
+        assertNull(result[1].posterPath)
+        assertNull(result[1].tmdb)
     }
 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModelTest.kt
@@ -1,11 +1,11 @@
 package com.justb81.watchbuddy.phone.ui.home
 
 import android.app.Application
-import com.justb81.watchbuddy.core.tmdb.TmdbApiService
-import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.phone.MainDispatcherRule
 import com.justb81.watchbuddy.phone.TestFixtures
 import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.server.ShowRepository
 import com.justb81.watchbuddy.phone.settings.AppSettings
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import com.justb81.watchbuddy.service.CompanionStateManager
@@ -36,10 +36,9 @@ class HomeViewModelTest {
     }
 
     private val application: Application = mockk(relaxed = true)
-    private val traktApi: TraktApiService = mockk(relaxed = true)
+    private val showRepository: ShowRepository = mockk(relaxed = true)
     private val tokenRepository: TokenRepository = mockk(relaxed = true)
     private val settingsRepository: SettingsRepository = mockk(relaxed = true)
-    private val tmdbApiService: TmdbApiService = mockk(relaxed = true)
     private val companionStateManager = CompanionStateManager()
 
     @BeforeEach
@@ -47,16 +46,19 @@ class HomeViewModelTest {
         every { settingsRepository.settings } returns flowOf(AppSettings())
         every { settingsRepository.getTmdbApiKey() } returns flowOf("")
         every { tokenRepository.getAccessToken() } returns null
+        coEvery { showRepository.getShows() } returns emptyList()
     }
 
     private fun createViewModel(): HomeViewModel = HomeViewModel(
         application = application,
-        traktApi = traktApi,
+        showRepository = showRepository,
         tokenRepository = tokenRepository,
         settingsRepository = settingsRepository,
-        tmdbApiService = tmdbApiService,
         companionStateManager = companionStateManager
     )
+
+    private fun enriched(title: String) =
+        EnrichedShowEntry(entry = TestFixtures.traktWatchedEntry(show = TestFixtures.traktShow(title)))
 
     @Nested
     @DisplayName("loadShows")
@@ -76,12 +78,9 @@ class HomeViewModelTest {
 
         @Test
         fun `loads shows successfully when token is available`() = runTest {
-            val shows = listOf(
-                TestFixtures.traktWatchedEntry(show = TestFixtures.traktShow("Breaking Bad")),
-                TestFixtures.traktWatchedEntry(show = TestFixtures.traktShow("The Wire"))
-            )
+            val shows = listOf(enriched("Breaking Bad"), enriched("The Wire"))
             every { tokenRepository.getAccessToken() } returns "valid-token"
-            coEvery { traktApi.getWatchedShows("Bearer valid-token") } returns shows
+            coEvery { showRepository.getShows() } returns shows
 
             val vm = createViewModel()
             advanceUntilIdle()
@@ -94,7 +93,7 @@ class HomeViewModelTest {
         @Test
         fun `sets lastSyncTime after successful load`() = runTest {
             every { tokenRepository.getAccessToken() } returns "valid-token"
-            coEvery { traktApi.getWatchedShows(any()) } returns emptyList()
+            coEvery { showRepository.getShows() } returns emptyList()
 
             val vm = createViewModel()
             advanceUntilIdle()
@@ -103,9 +102,9 @@ class HomeViewModelTest {
         }
 
         @Test
-        fun `sets error and clears loading when API throws`() = runTest {
+        fun `sets error and clears loading when repository throws`() = runTest {
             every { tokenRepository.getAccessToken() } returns "valid-token"
-            coEvery { traktApi.getWatchedShows(any()) } throws RuntimeException("Network error")
+            coEvery { showRepository.getShows() } throws RuntimeException("Network error")
 
             val vm = createViewModel()
             advanceUntilIdle()
@@ -119,7 +118,7 @@ class HomeViewModelTest {
         fun `shows auth error message on HTTP 401`() = runTest {
             every { tokenRepository.getAccessToken() } returns "valid-token"
             val httpEx = HttpException(retrofit2.Response.error<Any>(401, ResponseBody.create(null, "")))
-            coEvery { traktApi.getWatchedShows(any()) } throws httpEx
+            coEvery { showRepository.getShows() } throws httpEx
             every { application.getString(com.justb81.watchbuddy.R.string.home_sync_failed_auth) } returns "Session expired"
 
             val vm = createViewModel()
@@ -133,7 +132,7 @@ class HomeViewModelTest {
         fun `shows auth error message on HTTP 403`() = runTest {
             every { tokenRepository.getAccessToken() } returns "valid-token"
             val httpEx = HttpException(retrofit2.Response.error<Any>(403, ResponseBody.create(null, "")))
-            coEvery { traktApi.getWatchedShows(any()) } throws httpEx
+            coEvery { showRepository.getShows() } throws httpEx
             every { application.getString(com.justb81.watchbuddy.R.string.home_sync_failed_auth) } returns "Session expired"
 
             val vm = createViewModel()
@@ -146,14 +145,14 @@ class HomeViewModelTest {
         @Test
         fun `clears error on successful reload after failure`() = runTest {
             every { tokenRepository.getAccessToken() } returns "valid-token"
-            coEvery { traktApi.getWatchedShows(any()) } throws RuntimeException("fail")
+            coEvery { showRepository.getShows() } throws RuntimeException("fail")
 
             val vm = createViewModel()
             advanceUntilIdle()
             assertNotNull(vm.uiState.value.error)
 
-            val shows = listOf(TestFixtures.traktWatchedEntry())
-            coEvery { traktApi.getWatchedShows(any()) } returns shows
+            val shows = listOf(enriched("Test"))
+            coEvery { showRepository.getShows() } returns shows
 
             vm.loadShows()
             advanceUntilIdle()
@@ -165,7 +164,7 @@ class HomeViewModelTest {
         @Test
         fun `empty show list is a valid success result`() = runTest {
             every { tokenRepository.getAccessToken() } returns "valid-token"
-            coEvery { traktApi.getWatchedShows(any()) } returns emptyList()
+            coEvery { showRepository.getShows() } returns emptyList()
 
             val vm = createViewModel()
             advanceUntilIdle()
@@ -182,19 +181,16 @@ class HomeViewModelTest {
 
         @Test
         fun `sync reloads and reflects updated show list`() = runTest {
-            val initialShows = listOf(TestFixtures.traktWatchedEntry(show = TestFixtures.traktShow("Show A")))
-            val updatedShows = listOf(
-                TestFixtures.traktWatchedEntry(show = TestFixtures.traktShow("Show A")),
-                TestFixtures.traktWatchedEntry(show = TestFixtures.traktShow("Show B"))
-            )
+            val initialShows = listOf(enriched("Show A"))
+            val updatedShows = listOf(enriched("Show A"), enriched("Show B"))
             every { tokenRepository.getAccessToken() } returns "valid-token"
-            coEvery { traktApi.getWatchedShows(any()) } returns initialShows
+            coEvery { showRepository.getShows() } returns initialShows
 
             val vm = createViewModel()
             advanceUntilIdle()
             assertEquals(initialShows, vm.uiState.value.shows)
 
-            coEvery { traktApi.getWatchedShows(any()) } returns updatedShows
+            coEvery { showRepository.getShows() } returns updatedShows
             vm.sync()
             advanceUntilIdle()
 
@@ -204,13 +200,13 @@ class HomeViewModelTest {
         @Test
         fun `sync clears error from previous failed load`() = runTest {
             every { tokenRepository.getAccessToken() } returns "valid-token"
-            coEvery { traktApi.getWatchedShows(any()) } throws RuntimeException("fail")
+            coEvery { showRepository.getShows() } throws RuntimeException("fail")
 
             val vm = createViewModel()
             advanceUntilIdle()
             assertNotNull(vm.uiState.value.error)
 
-            coEvery { traktApi.getWatchedShows(any()) } returns emptyList()
+            coEvery { showRepository.getShows() } returns emptyList()
             vm.sync()
             advanceUntilIdle()
 
@@ -241,7 +237,6 @@ class HomeViewModelTest {
             val vm = createViewModel()
             advanceUntilIdle()
 
-            // loadShows() catches via existing broad catch; checkServiceConnections() catches via new try-catch
             assertFalse(vm.uiState.value.canWatch)
             assertNotNull(vm.uiState.value.error)
         }
@@ -258,8 +253,6 @@ class HomeViewModelTest {
             val vm = createViewModel()
             advanceUntilIdle()
 
-            // Application is a relaxed mock — startForegroundService() is a no-op.
-            // Reaching here without an exception confirms the code path executes safely.
             assertNotNull(vm)
         }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiService.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiService.kt
@@ -1,8 +1,8 @@
 package com.justb81.watchbuddy.tv.discovery
 
+import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktShow
-import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import kotlinx.serialization.Serializable
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -16,7 +16,7 @@ interface PhoneApiService {
     suspend fun getShows(
         @Query("offset") offset: Int = 0,
         @Query("limit") limit: Int = PAGE_SIZE
-    ): List<TraktWatchedEntry>
+    ): List<EnrichedShowEntry>
 
     companion object {
         const val PAGE_SIZE = 30

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -1,17 +1,28 @@
 package com.justb81.watchbuddy.tv.ui.home
 
+import android.text.format.DateUtils
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.GridItemSpan
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
@@ -19,16 +30,20 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.compose.ui.graphics.Color
 import androidx.tv.material3.*
+import coil.compose.AsyncImage
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.logging.CrashReporter
 import com.justb81.watchbuddy.core.logging.DiagnosticShare
+import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.progress.ShowProgress
+import com.justb81.watchbuddy.core.tmdb.TmdbImageHelper
 import com.justb81.watchbuddy.tv.ui.theme.extendedColors
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -49,7 +64,6 @@ fun TvHomeScreen(
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
 
-            // ── Header ────────────────────────────────────────────────────────
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -68,47 +82,33 @@ fun TvHomeScreen(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    // Phone status badge
                     if (uiState.connectedPhones > 0) {
-                        PhoneStatusBadge(
-                            count   = uiState.connectedPhones,
-                            bestName = uiState.bestPhoneName
-                        )
+                        PhoneStatusBadge(count = uiState.connectedPhones, bestName = uiState.bestPhoneName)
                     } else {
                         Text(
-                            text  = stringResource(R.string.tv_no_phone),
+                            text = stringResource(R.string.tv_no_phone),
                             fontSize = 12.sp,
                             color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f)
                         )
                     }
 
-                    // Diagnostics export button — always focusable on TV so we can
-                    // collect logs even when nothing has crashed yet.
                     OutlinedButton(
                         onClick = {
                             DiagnosticShare.launchShare(context)
                             pendingReports = CrashReporter.listReports(context).size
                         },
-                        scale   = ButtonDefaults.scale(scale = 1f)
-                    ) {
-                        Text(stringResource(R.string.diagnostics_export))
-                    }
+                        scale = ButtonDefaults.scale(scale = 1f)
+                    ) { Text(stringResource(R.string.diagnostics_export)) }
 
-                    // Streaming settings button
                     OutlinedButton(
                         onClick = onStreamingSettingsClick,
-                        scale   = ButtonDefaults.scale(scale = 1f)
-                    ) {
-                        Text(stringResource(R.string.tv_streaming_settings_button))
-                    }
+                        scale = ButtonDefaults.scale(scale = 1f)
+                    ) { Text(stringResource(R.string.tv_streaming_settings_button)) }
 
-                    // User select button
                     Button(
                         onClick = onUserSelectClick,
-                        scale   = ButtonDefaults.scale(scale = 1f)
-                    ) {
-                        Text(stringResource(R.string.tv_select_user))
-                    }
+                        scale = ButtonDefaults.scale(scale = 1f)
+                    ) { Text(stringResource(R.string.tv_select_user)) }
                 }
             }
 
@@ -123,7 +123,6 @@ fun TvHomeScreen(
                 )
             }
 
-            // ── Content ───────────────────────────────────────────────────────
             when {
                 uiState.isLoading -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -142,58 +141,106 @@ fun TvHomeScreen(
                 uiState.shows.isEmpty() -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Text(
-                            text      = stringResource(R.string.tv_no_shows),
-                            fontSize  = 18.sp,
-                            color     = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
+                            text = stringResource(R.string.tv_no_shows),
+                            fontSize = 18.sp,
+                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
                         )
                     }
                 }
 
                 else -> {
                     Column(Modifier.fillMaxSize()) {
-                        if (uiState.phoneApiError) {
-                            PhoneUnreachableBanner()
-                        }
-                        val gridState = rememberLazyGridState()
-                        val loadMoreTrigger by remember {
-                            derivedStateOf {
-                                val totalItems = gridState.layoutInfo.totalItemsCount
-                                val lastVisible = gridState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                                totalItems > 0 && lastVisible >= totalItems - 6
-                            }
-                        }
-                        LaunchedEffect(loadMoreTrigger) {
-                            if (loadMoreTrigger) viewModel.loadMoreShows()
-                        }
-                        LazyVerticalGrid(
-                            state                 = gridState,
-                            columns               = GridCells.Adaptive(minSize = 180.dp),
-                            contentPadding        = PaddingValues(horizontal = 48.dp, vertical = 16.dp),
-                            horizontalArrangement = Arrangement.spacedBy(16.dp),
-                            verticalArrangement   = Arrangement.spacedBy(16.dp),
-                            modifier              = Modifier.weight(1f).fillMaxWidth()
-                        ) {
-                            items(uiState.shows, key = { it.show.ids.trakt ?: it.show.title }) { entry ->
-                                ShowCard(
-                                    entry   = entry,
-                                    onClick = { onShowClick(entry) }
-                                )
-                            }
-                            if (uiState.isLoadingMore) {
-                                item(span = { GridItemSpan(maxLineSpan) }) {
-                                    Box(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .padding(vertical = 16.dp),
-                                        contentAlignment = Alignment.Center
-                                    ) {
-                                        CircularProgressIndicator(
-                                            color    = MaterialTheme.colorScheme.primary,
-                                            modifier = Modifier.size(32.dp)
-                                        )
-                                    }
-                                }
-                            }
+                        if (uiState.phoneApiError) PhoneUnreachableBanner()
+                        TvHomeShelves(
+                            state = uiState,
+                            onShowClick = onShowClick,
+                            onLoadMore = { viewModel.loadMoreShows() }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun TvHomeShelves(
+    state: TvHomeUiState,
+    onShowClick: (TraktWatchedEntry) -> Unit,
+    onLoadMore: () -> Unit
+) {
+    val (continueWatching, allOthers) = remember(state.shows, state.progress) {
+        state.shows.partition { entry ->
+            val id = entry.entry.show.ids.trakt
+            val p = id?.let { state.progress[it] }
+            p is ShowProgress.InProgress || p is ShowProgress.CaughtUpAiring
+        }
+    }
+    var allShowsExpanded by rememberSaveable { mutableStateOf(false) }
+
+    LazyColumn(
+        contentPadding = PaddingValues(horizontal = 48.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        if (continueWatching.isNotEmpty()) {
+            item {
+                Text(
+                    text = stringResource(R.string.tv_continue_watching),
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            }
+            item {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    contentPadding = PaddingValues(horizontal = 4.dp)
+                ) {
+                    items(continueWatching, key = { it.entry.show.ids.trakt ?: it.entry.show.title }) { enriched ->
+                        TvShowCard(
+                            enriched = enriched,
+                            progress = enriched.entry.show.ids.trakt?.let { state.progress[it] },
+                            onClick = { onShowClick(enriched.entry) }
+                        )
+                    }
+                }
+            }
+        }
+
+        item {
+            TvAllShowsHeader(
+                count = allOthers.size,
+                expanded = allShowsExpanded,
+                onToggle = { allShowsExpanded = !allShowsExpanded }
+            )
+        }
+
+        if (allShowsExpanded) {
+            item {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                    contentPadding = PaddingValues(horizontal = 4.dp)
+                ) {
+                    items(allOthers, key = { it.entry.show.ids.trakt ?: it.entry.show.title }) { enriched ->
+                        TvShowCard(
+                            enriched = enriched,
+                            progress = enriched.entry.show.ids.trakt?.let { state.progress[it] },
+                            onClick = { onShowClick(enriched.entry) }
+                        )
+                    }
+                }
+            }
+            // Trigger load-more when the All shows section is expanded.
+            if (state.canLoadMore) {
+                item {
+                    LaunchedEffect(allShowsExpanded) { if (allShowsExpanded) onLoadMore() }
+                    if (state.isLoadingMore) {
+                        Box(Modifier.fillMaxWidth().padding(8.dp), contentAlignment = Alignment.Center) {
+                            CircularProgressIndicator(
+                                color = MaterialTheme.colorScheme.primary,
+                                modifier = Modifier.size(32.dp)
+                            )
                         }
                     }
                 }
@@ -204,19 +251,62 @@ fun TvHomeScreen(
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
+private fun TvAllShowsHeader(count: Int, expanded: Boolean, onToggle: () -> Unit) {
+    val rotation by animateFloatAsState(if (expanded) 180f else 0f, label = "chevron")
+    val cd = stringResource(if (expanded) R.string.tv_section_collapse else R.string.tv_section_expand)
+    Surface(
+        onClick = onToggle,
+        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(8.dp)),
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.3f),
+            focusedContainerColor = MaterialTheme.colorScheme.surface
+        ),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.01f),
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics { contentDescription = cd }
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.tv_all_shows),
+                fontSize = 20.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.weight(1f)
+            )
+            Text(
+                text = pluralStringResource(R.plurals.tv_section_all_shows_count, count, count),
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+            )
+            Icon(
+                imageVector = Icons.Default.KeyboardArrowDown,
+                contentDescription = null,
+                modifier = Modifier.rotate(rotation),
+                tint = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f)
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
 private fun NoPhoneConnectedState(onRetry: () -> Unit) {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
-                text     = stringResource(R.string.tv_no_phone),
+                text = stringResource(R.string.tv_no_phone),
                 fontSize = 18.sp,
-                color    = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f),
                 modifier = Modifier.padding(bottom = 24.dp)
             )
-            Button(
-                onClick = onRetry,
-                scale   = ButtonDefaults.scale(scale = 1f)
-            ) {
+            Button(onClick = onRetry, scale = ButtonDefaults.scale(scale = 1f)) {
                 Text(stringResource(R.string.tv_retry))
             }
         }
@@ -229,15 +319,12 @@ private fun PhoneUnreachableState(onRetry: () -> Unit) {
     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             Text(
-                text     = stringResource(R.string.tv_error_phone_unreachable_no_cache),
+                text = stringResource(R.string.tv_error_phone_unreachable_no_cache),
                 fontSize = 18.sp,
-                color    = MaterialTheme.colorScheme.error.copy(alpha = 0.8f),
+                color = MaterialTheme.colorScheme.error.copy(alpha = 0.8f),
                 modifier = Modifier.padding(bottom = 24.dp)
             )
-            Button(
-                onClick = onRetry,
-                scale   = ButtonDefaults.scale(scale = 1f)
-            ) {
+            Button(onClick = onRetry, scale = ButtonDefaults.scale(scale = 1f)) {
                 Text(stringResource(R.string.tv_retry))
             }
         }
@@ -253,18 +340,15 @@ private fun PhoneUnreachableBanner() {
             .padding(horizontal = 48.dp, vertical = 8.dp)
     ) {
         Text(
-            text     = stringResource(R.string.tv_error_phone_unreachable),
+            text = stringResource(R.string.tv_error_phone_unreachable),
             fontSize = 13.sp,
-            color    = MaterialTheme.colorScheme.onErrorContainer
+            color = MaterialTheme.colorScheme.onErrorContainer
         )
     }
 }
 
 /**
- * Builds a content description for a show card.
- *
- * Pure Kotlin — no Compose context required, making it easy to unit-test.
- * Format: "Show Title, S01E05" when episode is known, or just "Show Title" otherwise.
+ * Pure Kotlin content-description builder — unit-testable without Compose context.
  */
 internal fun showCardContentDescription(
     showTitle: String,
@@ -278,38 +362,47 @@ internal fun showCardContentDescription(
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-private fun ShowCard(entry: TraktWatchedEntry, onClick: () -> Unit) {
-    val lastSeason  = entry.seasons.maxByOrNull { it.number }
-    val lastEpisode = lastSeason?.episodes?.maxByOrNull { it.number }
+private fun TvShowCard(
+    enriched: EnrichedShowEntry,
+    progress: ShowProgress?,
+    onClick: () -> Unit
+) {
+    val entry = enriched.entry
+    val posterUrl = TmdbImageHelper.poster(enriched.posterPath, 500)
 
-    val cardDescription = showCardContentDescription(
-        showTitle         = entry.show.title,
-        lastSeasonNumber  = lastSeason?.number,
-        lastEpisodeNumber = lastEpisode?.number
-    )
+    val lastSeason = entry.seasons.maxByOrNull { it.number }
+    val lastEp = lastSeason?.episodes?.maxByOrNull { it.number }
+    val cardDescription = showCardContentDescription(entry.show.title, lastSeason?.number, lastEp?.number)
 
     Card(
-        onClick   = onClick,
-        modifier  = Modifier
+        onClick = onClick,
+        modifier = Modifier
             .width(180.dp)
             .aspectRatio(2f / 3f)
             .semantics { contentDescription = cardDescription },
-        shape     = CardDefaults.shape(RoundedCornerShape(12.dp)),
-        colors    = CardDefaults.colors(
-            containerColor         = MaterialTheme.colorScheme.surface,
-            focusedContainerColor  = MaterialTheme.colorScheme.surfaceVariant,
+        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+        colors = CardDefaults.colors(
+            containerColor = MaterialTheme.colorScheme.surface,
+            focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
         ),
-        scale     = CardDefaults.scale(focusedScale = 1.05f)
+        scale = CardDefaults.scale(focusedScale = 1.05f)
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
-            // Poster placeholder
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .background(MaterialTheme.extendedColors.placeholder)
-            )
+            if (posterUrl != null) {
+                AsyncImage(
+                    model = posterUrl,
+                    contentDescription = null,
+                    contentScale = ContentScale.Crop,
+                    modifier = Modifier.fillMaxSize()
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(MaterialTheme.extendedColors.placeholder)
+                )
+            }
 
-            // Bottom overlay
             Column(
                 modifier = Modifier
                     .align(Alignment.BottomStart)
@@ -319,21 +412,159 @@ private fun ShowCard(entry: TraktWatchedEntry, onClick: () -> Unit) {
                 verticalArrangement = Arrangement.spacedBy(2.dp)
             ) {
                 Text(
-                    text       = entry.show.title,
-                    fontSize   = 13.sp,
+                    text = entry.show.title,
+                    fontSize = 13.sp,
                     fontWeight = FontWeight.SemiBold,
-                    color      = Color.White,
-                    maxLines   = 2
+                    color = Color.White,
+                    maxLines = 2
                 )
-                if (lastSeason != null && lastEpisode != null) {
-                    Text(
-                        text     = "S${lastSeason.number.toString().padStart(2,'0')}E${lastEpisode.number.toString().padStart(2,'0')}",
-                        fontSize = 11.sp,
-                        color    = MaterialTheme.colorScheme.primary
-                    )
-                }
+                TvProgressLines(progress)
+            }
+
+            Box(modifier = Modifier.align(Alignment.TopEnd).padding(6.dp)) {
+                TvProgressBadge(progress)
             }
         }
+    }
+}
+
+@Composable
+private fun TvProgressLines(progress: ShowProgress?) {
+    val context = LocalContext.current
+    val now = System.currentTimeMillis()
+    val color = Color.White.copy(alpha = 0.85f)
+
+    when (progress) {
+        is ShowProgress.InProgress -> {
+            Text(
+                text = stringResource(
+                    R.string.tv_last_watched,
+                    progress.latestWatchedLabel,
+                    relativeTime(context, progress.latestWatched, now)
+                ),
+                fontSize = 11.sp, color = color, maxLines = 1
+            )
+            Text(
+                text = stringResource(
+                    R.string.tv_last_aired_episode,
+                    progress.lastAiredLabel,
+                    relativeDate(context, progress.lastAired, now)
+                ),
+                fontSize = 11.sp, color = color, maxLines = 1
+            )
+        }
+        is ShowProgress.CaughtUpAiring -> {
+            Text(
+                text = stringResource(
+                    R.string.tv_next_aired,
+                    progress.nextAiredLabel,
+                    relativeDate(context, progress.nextAired, now)
+                ),
+                fontSize = 11.sp, color = MaterialTheme.colorScheme.primary, maxLines = 1
+            )
+        }
+        is ShowProgress.CaughtUpEnded -> {
+            progress.latestWatched?.let {
+                Text(
+                    text = relativeTime(context, it, now),
+                    fontSize = 11.sp, color = color, maxLines = 1
+                )
+            }
+        }
+        is ShowProgress.NotStarted -> {
+            progress.nextAired?.let {
+                Text(
+                    text = relativeDate(context, it, now),
+                    fontSize = 11.sp, color = color, maxLines = 1
+                )
+            }
+        }
+        is ShowProgress.Unknown, null -> Unit
+    }
+}
+
+@Composable
+private fun TvProgressBadge(progress: ShowProgress?) {
+    when (progress) {
+        is ShowProgress.InProgress -> {
+            val n = progress.episodesBehind
+            BadgePill(
+                text = pluralStringResource(R.plurals.tv_episodes_behind, n, n),
+                container = MaterialTheme.colorScheme.tertiaryContainer,
+                content = MaterialTheme.colorScheme.onTertiaryContainer
+            )
+        }
+        is ShowProgress.CaughtUpAiring -> BadgePill(
+            text = stringResource(R.string.tv_caught_up),
+            container = MaterialTheme.colorScheme.primaryContainer,
+            content = MaterialTheme.colorScheme.onPrimaryContainer,
+            leadingIcon = true
+        )
+        is ShowProgress.CaughtUpEnded -> BadgePill(
+            text = stringResource(R.string.tv_show_completed),
+            container = MaterialTheme.colorScheme.surfaceVariant,
+            content = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        is ShowProgress.NotStarted -> BadgePill(
+            text = stringResource(R.string.tv_not_started),
+            container = MaterialTheme.colorScheme.surface,
+            content = MaterialTheme.colorScheme.primary
+        )
+        is ShowProgress.Unknown, null -> Unit
+    }
+}
+
+@Composable
+private fun BadgePill(
+    text: String,
+    container: Color,
+    content: Color,
+    leadingIcon: Boolean = false
+) {
+    Row(
+        modifier = Modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(container)
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        if (leadingIcon) {
+            Icon(
+                imageVector = Icons.Default.Check,
+                contentDescription = null,
+                tint = content,
+                modifier = Modifier.size(12.dp)
+            )
+        }
+        Text(text = text, fontSize = 10.sp, color = content)
+    }
+}
+
+private fun relativeTime(context: android.content.Context, moment: Instant, now: Long): String {
+    val momentMs = moment.toEpochMilli()
+    val delta = momentMs - now
+    val dayMs = 24 * 60 * 60 * 1000L
+    return when {
+        delta in -dayMs..dayMs -> context.getString(R.string.tv_time_today)
+        delta in -2 * dayMs..-dayMs -> context.getString(R.string.tv_time_yesterday)
+        delta in dayMs..2 * dayMs -> context.getString(R.string.tv_time_tomorrow)
+        else -> DateUtils.getRelativeTimeSpanString(
+            momentMs, now, DateUtils.DAY_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE
+        ).toString()
+    }
+}
+
+private fun relativeDate(context: android.content.Context, moment: Instant, now: Long): String {
+    val today = LocalDate.now(ZoneId.systemDefault())
+    val day = moment.atZone(ZoneId.systemDefault()).toLocalDate()
+    return when {
+        day.isEqual(today) -> context.getString(R.string.tv_time_today)
+        day.isEqual(today.minusDays(1)) -> context.getString(R.string.tv_time_yesterday)
+        day.isEqual(today.plusDays(1)) -> context.getString(R.string.tv_time_tomorrow)
+        else -> DateUtils.getRelativeTimeSpanString(
+            moment.toEpochMilli(), now, DateUtils.DAY_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE
+        ).toString()
     }
 }
 
@@ -365,16 +596,10 @@ private fun TvDiagnosticsBanner(
                 color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.85f)
             )
         }
-        OutlinedButton(
-            onClick = onDismiss,
-            scale = ButtonDefaults.scale(scale = 1f)
-        ) {
+        OutlinedButton(onClick = onDismiss, scale = ButtonDefaults.scale(scale = 1f)) {
             Text(stringResource(R.string.diagnostics_banner_dismiss))
         }
-        Button(
-            onClick = onShare,
-            scale = ButtonDefaults.scale(scale = 1f)
-        ) {
+        Button(onClick = onShare, scale = ButtonDefaults.scale(scale = 1f)) {
             Text(stringResource(R.string.diagnostics_banner_share))
         }
     }
@@ -395,7 +620,6 @@ private fun PhoneStatusBadge(count: Int, bestName: String?) {
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            // Green dot — purely decorative; the adjacent text already conveys the status
             Box(
                 modifier = Modifier
                     .size(8.dp)
@@ -404,9 +628,9 @@ private fun PhoneStatusBadge(count: Int, bestName: String?) {
                     .clearAndSetSemantics {}
             )
             Text(
-                text     = if (bestName != null) bestName else stringResource(R.string.tv_devices_count, count),
+                text = if (bestName != null) bestName else stringResource(R.string.tv_devices_count, count),
                 fontSize = 12.sp,
-                color    = Color.White.copy(alpha = 0.8f)
+                color = Color.White.copy(alpha = 0.8f)
             )
         }
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -3,7 +3,9 @@ package com.justb81.watchbuddy.tv.ui.home
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
-import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.model.EnrichedShowEntry
+import com.justb81.watchbuddy.core.progress.ShowProgress
+import com.justb81.watchbuddy.core.progress.ShowProgressCalculator
 import com.justb81.watchbuddy.tv.data.TvShowCache
 import com.justb81.watchbuddy.tv.data.UserSessionRepository
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
@@ -17,7 +19,9 @@ import javax.inject.Inject
 data class TvHomeUiState(
     val isLoading: Boolean = true,
     val isLoadingMore: Boolean = false,
-    val shows: List<TraktWatchedEntry> = emptyList(),
+    val shows: List<EnrichedShowEntry> = emptyList(),
+    /** Progress keyed by Trakt id. */
+    val progress: Map<Int, ShowProgress> = emptyMap(),
     val selectedUserIds: Set<String> = emptySet(),
     val connectedPhones: Int = 0,
     val bestPhoneName: String? = null,
@@ -46,7 +50,7 @@ class TvHomeViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(TvHomeUiState())
     val uiState: StateFlow<TvHomeUiState> = _uiState.asStateFlow()
 
-    private var cachedShows: List<TraktWatchedEntry>? = null
+    private var cachedShows: List<EnrichedShowEntry>? = null
     private var cacheTimestamp: Long = 0L
     private var loadedOffset: Int = 0
 
@@ -108,7 +112,6 @@ class TvHomeViewModel @Inject constructor(
             }
         }
 
-        // Determine best phone before entering the try block so it is accessible in the catch.
         val bestPhone = phoneDiscovery.getBestPhone()
         val currentOffset = if (append) loadedOffset else 0
 
@@ -124,13 +127,14 @@ class TvHomeViewModel @Inject constructor(
 
                 cachedShows = allShows
                 cacheTimestamp = System.currentTimeMillis()
-                tvShowCache.updateShows(allShows)
+                tvShowCache.updateShows(allShows.map { it.entry })
 
                 _uiState.update {
                     it.copy(
                         isLoading = false,
                         isLoadingMore = false,
                         shows = allShows,
+                        progress = computeProgress(allShows),
                         canLoadMore = hasMore
                     )
                 }
@@ -142,6 +146,7 @@ class TvHomeViewModel @Inject constructor(
                             isLoading = false,
                             isLoadingMore = false,
                             shows = cached,
+                            progress = computeProgress(cached),
                             noPhoneConnected = true,
                             canLoadMore = false
                         )
@@ -158,8 +163,6 @@ class TvHomeViewModel @Inject constructor(
                 }
             }
         } catch (e: Exception) {
-            // A phone was found (bestPhone != null) but its API call failed — this is different from
-            // "no phone connected". Show phoneApiError so the UI can display the correct message.
             val phoneFound = bestPhone != null
             val cached = getCachedShows()
             if (cached != null) {
@@ -168,6 +171,7 @@ class TvHomeViewModel @Inject constructor(
                         isLoading = false,
                         isLoadingMore = false,
                         shows = cached,
+                        progress = computeProgress(cached),
                         phoneApiError = phoneFound,
                         error = e.message,
                         canLoadMore = false
@@ -188,7 +192,14 @@ class TvHomeViewModel @Inject constructor(
         }
     }
 
-    private fun getCachedShows(): List<TraktWatchedEntry>? {
+    private fun computeProgress(shows: List<EnrichedShowEntry>): Map<Int, ShowProgress> =
+        shows.mapNotNull { enriched ->
+            enriched.entry.show.ids.trakt?.let { id ->
+                id to ShowProgressCalculator.compute(enriched.entry, enriched.tmdb)
+            }
+        }.toMap()
+
+    private fun getCachedShows(): List<EnrichedShowEntry>? {
         val ttl = 5 * 60 * 1000L // 5 minutes
         val cached = cachedShows
         return if (cached != null && System.currentTimeMillis() - cacheTimestamp < ttl) cached else null

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -10,6 +10,25 @@
     <string name="tv_no_phone">Kein Handy verbunden.\nStarte die WatchBuddy-App auf deinem Smartphone.</string>
     <string name="tv_retry">Erneut versuchen</string>
     <string name="tv_devices_count">%1$d Gerät(e)</string>
+    <string name="tv_last_watched">Zuletzt: %1$s, %2$s</string>
+    <string name="tv_last_aired_episode">Ausgestrahlt: %1$s, %2$s</string>
+    <string name="tv_next_aired">Nächste: %1$s, %2$s</string>
+    <string name="tv_time_today">heute</string>
+    <string name="tv_time_tomorrow">morgen</string>
+    <string name="tv_time_yesterday">gestern</string>
+    <string name="tv_caught_up">Aktuell</string>
+    <string name="tv_show_completed">Abgeschlossen</string>
+    <string name="tv_not_started">Nicht gestartet</string>
+    <string name="tv_section_expand">Abschnitt ausklappen</string>
+    <string name="tv_section_collapse">Abschnitt einklappen</string>
+    <plurals name="tv_episodes_behind">
+        <item quantity="one">%d hinterher</item>
+        <item quantity="other">%d hinterher</item>
+    </plurals>
+    <plurals name="tv_section_all_shows_count">
+        <item quantity="one">%d Serie</item>
+        <item quantity="other">%d Serien</item>
+    </plurals>
 
     <!-- User select -->
     <string name="tv_select_user">Wer schaut?</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -10,6 +10,25 @@
     <string name="tv_no_phone">Ningún teléfono conectado.\nInicia la aplicación WatchBuddy en tu smartphone.</string>
     <string name="tv_retry">Reintentar</string>
     <string name="tv_devices_count">%1$d dispositivo(s)</string>
+    <string name="tv_last_watched">Último: %1$s, %2$s</string>
+    <string name="tv_last_aired_episode">Emitido: %1$s, %2$s</string>
+    <string name="tv_next_aired">Siguiente: %1$s, %2$s</string>
+    <string name="tv_time_today">hoy</string>
+    <string name="tv_time_tomorrow">mañana</string>
+    <string name="tv_time_yesterday">ayer</string>
+    <string name="tv_caught_up">Al día</string>
+    <string name="tv_show_completed">Terminada</string>
+    <string name="tv_not_started">No iniciada</string>
+    <string name="tv_section_expand">Expandir sección</string>
+    <string name="tv_section_collapse">Contraer sección</string>
+    <plurals name="tv_episodes_behind">
+        <item quantity="one">%d pendiente</item>
+        <item quantity="other">%d pendientes</item>
+    </plurals>
+    <plurals name="tv_section_all_shows_count">
+        <item quantity="one">%d serie</item>
+        <item quantity="other">%d series</item>
+    </plurals>
 
     <!-- User select -->
     <string name="tv_select_user">¿Quién está viendo?</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -10,6 +10,25 @@
     <string name="tv_no_phone">Aucun téléphone connecté.\nDémarrez l\'application WatchBuddy sur votre smartphone.</string>
     <string name="tv_retry">Réessayer</string>
     <string name="tv_devices_count">%1$d appareil(s)</string>
+    <string name="tv_last_watched">Dernier : %1$s, %2$s</string>
+    <string name="tv_last_aired_episode">Diffusé : %1$s, %2$s</string>
+    <string name="tv_next_aired">Suivant : %1$s, %2$s</string>
+    <string name="tv_time_today">aujourd\'hui</string>
+    <string name="tv_time_tomorrow">demain</string>
+    <string name="tv_time_yesterday">hier</string>
+    <string name="tv_caught_up">À jour</string>
+    <string name="tv_show_completed">Terminé</string>
+    <string name="tv_not_started">Non commencé</string>
+    <string name="tv_section_expand">Développer la section</string>
+    <string name="tv_section_collapse">Réduire la section</string>
+    <plurals name="tv_episodes_behind">
+        <item quantity="one">%d en retard</item>
+        <item quantity="other">%d en retard</item>
+    </plurals>
+    <plurals name="tv_section_all_shows_count">
+        <item quantity="one">%d série</item>
+        <item quantity="other">%d séries</item>
+    </plurals>
 
     <!-- User select -->
     <string name="tv_select_user">Qui regarde ?</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -10,6 +10,25 @@
     <string name="tv_no_phone">No phone connected.\nStart the WatchBuddy app on your smartphone.</string>
     <string name="tv_retry">Retry</string>
     <string name="tv_devices_count">%1$d device(s)</string>
+    <string name="tv_last_watched">Last: %1$s, %2$s</string>
+    <string name="tv_last_aired_episode">Aired: %1$s, %2$s</string>
+    <string name="tv_next_aired">Next: %1$s, %2$s</string>
+    <string name="tv_time_today">today</string>
+    <string name="tv_time_tomorrow">tomorrow</string>
+    <string name="tv_time_yesterday">yesterday</string>
+    <string name="tv_caught_up">Caught up</string>
+    <string name="tv_show_completed">Completed</string>
+    <string name="tv_not_started">Not started</string>
+    <string name="tv_section_expand">Expand section</string>
+    <string name="tv_section_collapse">Collapse section</string>
+    <plurals name="tv_episodes_behind">
+        <item quantity="one">%d behind</item>
+        <item quantity="other">%d behind</item>
+    </plurals>
+    <plurals name="tv_section_all_shows_count">
+        <item quantity="one">%d show</item>
+        <item quantity="other">%d shows</item>
+    </plurals>
 
     <!-- User select -->
     <string name="tv_select_user">Who\'s watching?</string>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.tv.ui.home
 
+import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
@@ -39,10 +40,11 @@ class TvHomeViewModelTest {
     private val phonesFlow = MutableStateFlow<List<PhoneDiscoveryManager.DiscoveredPhone>>(emptyList())
     private val phoneApiService: PhoneApiService = mockk()
 
-    private val testShows = listOf(
+    private val testTraktShows = listOf(
         TraktWatchedEntry(TraktShow("Show 1", 2024, TraktIds())),
         TraktWatchedEntry(TraktShow("Show 2", 2023, TraktIds()))
     )
+    private val testShows = testTraktShows.map { EnrichedShowEntry(entry = it) }
 
     @BeforeEach
     fun setUp() {
@@ -125,7 +127,7 @@ class TvHomeViewModelTest {
 
         val state = viewModel.uiState.value
         assertEquals(2, state.shows.size)
-        assertEquals("Show 1", state.shows[0].show.title)
+        assertEquals("Show 1", state.shows[0].entry.show.title)
         assertFalse(state.isLoading)
         assertFalse(state.phoneApiError)
         assertFalse(state.noPhoneConnected)
@@ -142,7 +144,7 @@ class TvHomeViewModelTest {
         createViewModel()
         advanceUntilIdle()
 
-        verify { tvShowCache.updateShows(testShows) }
+        verify { tvShowCache.updateShows(testTraktShows) }
     }
 
     @Test
@@ -184,7 +186,7 @@ class TvHomeViewModelTest {
 
         private fun makeShows(count: Int, startId: Int = 1) =
             (startId until startId + count).map { i ->
-                TraktWatchedEntry(TraktShow("Show $i", 2020, TraktIds(trakt = i)))
+                EnrichedShowEntry(entry = TraktWatchedEntry(TraktShow("Show $i", 2020, TraktIds(trakt = i))))
             }
 
         private fun setupPhone(): PhoneDiscoveryManager.DiscoveredPhone {
@@ -346,7 +348,7 @@ class TvHomeViewModelTest {
             advanceUntilIdle()
 
             val allShows = page1 + page2
-            verify { tvShowCache.updateShows(allShows) }
+            verify { tvShowCache.updateShows(allShows.map { it.entry }) }
         }
     }
 }

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -56,7 +56,12 @@ data class TmdbShow(
     val overview: String? = null,
     val poster_path: String? = null,
     val backdrop_path: String? = null,
-    val first_air_date: String? = null
+    val first_air_date: String? = null,
+    val status: String? = null,
+    val number_of_episodes: Int? = null,
+    val last_episode_to_air: TmdbEpisodeSummary? = null,
+    val next_episode_to_air: TmdbEpisodeSummary? = null,
+    val seasons: List<TmdbSeasonSummary> = emptyList()
 )
 
 @Serializable
@@ -73,6 +78,40 @@ data class TmdbEpisode(
     val season_number: Int,
     val episode_number: Int,
     val air_date: String? = null
+)
+
+@Serializable
+data class TmdbEpisodeSummary(
+    val season_number: Int,
+    val episode_number: Int,
+    val name: String? = null,
+    val air_date: String? = null
+)
+
+@Serializable
+data class TmdbSeasonSummary(
+    val season_number: Int,
+    val episode_count: Int
+)
+
+/**
+ * Wire-slim subset of TMDB per-show progress information shipped over the companion
+ * HTTP API as part of [EnrichedShowEntry]. Keeps /shows payload small while giving the
+ * TV all it needs to render the same progress visualisation as the phone.
+ */
+@Serializable
+data class TmdbProgressHint(
+    val status: String? = null,
+    val lastAired: TmdbEpisodeSummary? = null,
+    val nextAired: TmdbEpisodeSummary? = null,
+    val seasons: List<TmdbSeasonSummary> = emptyList()
+)
+
+@Serializable
+data class EnrichedShowEntry(
+    val entry: TraktWatchedEntry,
+    val tmdb: TmdbProgressHint? = null,
+    val posterPath: String? = null
 )
 
 // ── Companion / Device Models ─────────────────────────────────────────────────

--- a/core/src/main/java/com/justb81/watchbuddy/core/progress/ShowProgressCalculator.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/progress/ShowProgressCalculator.kt
@@ -1,0 +1,165 @@
+package com.justb81.watchbuddy.core.progress
+
+import com.justb81.watchbuddy.core.model.TmdbProgressHint
+import com.justb81.watchbuddy.core.model.TmdbSeasonSummary
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeParseException
+
+/**
+ * Per-show progress summary used by both the phone HomeScreen and the TV HomeScreen.
+ *
+ * The calculator is pure Kotlin — it lives in `core/` so the TV can reuse it without
+ * pulling in Android-only dependencies, and so it can be unit-tested on the JVM.
+ */
+sealed class ShowProgress {
+
+    /** User has not watched any non-special episode yet. */
+    data class NotStarted(
+        val nextAired: Instant?,
+        val nextAiredLabel: String?
+    ) : ShowProgress()
+
+    /**
+     * User watched at least one episode and at least one newer episode has aired.
+     * [episodesBehind] is clamped to ≥ 0 for cases where Trakt is fresher than the
+     * cached TMDB data.
+     */
+    data class InProgress(
+        val latestWatched: Instant,
+        val latestWatchedLabel: String,
+        val lastAired: Instant,
+        val lastAiredLabel: String,
+        val nextAired: Instant?,
+        val nextAiredLabel: String?,
+        val episodesBehind: Int
+    ) : ShowProgress()
+
+    /** User is up-to-date and a new episode is scheduled. */
+    data class CaughtUpAiring(
+        val latestWatched: Instant?,
+        val latestWatchedLabel: String?,
+        val nextAired: Instant,
+        val nextAiredLabel: String
+    ) : ShowProgress()
+
+    /** User is up-to-date and the show has ended. */
+    data class CaughtUpEnded(
+        val latestWatched: Instant?,
+        val latestWatchedLabel: String?
+    ) : ShowProgress()
+
+    /** No TMDB hint available — we only know what Trakt told us. */
+    data class Unknown(
+        val latestWatched: Instant?,
+        val latestWatchedLabel: String?
+    ) : ShowProgress()
+}
+
+object ShowProgressCalculator {
+
+    private const val STATUS_ENDED = "Ended"
+    private const val STATUS_CANCELED = "Canceled"
+
+    fun compute(
+        entry: TraktWatchedEntry,
+        hint: TmdbProgressHint?,
+        zone: ZoneId = ZoneId.systemDefault()
+    ): ShowProgress {
+        val latest = latestWatched(entry)
+        val latestInstant = latest?.instant
+        val latestLabel = latest?.label
+
+        if (hint == null) {
+            return ShowProgress.Unknown(latestInstant, latestLabel)
+        }
+
+        val nextAiredInstant = parseDate(hint.nextAired?.air_date, zone)
+        val nextAiredLabel = hint.nextAired?.let { formatLabel(it.season_number, it.episode_number) }
+
+        if (latest == null) {
+            return ShowProgress.NotStarted(nextAiredInstant, nextAiredLabel)
+        }
+
+        val ended = hint.status == STATUS_ENDED || hint.status == STATUS_CANCELED
+        val lastAiredSeason = hint.lastAired?.season_number
+        val lastAiredEpisode = hint.lastAired?.episode_number
+        val lastAiredLabel = hint.lastAired?.let { formatLabel(it.season_number, it.episode_number) }
+        val lastAiredInstant = parseDate(hint.lastAired?.air_date, zone)
+
+        val watchedOrdinal = absoluteOrdinal(latest.season, latest.episode, hint.seasons)
+        val airedOrdinal = if (lastAiredSeason != null && lastAiredEpisode != null) {
+            absoluteOrdinal(lastAiredSeason, lastAiredEpisode, hint.seasons)
+        } else 0
+        val behind = (airedOrdinal - watchedOrdinal).coerceAtLeast(0)
+
+        return when {
+            behind > 0 -> ShowProgress.InProgress(
+                latestWatched = latestInstant!!,
+                latestWatchedLabel = latestLabel!!,
+                lastAired = lastAiredInstant ?: latestInstant,
+                lastAiredLabel = lastAiredLabel ?: latestLabel,
+                nextAired = nextAiredInstant,
+                nextAiredLabel = nextAiredLabel,
+                episodesBehind = behind
+            )
+            ended -> ShowProgress.CaughtUpEnded(latestInstant, latestLabel)
+            nextAiredInstant != null && nextAiredLabel != null -> ShowProgress.CaughtUpAiring(
+                latestWatched = latestInstant,
+                latestWatchedLabel = latestLabel,
+                nextAired = nextAiredInstant,
+                nextAiredLabel = nextAiredLabel
+            )
+            else -> ShowProgress.CaughtUpEnded(latestInstant, latestLabel)
+        }
+    }
+
+    private data class WatchedRef(val season: Int, val episode: Int, val instant: Instant) {
+        val label: String get() = formatLabel(season, episode)
+    }
+
+    private fun latestWatched(entry: TraktWatchedEntry): WatchedRef? {
+        var best: WatchedRef? = null
+        for (season in entry.seasons) {
+            if (season.number <= 0) continue
+            for (ep in season.episodes) {
+                val ts = parseInstant(ep.last_watched_at) ?: continue
+                if (best == null || ts.isAfter(best.instant)) {
+                    best = WatchedRef(season.number, ep.number, ts)
+                }
+            }
+        }
+        return best
+    }
+
+    private fun absoluteOrdinal(season: Int, episode: Int, seasons: List<TmdbSeasonSummary>): Int {
+        if (season <= 0) return 0
+        val priorSum = seasons
+            .filter { it.season_number in 1 until season }
+            .sumOf { it.episode_count }
+        return priorSum + episode
+    }
+
+    private fun parseInstant(raw: String?): Instant? {
+        if (raw.isNullOrBlank()) return null
+        return try {
+            Instant.parse(raw)
+        } catch (_: DateTimeParseException) {
+            null
+        }
+    }
+
+    private fun parseDate(raw: String?, zone: ZoneId): Instant? {
+        if (raw.isNullOrBlank()) return null
+        return try {
+            LocalDate.parse(raw).atStartOfDay(zone).toInstant()
+        } catch (_: DateTimeParseException) {
+            null
+        }
+    }
+}
+
+internal fun formatLabel(season: Int, episode: Int): String =
+    "S%02dE%02d".format(season, episode)

--- a/core/src/main/java/com/justb81/watchbuddy/core/tmdb/TmdbApiService.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/tmdb/TmdbApiService.kt
@@ -11,7 +11,13 @@ interface TmdbApiService {
     suspend fun getShow(
         @Path("series_id") id: Int,
         @Query("api_key") apiKey: String,
-        @Query("language") language: String = "en-US"
+        @Query("language") language: String = "en-US",
+        /**
+         * TMDB returns `status`, `last_episode_to_air`, `next_episode_to_air`, and `seasons`
+         * on the base tv-show resource without an explicit `append_to_response` — the parameter
+         * is still accepted here in case callers want to request extra bundles in the future.
+         */
+        @Query("append_to_response") appendToResponse: String? = null
     ): TmdbShow
 
     @GET("tv/{series_id}/season/{season_number}/episode/{episode_number}")

--- a/core/src/test/java/com/justb81/watchbuddy/core/progress/ShowProgressCalculatorTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/progress/ShowProgressCalculatorTest.kt
@@ -1,0 +1,234 @@
+package com.justb81.watchbuddy.core.progress
+
+import com.justb81.watchbuddy.core.model.TmdbEpisodeSummary
+import com.justb81.watchbuddy.core.model.TmdbProgressHint
+import com.justb81.watchbuddy.core.model.TmdbSeasonSummary
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.model.TraktWatchedEpisode
+import com.justb81.watchbuddy.core.model.TraktWatchedSeason
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.ZoneId
+
+@DisplayName("ShowProgressCalculator")
+class ShowProgressCalculatorTest {
+
+    private val utc = ZoneId.of("UTC")
+
+    private fun entry(vararg episodes: Triple<Int, Int, String?>): TraktWatchedEntry {
+        val grouped = episodes.groupBy { it.first }
+        val seasons = grouped.map { (seasonNum, eps) ->
+            TraktWatchedSeason(
+                number = seasonNum,
+                episodes = eps.map { TraktWatchedEpisode(number = it.second, last_watched_at = it.third) }
+            )
+        }
+        return TraktWatchedEntry(
+            show = com.justb81.watchbuddy.core.model.TraktShow(
+                title = "Test Show",
+                year = 2020,
+                ids = com.justb81.watchbuddy.core.model.TraktIds()
+            ),
+            seasons = seasons
+        )
+    }
+
+    private fun hint(
+        status: String? = "Returning Series",
+        lastAired: TmdbEpisodeSummary? = null,
+        nextAired: TmdbEpisodeSummary? = null,
+        seasons: List<TmdbSeasonSummary> = emptyList()
+    ) = TmdbProgressHint(status, lastAired, nextAired, seasons)
+
+    @Nested
+    @DisplayName("no TMDB hint")
+    inner class NoHint {
+        @Test
+        fun `returns Unknown with latestWatched when shows exist`() {
+            val e = entry(Triple(1, 1, "2024-01-01T10:00:00Z"))
+            val result = ShowProgressCalculator.compute(e, null)
+            assertTrue(result is ShowProgress.Unknown)
+            assertEquals(Instant.parse("2024-01-01T10:00:00Z"), (result as ShowProgress.Unknown).latestWatched)
+            assertEquals("S01E01", result.latestWatchedLabel)
+        }
+
+        @Test
+        fun `returns Unknown with null fields when nothing watched`() {
+            val e = entry()
+            val result = ShowProgressCalculator.compute(e, null)
+            assertTrue(result is ShowProgress.Unknown)
+            assertNull((result as ShowProgress.Unknown).latestWatched)
+        }
+    }
+
+    @Nested
+    @DisplayName("NotStarted")
+    inner class NotStartedTest {
+        @Test
+        fun `no watched episodes and hint exists returns NotStarted`() {
+            val e = entry()
+            val h = hint(nextAired = TmdbEpisodeSummary(1, 1, air_date = "2025-06-01"))
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            assertTrue(result is ShowProgress.NotStarted)
+            val ns = result as ShowProgress.NotStarted
+            assertEquals("S01E01", ns.nextAiredLabel)
+            assertEquals(Instant.parse("2025-06-01T00:00:00Z"), ns.nextAired)
+        }
+
+        @Test
+        fun `only season 0 specials watched is still NotStarted`() {
+            val e = entry(Triple(0, 1, "2024-01-01T10:00:00Z"))
+            val h = hint(nextAired = TmdbEpisodeSummary(1, 1, air_date = "2025-06-01"))
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            assertTrue(result is ShowProgress.NotStarted)
+        }
+    }
+
+    @Nested
+    @DisplayName("InProgress")
+    inner class InProgressTest {
+        @Test
+        fun `watched S01E03 with S01E05 aired yields behind=2`() {
+            val e = entry(
+                Triple(1, 1, "2024-01-01T10:00:00Z"),
+                Triple(1, 2, "2024-01-02T10:00:00Z"),
+                Triple(1, 3, "2024-01-03T10:00:00Z")
+            )
+            val h = hint(
+                status = "Returning Series",
+                lastAired = TmdbEpisodeSummary(1, 5, air_date = "2024-02-01"),
+                nextAired = TmdbEpisodeSummary(1, 6, air_date = "2024-02-08"),
+                seasons = listOf(TmdbSeasonSummary(1, 10))
+            )
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            assertTrue(result is ShowProgress.InProgress)
+            val ip = result as ShowProgress.InProgress
+            assertEquals(2, ip.episodesBehind)
+            assertEquals("S01E03", ip.latestWatchedLabel)
+            assertEquals("S01E05", ip.lastAiredLabel)
+            assertEquals("S01E06", ip.nextAiredLabel)
+        }
+
+        @Test
+        fun `multi-season gap math sums prior seasons`() {
+            val e = entry(Triple(1, 10, "2024-01-01T10:00:00Z"))
+            val h = hint(
+                status = "Returning Series",
+                lastAired = TmdbEpisodeSummary(3, 2, air_date = "2024-06-01"),
+                seasons = listOf(
+                    TmdbSeasonSummary(1, 10),
+                    TmdbSeasonSummary(2, 8),
+                    TmdbSeasonSummary(3, 10)
+                )
+            )
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            assertTrue(result is ShowProgress.InProgress)
+            // watched=10 (S1E10), aired=S3E2 => 10+8+2=20 → behind=10
+            assertEquals(10, (result as ShowProgress.InProgress).episodesBehind)
+        }
+
+        @Test
+        fun `picks latest timestamp not highest episode number`() {
+            val e = entry(
+                Triple(1, 5, "2024-01-05T10:00:00Z"),
+                Triple(1, 3, "2024-02-01T10:00:00Z") // re-watch, later timestamp
+            )
+            val h = hint(
+                lastAired = TmdbEpisodeSummary(1, 5, air_date = "2024-01-05"),
+                seasons = listOf(TmdbSeasonSummary(1, 10))
+            )
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            assertTrue(result is ShowProgress.InProgress)
+            assertEquals("S01E03", (result as ShowProgress.InProgress).latestWatchedLabel)
+        }
+
+        @Test
+        fun `season 0 specials are ignored when picking latest`() {
+            val e = entry(
+                Triple(0, 1, "2024-03-01T10:00:00Z"), // later special
+                Triple(1, 2, "2024-01-01T10:00:00Z")
+            )
+            val h = hint(
+                lastAired = TmdbEpisodeSummary(1, 5, air_date = "2024-02-01"),
+                seasons = listOf(TmdbSeasonSummary(1, 10))
+            )
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            assertTrue(result is ShowProgress.InProgress)
+            assertEquals("S01E02", (result as ShowProgress.InProgress).latestWatchedLabel)
+        }
+    }
+
+    @Nested
+    @DisplayName("CaughtUp")
+    inner class CaughtUpTest {
+        @Test
+        fun `ended show all watched returns CaughtUpEnded`() {
+            val e = entry(
+                Triple(1, 1, "2024-01-01T10:00:00Z"),
+                Triple(1, 2, "2024-01-02T10:00:00Z")
+            )
+            val h = hint(
+                status = "Ended",
+                lastAired = TmdbEpisodeSummary(1, 2, air_date = "2023-12-01"),
+                seasons = listOf(TmdbSeasonSummary(1, 2))
+            )
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            assertTrue(result is ShowProgress.CaughtUpEnded)
+            assertEquals("S01E02", (result as ShowProgress.CaughtUpEnded).latestWatchedLabel)
+        }
+
+        @Test
+        fun `airing show all watched with next scheduled returns CaughtUpAiring`() {
+            val e = entry(Triple(1, 5, "2024-02-01T10:00:00Z"))
+            val h = hint(
+                status = "Returning Series",
+                lastAired = TmdbEpisodeSummary(1, 5, air_date = "2024-02-01"),
+                nextAired = TmdbEpisodeSummary(1, 6, air_date = "2024-02-08"),
+                seasons = listOf(TmdbSeasonSummary(1, 10))
+            )
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            assertTrue(result is ShowProgress.CaughtUpAiring)
+            assertEquals("S01E06", (result as ShowProgress.CaughtUpAiring).nextAiredLabel)
+        }
+
+        @Test
+        fun `stale TMDB (watched ahead of lastAired) clamps to zero and stays CaughtUp`() {
+            val e = entry(Triple(1, 8, "2024-02-10T10:00:00Z"))
+            val h = hint(
+                status = "Returning Series",
+                lastAired = TmdbEpisodeSummary(1, 5, air_date = "2024-02-01"),
+                nextAired = TmdbEpisodeSummary(1, 6, air_date = "2024-02-08"),
+                seasons = listOf(TmdbSeasonSummary(1, 10))
+            )
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            // watchedOrdinal=8, airedOrdinal=5 → behind=0 (clamped), next scheduled → CaughtUpAiring
+            assertTrue(result is ShowProgress.CaughtUpAiring)
+        }
+
+        @Test
+        fun `canceled status treated as ended`() {
+            val e = entry(Triple(1, 3, "2024-02-10T10:00:00Z"))
+            val h = hint(
+                status = "Canceled",
+                lastAired = TmdbEpisodeSummary(1, 3, air_date = "2024-02-01"),
+                seasons = listOf(TmdbSeasonSummary(1, 3))
+            )
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            assertTrue(result is ShowProgress.CaughtUpEnded)
+        }
+
+        @Test
+        fun `no lastAired and no nextAired and airing status returns CaughtUpEnded fallback`() {
+            val e = entry(Triple(1, 1, "2024-02-01T10:00:00Z"))
+            val h = hint(status = "Returning Series")
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            // No aired info → behind=0, not ended, no next → fallback CaughtUpEnded
+            assertTrue(result is ShowProgress.CaughtUpEnded)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the phone home list, which previously rendered `S01E05 - N/N` because `ShowCard` passed the total episode count as both watched and total, and had no concept of which TMDB episode aired last or when (closes #239).

Per-show progress is now computed by a shared `ShowProgressCalculator` in `core/` and reused by both the phone and TV apps:

- Sealed `ShowProgress` states: `NotStarted`, `InProgress`, `CaughtUpAiring`, `CaughtUpEnded`, `Unknown`. Season 0 specials are ignored; `episodesBehind` is clamped to ≥ 0 for stale-TMDB cases.
- `TmdbShow` gains `status`, `number_of_episodes`, `last_episode_to_air`, `next_episode_to_air`, `seasons`; a wire-slim `TmdbProgressHint` ships as part of the new `EnrichedShowEntry` over the `/shows` endpoint.
- `ShowRepository` fans out TMDB enrichment in parallel with per-show `runCatching`, so one failing TMDB lookup doesn't break the whole list and every connected TV reuses the phone's cached TMDB calls.

Both home screens split shows into two sections:

- **Continue watching** — always expanded, shows in `InProgress` or `CaughtUpAiring`.
- **All shows** — collapsible and **collapsed by default** on phone (portrait + landscape) and TV. State is held in `rememberSaveable`, so rotation preserves it.

Phone portrait keeps the row cards; phone landscape and TV use horizontal `LazyRow` shelves. TV finally renders actual TMDB posters from `EnrichedShowEntry.posterPath` (it previously only showed the placeholder box). Progress badges communicate `In progress (N behind)`, `Caught up`, `Completed`, and `Not started` states.

New strings and plurals added in EN/DE/FR/ES for both apps; the broken `home_episode_progress` string was removed.

## Test plan

- [x] `./gradlew :core:testDebugUnitTest :app-phone:testDebugUnitTest :app-tv:testDebugUnitTest` — green locally
- [x] `./gradlew :app-phone:assembleDebug :app-tv:assembleDebug` — green locally
- [x] New `ShowProgressCalculatorTest` covering latest-timestamp selection, multi-season gap math, season-0 handling, ended vs. airing caught-up, stale-TMDB clamp, no-hint fallback
- [x] `ShowRepositoryTest` extended with TMDB enrichment + per-show failure tolerance
- [x] `HomeViewModelTest`, `CompanionHttpServerTest`, `TvHomeViewModelTest` updated for the new enriched API contract
- [ ] Manual QA on phone (portrait + landscape, rotation round-trip) with all four progress states
- [ ] Manual QA on TV with ≥ 1 phone connected, D-pad focus + TalkBack on the collapsible header
- [ ] DE and FR translations visible and correct
