### PR TITLE
fix(tv): pin Retrofit service interfaces to stop R8 CCE on app launch

### DIFF
--- a/app-phone/proguard-rules.pro
+++ b/app-phone/proguard-rules.pro
@@ -32,6 +32,21 @@
 -keep,allowobfuscation interface <1>
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
 
+# Explicit non-obfuscated keep rules for every Retrofit service interface in
+# the project.  Under AGP 9 / R8 full mode, the generic
+# `-keep,allowobfuscation interface <1>` rule above permits renaming and
+# horizontal class merging, which breaks the `Proxy.newProxyInstance` →
+# Kotlin-inserted checkcast invariant that `retrofit.create(Foo::class.java)`
+# relies on.  Symptom: ClassCastException thrown from the @Provides method
+# the moment the Hilt graph constructs the Retrofit service (issue #247).
+# The phone has more live call sites into TmdbApiService / TraktApiService
+# than the TV, so R8 has been less aggressive there in practice — but the
+# guarantee is fragile.  Keep the rules aligned across modules.
+# NOTE: Every new Retrofit interface MUST be added here as well.
+-keep interface com.justb81.watchbuddy.core.tmdb.TmdbApiService { *; }
+-keep interface com.justb81.watchbuddy.core.trakt.TraktApiService { *; }
+-keep interface com.justb81.watchbuddy.core.trakt.TokenProxyService { *; }
+
 # ── OkHttp ───────────────────────────────────────────────────────────────────
 -dontwarn okhttp3.internal.platform.**
 -dontwarn org.conscrypt.**

--- a/app-tv/proguard-rules.pro
+++ b/app-tv/proguard-rules.pro
@@ -32,6 +32,20 @@
 -keep,allowobfuscation interface <1>
 -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
 
+# Explicit non-obfuscated keep rules for every Retrofit service interface in
+# the project.  Under AGP 9 / R8 full mode, the generic
+# `-keep,allowobfuscation interface <1>` rule above permits renaming and
+# horizontal class merging, which breaks the `Proxy.newProxyInstance` →
+# Kotlin-inserted checkcast invariant that `retrofit.create(Foo::class.java)`
+# relies on.  Symptom: ClassCastException thrown from the @Provides method
+# the moment the Hilt graph constructs the Retrofit service (issue #247 on
+# 0.14.3, first triggered on TV because app-tv has fewer live call sites
+# into these interfaces than app-phone, so R8 is more aggressive).
+# NOTE: Every new Retrofit interface MUST be added here as well.
+-keep interface com.justb81.watchbuddy.core.tmdb.TmdbApiService { *; }
+-keep interface com.justb81.watchbuddy.core.trakt.TraktApiService { *; }
+-keep interface com.justb81.watchbuddy.core.trakt.TokenProxyService { *; }
+
 # ── OkHttp ───────────────────────────────────────────────────────────────────
 -dontwarn okhttp3.internal.platform.**
 -dontwarn org.conscrypt.**


### PR DESCRIPTION
## Summary

Fixes the TV app crash reported in #247 (0.14.3 Android Vitals stack trace): a `ClassCastException` thrown from `NetworkModule.provideTmdbApiService` the moment the first composition requests `ScrobbleViewModel` via `hiltViewModel()`, killing the app before any screen draws.

## Root cause

Stack from #247:

```
java.lang.ClassCastException
  at com.justb81.watchbuddy.core.network.NetworkModule.provideTmdbApiService (NetworkModule.java:93)
  at com.justb81.watchbuddy.core.network.NetworkModule_ProvideTmdbApiServiceFactory.provideTmdbApiService (:47)
  at DaggerWatchBuddyTvApp_HiltComponents_SingletonC$SingletonCImpl$SwitchingProvider.get (:709)
  ...
  at com.justb81.watchbuddy.tv.ui.navigation.TvNavGraphKt.TvNavGraph (TvNavGraph.kt:126)
```

Line 93 of `core/.../NetworkModule.kt` is `retrofit.create(TmdbApiService::class.java)`. The CCE is the Kotlin-compiler-inserted checkcast after `retrofit.create` — the `Proxy.newProxyInstance` return fails the cast to `TmdbApiService` because R8 (AGP 9 default full mode) renamed or horizontally-merged the interface, breaking Retrofit's proxy invariant.

The existing retrofit proguard rule

```
-if interface * { @retrofit2.http.* <methods>; }
-keep,allowobfuscation interface <1>
```

uses `allowobfuscation`, which under R8 full mode permits both renaming and class merging. That's strong enough for the phone (many live call sites anchor the interface identity) but not for the TV, which has only a single injection site for `TmdbApiService` (`MediaSessionScrobbler`).

## Change

Add explicit non-obfuscated `-keep interface <FQN> { *; }` rules for every Retrofit service in the project, in both `app-tv/proguard-rules.pro` and `app-phone/proguard-rules.pro`. The generic rule is kept as a safety net.

Interfaces pinned:
- `com.justb81.watchbuddy.core.tmdb.TmdbApiService`
- `com.justb81.watchbuddy.core.trakt.TraktApiService`
- `com.justb81.watchbuddy.core.trakt.TokenProxyService`

The in-file comment calls out the invariant and warns that any new Retrofit interface added to the project must also be added to these lists.

## Relationship to prior PRs

- **#240 (0.14.3)** fixed a manifest bug that blocked the activity from launching at all. Once launched, this CCE fires.
- **#242 (0.14.4)** moved `hiltViewModel<ScrobbleViewModel>()` into a child composable (`ScrobbleOverlayHost`), but the `ViewModel` is still instantiated during the first composition of `TvNavGraph`, so the CCE fires at the same point.
- **#245 (0.14.5)** excluded androidx.work from the TV classpath. Orthogonal to this crash.

This PR is the one that actually lets the TV app render its first frame.

## Test plan

- [x] CI `build-android.yml` green (release build + R8 must survive the new keeps).
- [ ] Install the 0.14.6 release APK on Google TV 14 and confirm the TV Home screen renders.
- [ ] Play Console → Android Vitals for 0.14.6: no new stack traces from `NetworkModule.provideTmdbApiService`.

closes #247
refs #238

https://claude.ai/code/session_01NPSmwjzS3oARBvC5WsSnuU