### PR TITLE
fix(tv): remove diagnostic surface and unsafe setContent guard (closes #252)

### DIFF
--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -55,19 +55,6 @@
             </intent-filter>
         </activity>
 
-        <!-- Diagnostic report sharing. Exposes filesDir/diagnostics/ so crash
-             reports can be attached to an ACTION_SEND intent from the Home
-             screen banner. See CrashReporter / DiagnosticShare. -->
-        <provider
-            android:name="androidx.core.content.FileProvider"
-            android:authorities="${applicationId}.diagnostics.fileprovider"
-            android:exported="false"
-            android:grantUriPermissions="true">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/provider_paths" />
-        </provider>
-
         <!-- TV app does not use WorkManager; disable its auto-init so the
              startup path does not build a Room-backed WorkDatabase for
              nothing (which can crash under R8 if any keep rule is off). -->

--- a/app-tv/src/main/java/com/justb81/watchbuddy/WatchBuddyTvApp.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/WatchBuddyTvApp.kt
@@ -1,38 +1,7 @@
 package com.justb81.watchbuddy
 
 import android.app.Application
-import android.content.Context
-import android.os.Build
-import com.justb81.watchbuddy.core.logging.CrashReporter
-import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class WatchBuddyTvApp : Application() {
-
-    override fun attachBaseContext(base: Context) {
-        super.attachBaseContext(base)
-        // Install the crash reporter as early as possible so failures inside
-        // Application.super.onCreate() (e.g. Hilt component build) and the
-        // first Activity's super.onCreate() are captured. Installing only in
-        // Application.onCreate() is too late — the reporter is still null when
-        // the Hilt singleton graph is assembled.
-        runCatching { CrashReporter.install(base) }
-        DiagnosticLog.event("App", "TV attachBaseContext")
-    }
-
-    override fun onCreate() {
-        DiagnosticLog.event("App", "TV onCreate entered")
-        try {
-            super.onCreate()
-            DiagnosticLog.event(
-                "App",
-                "TV onCreate ${BuildConfig.VERSION_NAME} (vc=${BuildConfig.VERSION_CODE}) " +
-                    "device=${Build.MANUFACTURER} ${Build.MODEL} sdk=${Build.VERSION.SDK_INT}"
-            )
-        } catch (t: Throwable) {
-            DiagnosticLog.error("App", "TV onCreate failed", t)
-            throw t
-        }
-    }
-}
+class WatchBuddyTvApp : Application()

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepository.kt
@@ -7,7 +7,6 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
-import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
@@ -31,10 +30,7 @@ class StreamingPreferencesRepository @Inject constructor(
      * Empty list means no preference has been set (show all as fallback).
      */
     val subscribedServiceIds: Flow<List<String>> = context.streamingDataStore.data
-        .catch { e ->
-            DiagnosticLog.error(TAG, "streamingDataStore.data flow errored", e)
-            emit(androidx.datastore.preferences.core.emptyPreferences())
-        }
+        .catch { emit(androidx.datastore.preferences.core.emptyPreferences()) }
         .map { prefs ->
             val ids = prefs[subscribedKey] ?: emptySet()
             val order = prefs[orderKey]?.split(",") ?: emptyList()
@@ -47,18 +43,9 @@ class StreamingPreferencesRepository @Inject constructor(
         }
 
     suspend fun setSubscribedServices(orderedIds: List<String>) {
-        try {
-            context.streamingDataStore.edit { prefs ->
-                prefs[subscribedKey] = orderedIds.toSet()
-                prefs[orderKey] = orderedIds.joinToString(",")
-            }
-        } catch (e: Exception) {
-            DiagnosticLog.error(TAG, "setSubscribedServices failed", e)
-            throw e
+        context.streamingDataStore.edit { prefs ->
+            prefs[subscribedKey] = orderedIds.toSet()
+            prefs[orderKey] = orderedIds.joinToString(",")
         }
-    }
-
-    private companion object {
-        const val TAG = "StreamingPrefsRepo"
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.util.Log
-import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.model.LlmBackend
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -57,8 +56,6 @@ class PhoneDiscoveryManager @Inject constructor(
     // from ever drawing a frame.
     private val nsdManager: NsdManager? = runCatching {
         context.getSystemService(Context.NSD_SERVICE) as? NsdManager
-    }.onFailure {
-        DiagnosticLog.error(TAG, "NSD_SERVICE lookup failed", it)
     }.getOrNull()
     private val heartbeatScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var heartbeatJob: Job? = null
@@ -107,14 +104,10 @@ class PhoneDiscoveryManager @Inject constructor(
     }
 
     fun startDiscovery() {
-        val mgr = nsdManager
-        if (mgr == null) {
-            DiagnosticLog.warn(TAG, "NSD unavailable; discovery disabled")
-            return
-        }
+        val mgr = nsdManager ?: return
         runCatching {
             mgr.discoverServices(SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
-        }.onFailure { DiagnosticLog.error(TAG, "discoverServices failed", it) }
+        }
         startHeartbeat()
     }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/TvMainActivity.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/TvMainActivity.kt
@@ -3,31 +3,6 @@ package com.justb81.watchbuddy.tv.ui
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
-import com.justb81.watchbuddy.R
-import com.justb81.watchbuddy.core.logging.CrashReporter
-import com.justb81.watchbuddy.core.logging.DiagnosticLog
-import com.justb81.watchbuddy.core.logging.DiagnosticShare
 import com.justb81.watchbuddy.tv.ui.navigation.TvNavGraph
 import com.justb81.watchbuddy.tv.ui.theme.WatchBuddyTvTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -35,71 +10,11 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class TvMainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
-        DiagnosticLog.event(TAG, "onCreate entered")
         super.onCreate(savedInstanceState)
-
         setContent {
             WatchBuddyTvTheme {
-                // Catch exceptions thrown during initial composition of the real
-                // nav graph and swap in a fallback that lets the user share the
-                // crash report. Without this, a throw inside TvNavGraph() tears
-                // down the window before anything is drawn — and the only symptom
-                // the user sees is "tap icon, nothing happens" (issue #238).
-                var initError by remember { mutableStateOf<Throwable?>(null) }
-                val err = initError
-                if (err == null) {
-                    runCatching { TvNavGraph() }.onFailure { t ->
-                        DiagnosticLog.error(TAG, "TvNavGraph composition failed", t)
-                        runCatching {
-                            CrashReporter.writeManualSnapshot(
-                                this@TvMainActivity,
-                                reason = "TvNavGraph composition failed: ${t.javaClass.simpleName}: ${t.message}"
-                            )
-                        }
-                        initError = t
-                    }
-                } else {
-                    StartupFailedScreen(error = err)
-                }
+                TvNavGraph()
             }
-        }
-        DiagnosticLog.event(TAG, "onCreate completed")
-    }
-
-    private companion object {
-        const val TAG = "TvMainActivity"
-    }
-}
-
-@Composable
-private fun StartupFailedScreen(error: Throwable) {
-    val context = LocalContext.current
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(Color.Black)
-            .padding(48.dp)
-            .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(16.dp),
-        horizontalAlignment = Alignment.Start
-    ) {
-        Text(
-            text = stringResource(R.string.tv_startup_failed_title),
-            color = Color.White,
-            style = MaterialTheme.typography.headlineMedium
-        )
-        Text(
-            text = "${error.javaClass.name}: ${error.message ?: ""}",
-            color = Color.White,
-            style = MaterialTheme.typography.bodyMedium
-        )
-        Text(
-            text = error.stackTraceToString(),
-            color = Color.White.copy(alpha = 0.7f),
-            style = MaterialTheme.typography.bodySmall
-        )
-        Button(onClick = { DiagnosticShare.launchShare(context) }) {
-            Text(stringResource(R.string.tv_startup_failed_share))
         }
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -34,8 +34,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.tv.material3.*
 import coil.compose.AsyncImage
 import com.justb81.watchbuddy.R
-import com.justb81.watchbuddy.core.logging.CrashReporter
-import com.justb81.watchbuddy.core.logging.DiagnosticShare
 import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.progress.ShowProgress
@@ -54,8 +52,6 @@ fun TvHomeScreen(
     viewModel: TvHomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
-    val context = LocalContext.current
-    var pendingReports by remember { mutableStateOf(CrashReporter.listReports(context).size) }
 
     Box(
         modifier = Modifier
@@ -93,14 +89,6 @@ fun TvHomeScreen(
                     }
 
                     OutlinedButton(
-                        onClick = {
-                            DiagnosticShare.launchShare(context)
-                            pendingReports = CrashReporter.listReports(context).size
-                        },
-                        scale = ButtonDefaults.scale(scale = 1f)
-                    ) { Text(stringResource(R.string.diagnostics_export)) }
-
-                    OutlinedButton(
                         onClick = onStreamingSettingsClick,
                         scale = ButtonDefaults.scale(scale = 1f)
                     ) { Text(stringResource(R.string.tv_streaming_settings_button)) }
@@ -110,17 +98,6 @@ fun TvHomeScreen(
                         scale = ButtonDefaults.scale(scale = 1f)
                     ) { Text(stringResource(R.string.tv_select_user)) }
                 }
-            }
-
-            if (pendingReports > 0) {
-                TvDiagnosticsBanner(
-                    reportCount = pendingReports,
-                    onShare = { DiagnosticShare.launchShare(context) },
-                    onDismiss = {
-                        CrashReporter.clearReports(context)
-                        pendingReports = 0
-                    }
-                )
             }
 
             when {
@@ -565,43 +542,6 @@ private fun relativeDate(context: android.content.Context, moment: Instant, now:
         else -> DateUtils.getRelativeTimeSpanString(
             moment.toEpochMilli(), now, DateUtils.DAY_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE
         ).toString()
-    }
-}
-
-@OptIn(ExperimentalTvMaterial3Api::class)
-@Composable
-private fun TvDiagnosticsBanner(
-    reportCount: Int,
-    onShare: () -> Unit,
-    onDismiss: () -> Unit
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(MaterialTheme.colorScheme.errorContainer)
-            .padding(horizontal = 48.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = stringResource(R.string.diagnostics_banner_title),
-                fontSize = 14.sp,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onErrorContainer
-            )
-            Text(
-                text = stringResource(R.string.diagnostics_banner_message, reportCount),
-                fontSize = 12.sp,
-                color = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.85f)
-            )
-        }
-        OutlinedButton(onClick = onDismiss, scale = ButtonDefaults.scale(scale = 1f)) {
-            Text(stringResource(R.string.diagnostics_banner_dismiss))
-        }
-        Button(onClick = onShare, scale = ButtonDefaults.scale(scale = 1f)) {
-            Text(stringResource(R.string.diagnostics_banner_share))
-        }
     }
 }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -2,7 +2,6 @@ package com.justb81.watchbuddy.tv.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.progress.ShowProgress
 import com.justb81.watchbuddy.core.progress.ShowProgressCalculator
@@ -44,7 +43,6 @@ class TvHomeViewModel @Inject constructor(
 
     companion object {
         val PAGE_SIZE = PhoneApiService.PAGE_SIZE
-        private const val TAG = "TvHomeViewModel"
     }
 
     private val _uiState = MutableStateFlow(TvHomeUiState())
@@ -56,7 +54,6 @@ class TvHomeViewModel @Inject constructor(
 
     init {
         runCatching { phoneDiscovery.startDiscovery() }
-            .onFailure { DiagnosticLog.error(TAG, "startDiscovery failed", it) }
         observePhones()
         observeSelectedUsers()
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsViewModel.kt
@@ -2,7 +2,6 @@ package com.justb81.watchbuddy.tv.ui.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.KNOWN_STREAMING_SERVICES
 import com.justb81.watchbuddy.core.model.StreamingService
 import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
@@ -30,24 +29,18 @@ class StreamingSettingsViewModel @Inject constructor(
 
     /**
      * Safety-net handler so a DataStore-IO failure inside the subscribed-services
-     * flow doesn't force-close the TV Settings screen.  The same pattern that was
-     * retrofitted onto the phone SettingsViewModel in #224 — every exception also
-     * lands in the [DiagnosticLog] so shared reports capture silent failures.
+     * flow doesn't force-close the TV Settings screen. Same pattern as the phone
+     * SettingsViewModel in #224.
      */
-    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        DiagnosticLog.error(TAG, "swallowed coroutine exception", throwable)
-    }
+    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, _ -> }
 
     private fun launchSafe(block: suspend CoroutineScope.() -> Unit): Job =
         viewModelScope.launch(coroutineExceptionHandler, block = block)
 
     init {
-        DiagnosticLog.event(TAG, "init: subscribing to subscribedServiceIds")
         launchSafe {
             repository.subscribedServiceIds
-                .catch { e ->
-                    DiagnosticLog.error(TAG, "subscribedServiceIds flow errored", e)
-                }
+                .catch { }
                 .collect { ids ->
                     _uiState.update {
                         it.copy(subscribedIds = ids.toSet(), orderedIds = ids)
@@ -95,7 +88,4 @@ class StreamingSettingsViewModel @Inject constructor(
         }
     }
 
-    private companion object {
-        const val TAG = "StreamingSettingsVM"
-    }
 }

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -93,12 +93,4 @@
     <string name="cd_service_move_up">%1$s in der Priorität nach oben verschieben</string>
     <string name="cd_service_move_down">%1$s in der Priorität nach unten verschieben</string>
 
-    <!-- Diagnostics -->
-    <string name="diagnostics_banner_title">Diagnoseprotokoll verfügbar</string>
-    <string name="diagnostics_banner_message">Die App hat %1$d Absturzprotokoll(e) erfasst. Teile sie mit dem Entwickler, damit das Problem analysiert werden kann.</string>
-    <string name="diagnostics_banner_share">Teilen</string>
-    <string name="diagnostics_banner_dismiss">Verwerfen</string>
-    <string name="diagnostics_export">Diagnose exportieren</string>
-    <string name="tv_startup_failed_title">WatchBuddy konnte nicht gestartet werden</string>
-    <string name="tv_startup_failed_share">Diagnosebericht teilen</string>
 </resources>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -93,12 +93,4 @@
     <string name="cd_service_move_up">Subir %1$s en la prioridad</string>
     <string name="cd_service_move_down">Bajar %1$s en la prioridad</string>
 
-    <!-- Diagnostics -->
-    <string name="diagnostics_banner_title">Informe de diagnóstico disponible</string>
-    <string name="diagnostics_banner_message">La aplicación ha registrado %1$d informe(s) de error. Compártelos con el mantenedor para que pueda analizar el problema.</string>
-    <string name="diagnostics_banner_share">Compartir</string>
-    <string name="diagnostics_banner_dismiss">Descartar</string>
-    <string name="diagnostics_export">Exportar diagnóstico</string>
-    <string name="tv_startup_failed_title">WatchBuddy no pudo iniciarse</string>
-    <string name="tv_startup_failed_share">Compartir informe de diagnóstico</string>
 </resources>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -93,12 +93,4 @@
     <string name="cd_service_move_up">Monter %1$s dans la priorité</string>
     <string name="cd_service_move_down">Descendre %1$s dans la priorité</string>
 
-    <!-- Diagnostics -->
-    <string name="diagnostics_banner_title">Rapport de diagnostic disponible</string>
-    <string name="diagnostics_banner_message">L\'application a enregistré %1$d rapport(s) de plantage. Partagez-les avec le mainteneur pour qu\'il puisse analyser le problème.</string>
-    <string name="diagnostics_banner_share">Partager</string>
-    <string name="diagnostics_banner_dismiss">Ignorer</string>
-    <string name="diagnostics_export">Exporter le diagnostic</string>
-    <string name="tv_startup_failed_title">WatchBuddy n\'a pas pu démarrer</string>
-    <string name="tv_startup_failed_share">Partager le rapport de diagnostic</string>
 </resources>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -64,15 +64,6 @@
     <string name="tv_error_phone_unreachable">Companion app unreachable. Showing cached data.</string>
     <string name="tv_error_phone_unreachable_no_cache">Companion app unreachable. Make sure WatchBuddy is running on your phone.</string>
 
-    <!-- Diagnostics -->
-    <string name="diagnostics_banner_title">Diagnostic report available</string>
-    <string name="diagnostics_banner_message">The app captured %1$d crash report(s). Share them with the maintainer so the problem can be analysed.</string>
-    <string name="diagnostics_banner_share">Share</string>
-    <string name="diagnostics_banner_dismiss">Dismiss</string>
-    <string name="diagnostics_export">Export diagnostics</string>
-    <string name="tv_startup_failed_title">WatchBuddy could not start</string>
-    <string name="tv_startup_failed_share">Share diagnostic report</string>
-
     <!-- Streaming settings -->
     <string name="tv_streaming_settings_button">Services</string>
     <string name="tv_streaming_settings_title">Streaming Services</string>

--- a/app-tv/src/main/res/xml/provider_paths.xml
+++ b/app-tv/src/main/res/xml/provider_paths.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<paths>
-    <!-- Exposes /files/diagnostics/ so crash reports can be shared via
-         an ACTION_SEND intent. See CrashReporter / DiagnosticShare. -->
-    <files-path name="diagnostics" path="diagnostics/" />
-</paths>


### PR DESCRIPTION
## Summary

Remove the entire diagnostic surface from the TV app — it is unusable on Google TV (no ACTION_SEND target, no keyboard). That also removes the reason the buggy `runCatching { TvNavGraph() }` guard in `TvMainActivity` existed, which is the direct cause of the Compose *Start/end imbalance* crash reported in #252.

### Why the removal also fixes #252

`TvMainActivity` wrapped the root nav graph as `runCatching { TvNavGraph() }.onFailure { … }` to be able to render a `StartupFailedScreen` with a "Share diagnostic report" button. Calling a `@Composable` inside a *non-composable* `runCatching { … }` lambda breaks the Compose compiler's `startRestartGroup` / `endRestartGroup` pairing: when any composable reached from `TvNavGraph()` throws (in 0.14.5 this was the CCE from `NetworkModule.provideTmdbApiService`, addressed in #251), the matching `end*` calls are skipped and `finalizeCompose()` reports the imbalance — exactly the stack trace in #252.

With the diagnostic button gone, the fallback screen is gone, the unsafe guard is gone, and the imbalance vector disappears. `setContent` is now just:

```kotlin
setContent { WatchBuddyTvTheme { TvNavGraph() } }
```

### What changed

- `TvMainActivity`: no guard, no `StartupFailedScreen`.
- `TvHomeScreen`: removed **Export diagnostics** button and the `TvDiagnosticsBanner`.
- `WatchBuddyTvApp`: removed `CrashReporter.install()` and `DiagnosticLog` breadcrumbs.
- `TvHomeViewModel`, `StreamingSettingsViewModel`, `StreamingPreferencesRepository`, `PhoneDiscoveryManager`: dropped `DiagnosticLog.*` calls (errors still surface through UI state / normal exception propagation).
- `AndroidManifest.xml`: removed the diagnostics `FileProvider`.
- `res/xml/provider_paths.xml`: deleted.
- `values/`, `values-de/`, `values-es/`, `values-fr/` `strings.xml`: removed `diagnostics_*` and `tv_startup_failed_*` keys.

Out of scope: the phone app and `core/src/.../logging/*` are **not** touched — the phone continues to use the crash reporter / share button.

## Test plan

- [ ] CI `build-android.yml` green (`:app-tv:assembleDebug` / `:app-tv:assembleRelease` / `:app-phone:assembleDebug`).
- [ ] Install the resulting TV APK on Google TV: Home screen shows no "Export diagnostics" button and no diagnostics banner.
- [ ] Temporarily inject a throw inside `TvHomeViewModel.init` on a release build and confirm the app dies cleanly via the system crash dialog — no Compose start/end imbalance, no "Share diagnostic report" fallback.
- [ ] Phone: "Export diagnostics" + crash banner still work (regression gate for the shared `core/logging/*`).

closes #252

https://claude.ai/code/session_01EocSH9829FxECbwAxC2igm