### PR TITLE
fix: diagnose + harden TV phone discovery (closes #259)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,8 @@ The phone acts as an NSD/mDNS server on port 8765. The TV discovers phone(s) on 
 
 The TV ranks connected phones by LLM quality and uses the best one. Failover chain: best phone → next phone → local cache → TMDB synopsis only.
 
+**NSD TXT record contract:** The phone advertises three attributes — `version` (the phone app's `BuildConfig.VERSION_NAME`, e.g. `0.15.1`, **not** a protocol version), `modelQuality` (integer 0–150), and `llmBackend` (one of the `LlmBackend` enum names). The TV parses `llmBackend` leniently (unknown values fall back to `LlmBackend.NONE`) but treats missing / unparseable `version` or `modelQuality` as a hard failure. Contract is pinned by `CompanionServiceNsdTest` and `PhoneDiscoveryManagerTest`.
+
 ## Important Patterns
 
 - **Watching TV toggle:** The phone HomeScreen shows an "I am watching TV" toggle, gated by Trakt + TMDB availability. Toggling starts/stops the `CompanionService`. When the user swipes the app from recents, the service auto-stops via `onTaskRemoved()`.

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
@@ -15,6 +15,7 @@ import android.net.nsd.NsdServiceInfo
 import android.os.IBinder
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import com.justb81.watchbuddy.BuildConfig
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
 import com.justb81.watchbuddy.phone.server.CompanionHttpServer
@@ -38,7 +39,6 @@ class CompanionService : Service() {
         private const val NOTIFICATION_ID = 1
         private const val NSD_SERVICE_TYPE = "_watchbuddy._tcp."
         private const val NSD_SERVICE_NAME = "watchbuddy-companion"
-        private const val NSD_TXT_VERSION = "1"
 
         /** How often to check whether the TV is still polling us. */
         private const val PRESENCE_CHECK_INTERVAL_MS = 60_000L
@@ -53,6 +53,21 @@ class CompanionService : Service() {
         fun stop(context: Context) {
             context.stopService(Intent(context, CompanionService::class.java))
         }
+
+        /**
+         * Builds the NSD TXT record attributes for the WatchBuddy companion service.
+         *
+         * `version` carries the phone app's `versionName` (e.g. `0.15.1`), not a
+         * protocol version. The HTTP contract is versioned by endpoint.
+         */
+        fun buildTxtAttributes(
+            versionName: String,
+            llmConfig: LlmOrchestrator.LlmConfig
+        ): Map<String, String> = mapOf(
+            "version" to versionName,
+            "modelQuality" to llmConfig.qualityScore.toString(),
+            "llmBackend" to llmConfig.backend.name
+        )
     }
 
     @Inject lateinit var companionHttpServer: CompanionHttpServer
@@ -183,18 +198,17 @@ class CompanionService : Service() {
         if (nsdRegistrationListener != null) return
 
         val llmConfig = llmOrchestrator.selectConfig()
+        val txtAttributes = buildTxtAttributes(BuildConfig.VERSION_NAME, llmConfig)
         val serviceInfo = NsdServiceInfo().apply {
             serviceName = NSD_SERVICE_NAME
             serviceType = NSD_SERVICE_TYPE
             port = CompanionHttpServer.PORT
-            setAttribute("version", NSD_TXT_VERSION)
-            setAttribute("modelQuality", llmConfig.qualityScore.toString())
-            setAttribute("llmBackend", llmConfig.backend.name)
+            txtAttributes.forEach { (key, value) -> setAttribute(key, value) }
         }
 
         val listener = object : NsdManager.RegistrationListener {
             override fun onServiceRegistered(info: NsdServiceInfo) {
-                Log.i(TAG, "NSD service registered: ${info.serviceName}")
+                Log.i(TAG, "NSD service registered: ${info.serviceName} TXT=$txtAttributes")
             }
             override fun onRegistrationFailed(info: NsdServiceInfo, errorCode: Int) {
                 Log.e(TAG, "NSD registration failed: error=$errorCode, service=${info.serviceName}")

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/service/CompanionServiceNsdTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/service/CompanionServiceNsdTest.kt
@@ -1,0 +1,95 @@
+package com.justb81.watchbuddy.phone.service
+
+import com.justb81.watchbuddy.BuildConfig
+import com.justb81.watchbuddy.core.model.LlmBackend
+import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
+import com.justb81.watchbuddy.service.CompanionService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Contract tests for the NSD TXT record assembly. This pins the on-the-wire
+ * contract advertised by the phone so regressions (like the hard-coded
+ * `version=1` placeholder seen in #259) are caught by CI.
+ */
+@DisplayName("CompanionService.buildTxtAttributes")
+class CompanionServiceNsdTest {
+
+    private fun config(
+        backend: LlmBackend = LlmBackend.LITERT,
+        qualityScore: Int = 70,
+        modelVariant: LlmOrchestrator.ModelVariant? = LlmOrchestrator.ModelVariant.GEMMA4_E2B
+    ) = LlmOrchestrator.LlmConfig(
+        backend = backend,
+        modelVariant = modelVariant,
+        qualityScore = qualityScore
+    )
+
+    @Test
+    fun `version carries the phone app BuildConfig versionName`() {
+        val attrs = CompanionService.buildTxtAttributes(BuildConfig.VERSION_NAME, config())
+        assertEquals(BuildConfig.VERSION_NAME, attrs["version"])
+    }
+
+    @Test
+    fun `version is never the legacy hardcoded protocol placeholder`() {
+        val attrs = CompanionService.buildTxtAttributes(BuildConfig.VERSION_NAME, config())
+        val version = attrs["version"]
+        // Guard against regressing to the old NSD_TXT_VERSION = "1" placeholder.
+        assertTrue(
+            version != null && version != "1",
+            "version TXT field must carry the real versionName, got '$version'"
+        )
+    }
+
+    @Test
+    fun `version field is verbatim the provided semver string`() {
+        val attrs = CompanionService.buildTxtAttributes("0.15.1", config())
+        assertEquals("0.15.1", attrs["version"])
+    }
+
+    @Test
+    fun `modelQuality equals llmConfig qualityScore as string`() {
+        val attrs = CompanionService.buildTxtAttributes("0.15.1", config(qualityScore = 90))
+        assertEquals("90", attrs["modelQuality"])
+    }
+
+    @Test
+    fun `llmBackend equals llmConfig backend name for LITERT`() {
+        val attrs = CompanionService.buildTxtAttributes(
+            "0.15.1",
+            config(backend = LlmBackend.LITERT)
+        )
+        assertEquals("LITERT", attrs["llmBackend"])
+    }
+
+    @Test
+    fun `llmBackend equals llmConfig backend name for AICORE`() {
+        val attrs = CompanionService.buildTxtAttributes(
+            "0.15.1",
+            config(backend = LlmBackend.AICORE, qualityScore = 150, modelVariant = null)
+        )
+        assertEquals("AICORE", attrs["llmBackend"])
+    }
+
+    @Test
+    fun `llmBackend equals llmConfig backend name for NONE`() {
+        val attrs = CompanionService.buildTxtAttributes(
+            "0.15.1",
+            config(backend = LlmBackend.NONE, qualityScore = 0, modelVariant = null)
+        )
+        assertEquals("NONE", attrs["llmBackend"])
+    }
+
+    @Test
+    fun `no unexpected TXT keys are set`() {
+        val attrs = CompanionService.buildTxtAttributes("0.15.1", config())
+        assertEquals(
+            setOf("version", "modelQuality", "llmBackend"),
+            attrs.keys,
+            "TXT contract must stay limited to version, modelQuality, llmBackend"
+        )
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -110,7 +110,11 @@ class PhoneDiscoveryManager @Inject constructor(
             if (errorCode == NsdManager.FAILURE_ALREADY_ACTIVE && isDiscovering) {
                 heartbeatScope.launch {
                     delay(RESTART_BACKOFF_MS)
-                    Log.i(TAG, "retrying discovery after FAILURE_ALREADY_ACTIVE")
+                    Log.i(
+                        TAG,
+                        "self-heal: retrying discovery after FAILURE_ALREADY_ACTIVE " +
+                            "(stale listener registration in system NSD service)"
+                    )
                     restartDiscoveryInternal()
                 }
             }
@@ -135,9 +139,13 @@ class PhoneDiscoveryManager @Inject constructor(
                 override fun onServiceResolved(serviceInfo: NsdServiceInfo) {
                     @Suppress("DEPRECATION")
                     val host = serviceInfo.host?.hostAddress
+                    val attrs = serviceInfo.attributes
+                        ?.mapValues { (_, v) -> v?.toString(Charsets.UTF_8) ?: "<null>" }
+                        ?: emptyMap()
                     Log.i(
                         TAG,
-                        "service resolved: ${serviceInfo.serviceName} → $host:${serviceInfo.port}"
+                        "service resolved: name=${serviceInfo.serviceName} " +
+                            "host=$host port=${serviceInfo.port} TXT=$attrs"
                     )
                     fetchCapabilityAndAdd(serviceInfo)
                 }
@@ -237,7 +245,10 @@ class PhoneDiscoveryManager @Inject constructor(
     // an app holds a multicast lock, so NsdManager runs but never receives the
     // phone's mDNS announcements. Hold the lock only while discovery is active.
     private fun acquireMulticastLock() {
-        if (multicastLock?.isHeld == true) return
+        if (multicastLock?.isHeld == true) {
+            Log.i(TAG, "multicast lock already held; skipping acquire")
+            return
+        }
         val wifi = wifiManager ?: run {
             Log.w(TAG, "WifiManager unavailable; skipping multicast lock")
             return
@@ -248,15 +259,22 @@ class PhoneDiscoveryManager @Inject constructor(
                 acquire()
             }
             multicastLock = lock
-            Log.i(TAG, "multicast lock acquired")
+            Log.i(TAG, "multicast lock acquired (held=${lock.isHeld})")
         }.onFailure { Log.e(TAG, "multicast lock acquire failed", it) }
     }
 
     private fun releaseMulticastLock() {
-        val lock = multicastLock ?: return
+        val lock = multicastLock ?: run {
+            Log.i(TAG, "multicast lock release skipped: no lock held")
+            return
+        }
         runCatching {
-            if (lock.isHeld) lock.release()
-            Log.i(TAG, "multicast lock released")
+            if (lock.isHeld) {
+                lock.release()
+                Log.i(TAG, "multicast lock released")
+            } else {
+                Log.i(TAG, "multicast lock already released")
+            }
         }.onFailure { Log.w(TAG, "multicast lock release failed", it) }
         multicastLock = null
     }
@@ -284,8 +302,14 @@ class PhoneDiscoveryManager @Inject constructor(
             // NSD service may have silently dropped our listener (seen on some
             // Google TV ROMs). Cycle discovery so we recover without relaunch.
             if (isDiscovering) {
-                Log.i(TAG, "no phones discovered; cycling NSD discovery")
+                Log.i(
+                    TAG,
+                    "heartbeat self-heal: no phones discovered → restarting NSD discovery " +
+                        "(multicastLockHeld=${multicastLock?.isHeld == true})"
+                )
                 restartDiscoveryInternal()
+            } else {
+                Log.d(TAG, "heartbeat tick: no phones and discovery inactive; nothing to do")
             }
             return
         }
@@ -355,22 +379,59 @@ class PhoneDiscoveryManager @Inject constructor(
 
     /**
      * Parses WatchBuddy TXT records from a resolved NsdServiceInfo.
-     * Returns null if any required field is missing or unparseable.
+     *
+     * Returns null if `version` or `modelQuality` is missing / unparseable.
+     * `llmBackend` parsing is lenient: unknown values fall back to
+     * [LlmBackend.NONE] so a new phone-side enum value does not make the
+     * phone silently invisible to older TV builds.
+     *
+     * Every failure path logs a structured reason — this code path is the
+     * primary suspect when a phone is emitting mDNS but the TV does not list
+     * it, and silent returns were observed to mask the root cause in the
+     * field (see #259).
      */
     private fun parseTxtRecord(serviceInfo: NsdServiceInfo): PhoneTxtRecord? {
         return try {
-            val attrs = serviceInfo.attributes
-            val version = attrs["version"]?.toString(Charsets.UTF_8) ?: return null
-            val modelQuality = attrs["modelQuality"]?.toString(Charsets.UTF_8)?.toIntOrNull()
-                ?: return null
-            val llmBackendStr = attrs["llmBackend"]?.toString(Charsets.UTF_8) ?: return null
-            val llmBackend = try {
-                LlmBackend.valueOf(llmBackendStr)
-            } catch (_: IllegalArgumentException) {
+            val attrs = serviceInfo.attributes ?: emptyMap()
+            val decoded = attrs.mapValues { (_, v) ->
+                v?.toString(Charsets.UTF_8) ?: "<null>"
+            }
+            Log.d(TAG, "parseTxtRecord: attrs=$decoded")
+
+            val version = attrs["version"]?.toString(Charsets.UTF_8)
+            if (version == null) {
+                Log.w(TAG, "parseTxtRecord: missing 'version' attribute; attrs=$decoded")
                 return null
             }
+            val modelQualityRaw = attrs["modelQuality"]?.toString(Charsets.UTF_8)
+            if (modelQualityRaw == null) {
+                Log.w(TAG, "parseTxtRecord: missing 'modelQuality' attribute; attrs=$decoded")
+                return null
+            }
+            val modelQuality = modelQualityRaw.toIntOrNull()
+            if (modelQuality == null) {
+                Log.w(
+                    TAG,
+                    "parseTxtRecord: unparseable 'modelQuality'='$modelQualityRaw'; attrs=$decoded"
+                )
+                return null
+            }
+            val llmBackendStr = attrs["llmBackend"]?.toString(Charsets.UTF_8)
+            if (llmBackendStr == null) {
+                Log.w(TAG, "parseTxtRecord: missing 'llmBackend' attribute; attrs=$decoded")
+                return null
+            }
+            val llmBackend = runCatching { LlmBackend.valueOf(llmBackendStr) }
+                .getOrElse {
+                    Log.w(
+                        TAG,
+                        "parseTxtRecord: unknown llmBackend='$llmBackendStr' → falling back to NONE"
+                    )
+                    LlmBackend.NONE
+                }
             PhoneTxtRecord(version = version, modelQuality = modelQuality, llmBackend = llmBackend)
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            Log.w(TAG, "parseTxtRecord: unexpected error", e)
             null
         }
     }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
@@ -276,53 +276,89 @@ class PhoneDiscoveryManagerTest {
                     "llmBackend" to "LITERT".toByteArray()
                 )
             )
-            assertNull(parseTxtRecord(info))
+            assertNull(
+                parseTxtRecord(info),
+                "Missing 'version' must hard-fail parsing; do not mask as NONE fallback"
+            )
         }
 
         @Test
         fun `returns null when modelQuality attribute is missing`() {
             val info = mockServiceInfo(
                 mapOf(
-                    "version" to "1".toByteArray(),
+                    "version" to "0.15.1".toByteArray(),
                     "llmBackend" to "LITERT".toByteArray()
                 )
             )
-            assertNull(parseTxtRecord(info))
+            assertNull(
+                parseTxtRecord(info),
+                "Missing 'modelQuality' must hard-fail parsing; do not fall back to 0"
+            )
         }
 
         @Test
         fun `returns null when llmBackend attribute is missing`() {
             val info = mockServiceInfo(
                 mapOf(
-                    "version" to "1".toByteArray(),
+                    "version" to "0.15.1".toByteArray(),
                     "modelQuality" to "70".toByteArray()
                 )
             )
-            assertNull(parseTxtRecord(info))
+            assertNull(
+                parseTxtRecord(info),
+                "Missing 'llmBackend' (distinct from unknown value) must hard-fail parsing"
+            )
         }
 
         @Test
         fun `returns null when modelQuality is not a valid integer`() {
             val info = mockServiceInfo(
                 mapOf(
-                    "version" to "1".toByteArray(),
+                    "version" to "0.15.1".toByteArray(),
                     "modelQuality" to "not-a-number".toByteArray(),
                     "llmBackend" to "LITERT".toByteArray()
                 )
             )
-            assertNull(parseTxtRecord(info))
+            assertNull(
+                parseTxtRecord(info),
+                "Unparseable 'modelQuality' must hard-fail parsing; do not fall back to 0"
+            )
         }
 
         @Test
-        fun `returns null when llmBackend is an unknown value`() {
+        fun `falls back to NONE when llmBackend is an unknown value`() {
+            // A phone running a newer build may advertise an enum value this TV
+            // build does not know about yet. We must not make the phone silently
+            // invisible — fall back to LlmBackend.NONE instead.
             val info = mockServiceInfo(
                 mapOf(
-                    "version" to "1".toByteArray(),
+                    "version" to "0.15.1".toByteArray(),
                     "modelQuality" to "70".toByteArray(),
                     "llmBackend" to "UNKNOWN_BACKEND".toByteArray()
                 )
             )
-            assertNull(parseTxtRecord(info))
+            val result = parseTxtRecord(info)
+            assertNotNull(result)
+            assertEquals(LlmBackend.NONE, result!!.llmBackend)
+            // Other fields must be preserved so the phone still ranks correctly.
+            assertEquals("0.15.1", result.version)
+            assertEquals(70, result.modelQuality)
+        }
+
+        @Test
+        fun `preserves semver version string verbatim`() {
+            // The phone now advertises its real versionName (e.g. "0.15.1") in
+            // the TXT `version` field, not a hardcoded protocol placeholder.
+            val info = mockServiceInfo(
+                mapOf(
+                    "version" to "0.15.1".toByteArray(),
+                    "modelQuality" to "90".toByteArray(),
+                    "llmBackend" to "LITERT".toByteArray()
+                )
+            )
+            val result = parseTxtRecord(info)
+            assertNotNull(result)
+            assertEquals("0.15.1", result!!.version)
         }
 
         @Test

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,8 +25,20 @@ graph TB
 Service name:  watchbuddy-{username}
 Service type:  _watchbuddy._tcp.
 Port:          8765
-TXT records:   version=1, modelQuality=70, llmBackend=LITERT
+TXT records:   version=0.15.1, modelQuality=70, llmBackend=LITERT
 ```
+
+**TXT record contract:**
+- `version` — the phone app's `versionName` (e.g. `0.15.1`), sourced from
+  `BuildConfig.VERSION_NAME`. This is **not** a protocol version; the HTTP
+  contract is versioned by endpoint. If a protocol version is ever needed, a
+  new TXT key (`proto`) will be added — `version` will not be reused.
+- `modelQuality` — integer 0–150, matches `LlmOrchestrator.LlmConfig.qualityScore`.
+- `llmBackend` — one of the `LlmBackend` enum names. The TV parses this
+  leniently: unknown values fall back to `LlmBackend.NONE` so a new phone-side
+  enum value does not make the phone silently invisible to older TVs. Missing
+  or unparseable `version` / `modelQuality`, however, cause the entry to be
+  rejected outright.
 
 ### HTTP API (Phone exposes, TV calls)
 


### PR DESCRIPTION
Closes #259.

## Summary

Two paired fixes so the TV reliably picks up the phone's NSD announcements and so future regressions in this area leave a diagnostic trail:

- **Phone** (`fix(phone)` commit): advertise the real `BuildConfig.VERSION_NAME` in the `version` TXT field instead of the hardcoded `"1"` placeholder. The TXT assembly is now a pure helper so the contract is pinned by a unit test.
- **TV** (`fix(tv)` commit): `parseTxtRecord()` is now lenient for `llmBackend` (unknown values → `LlmBackend.NONE`) and logs a structured reason for every hard-fail. `onServiceResolved()`, the multicast lock, and both self-heal paths (empty-list heartbeat, `FAILURE_ALREADY_ACTIVE` retry) now log their state transitions, so the discovery pipeline is diagnosable from logcat.

Per the architectural decisions in #259:
- `version` is the app `versionName`, **not** a protocol version. A new TXT key would be added (`proto`) if a protocol version is ever needed.
- Parsing stays lenient, not strict — a new phone-side enum value must not make older TVs silently stop discovering the phone.

## Changes

- `app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt` — remove `NSD_TXT_VERSION`, extract `buildTxtAttributes()`, wire `BuildConfig.VERSION_NAME`, log the TXT map on successful registration.
- `app-phone/src/test/java/com/justb81/watchbuddy/phone/service/CompanionServiceNsdTest.kt` — new contract tests (version = `VERSION_NAME`, modelQuality = `qualityScore`, llmBackend = `backend.name`, no unexpected keys, guard against regressing to `"1"`).
- `app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt` — lenient `llmBackend` via `runCatching.getOrElse`, per-field diagnostic logs in `parseTxtRecord()`, resolved-service log with TXT map, multicast-lock state-transition logs, restart-reason logs on self-heal.
- `app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt` — new lenient-backend and verbatim-semver cases; tightened messages on existing missing-field cases.
- `docs/architecture.md` — refreshed TXT example (`version=0.15.1`) and documented the contract + lenient parsing.
- `CLAUDE.md` — brief TXT contract note under Communication Protocol.

## Test plan

- [ ] `./gradlew :app-phone:testDebugUnitTest :app-tv:testDebugUnitTest` green in CI
- [ ] `./gradlew assembleDebug` green in CI
- [ ] On-device: phone logcat prints the TXT map with `version=0.15.1` (not `1`)
- [ ] On-device: TV logcat shows `onServiceResolved` with resolved host/port and the attribute map; phone appears in `connectedPhones`
- [ ] On-device: flipping the phone to an unknown `llmBackend` locally still lets the TV discover it (with `LlmBackend.NONE`)
- [ ] On-device: Wi-Fi off/on on the TV shows the multicast-lock and discovery-restart logs, and the phone re-appears within one heartbeat

https://claude.ai/code/session_016R2sSVN7oLGLV26d5t8URD