### PR TITLE
fix(phone): show foreground notification while watching TV

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/permissions/NotificationPermissionHandler.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/permissions/NotificationPermissionHandler.kt
@@ -1,0 +1,59 @@
+package com.justb81.watchbuddy.phone.permissions
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.core.content.ContextCompat
+
+/**
+ * Helpers for the runtime `POST_NOTIFICATIONS` prompt introduced in Android 13.
+ * The companion foreground service silently drops its notification if the user
+ * hasn't granted this permission (#261), which is indistinguishable from the
+ * service not running at all — we always ask before the first start.
+ */
+object NotificationPermission {
+
+    fun isGranted(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+
+    /**
+     * Launches `Settings.ACTION_APP_NOTIFICATION_SETTINGS` for the current app.
+     * Used as the fallback when the user has permanently denied the prompt —
+     * only the OS can undo that choice.
+     */
+    fun openAppNotificationSettings(context: Context) {
+        val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+            putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+    }
+}
+
+/**
+ * Remembers a launcher that requests `POST_NOTIFICATIONS` and invokes [onResult]
+ * with the grant outcome. Safe to call on every Android version: if the
+ * permission is not applicable (pre-Android 13 — not reachable with the current
+ * `minSdk = 34`, but kept for symmetry) the launcher still returns `granted`.
+ */
+@Composable
+fun rememberNotificationPermissionRequest(
+    onResult: (granted: Boolean) -> Unit
+): () -> Unit {
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+        onResult = { granted -> onResult(granted) }
+    )
+    return remember(launcher) {
+        { launcher.launch(Manifest.permission.POST_NOTIFICATIONS) }
+    }
+}

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
@@ -42,6 +42,8 @@ import com.justb81.watchbuddy.core.model.ScrobbleAction
 import com.justb81.watchbuddy.core.model.ScrobbleDisplayEvent
 import com.justb81.watchbuddy.core.progress.ShowProgress
 import com.justb81.watchbuddy.core.tmdb.TmdbImageHelper
+import com.justb81.watchbuddy.phone.permissions.NotificationPermission
+import com.justb81.watchbuddy.phone.permissions.rememberNotificationPermissionRequest
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -60,6 +62,50 @@ fun HomeScreen(
     // and this avoids adding Flow plumbing to HomeViewModel just for a debug surface.
     var pendingReports by remember { mutableStateOf(CrashReporter.listReports(context).size) }
     var overflowExpanded by remember { mutableStateOf(false) }
+    var showNotificationRationale by remember { mutableStateOf(false) }
+
+    val requestNotificationPermission = rememberNotificationPermissionRequest { granted ->
+        if (granted) {
+            viewModel.toggleWatchingTv(true)
+        } else {
+            showNotificationRationale = true
+        }
+    }
+
+    val handleToggleWatchingTv: (Boolean) -> Unit = { enabled ->
+        if (!enabled) {
+            viewModel.toggleWatchingTv(false)
+        } else if (NotificationPermission.isGranted(context)) {
+            viewModel.toggleWatchingTv(true)
+        } else {
+            requestNotificationPermission()
+        }
+    }
+
+    if (showNotificationRationale) {
+        AlertDialog(
+            onDismissRequest = { showNotificationRationale = false },
+            title = {
+                Text(stringResource(R.string.companion_notification_permission_rationale_title))
+            },
+            text = {
+                Text(stringResource(R.string.companion_notification_permission_rationale_body))
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showNotificationRationale = false
+                    NotificationPermission.openAppNotificationSettings(context)
+                }) {
+                    Text(stringResource(R.string.companion_notification_permission_open_settings))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showNotificationRationale = false }) {
+                    Text(stringResource(R.string.settings_cancel))
+                }
+            }
+        )
+    }
 
     Scaffold(
         topBar = {
@@ -176,7 +222,7 @@ fun HomeScreen(
                         HomeContent(
                             state = uiState,
                             onShowClick = onShowClick,
-                            onToggleWatchingTv = { viewModel.toggleWatchingTv(it) }
+                            onToggleWatchingTv = handleToggleWatchingTv
                         )
                     }
                 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.service
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
+import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
@@ -20,6 +21,7 @@ import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.phone.llm.LlmOrchestrator
 import com.justb81.watchbuddy.phone.server.CompanionHttpServer
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
+import com.justb81.watchbuddy.phone.ui.MainActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -183,13 +185,31 @@ class CompanionService : Service() {
         }
     }
 
-    private fun buildNotification(): Notification =
-        NotificationCompat.Builder(this, CHANNEL_ID)
+    private fun buildNotification(): Notification {
+        // Tapping the notification brings MainActivity back to the front so the
+        // user can toggle the "I am watching TV" switch off without fishing the
+        // app out of recents.
+        val contentIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP
+            },
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
             .setContentTitle(getString(R.string.companion_notification_title))
             .setContentText(getString(R.string.companion_notification_text))
-            .setSmallIcon(R.mipmap.ic_launcher)
+            // Must be a white-on-transparent vector — adaptive mipmaps are
+            // rejected or rendered blank by some OEM skins (#261).
+            .setSmallIcon(R.drawable.ic_companion_notification)
             .setOngoing(true)
+            .setCategory(NotificationCompat.CATEGORY_SERVICE)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setContentIntent(contentIntent)
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .build()
+    }
 
     // ── NSD ──────────────────────────────────────────────────────────────────
 

--- a/app-phone/src/main/res/drawable/ic_companion_notification.xml
+++ b/app-phone/src/main/res/drawable/ic_companion_notification.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Monochrome white-on-transparent notification icon for the companion foreground
+  service. Android status bar icons MUST be single-color (the system recolors
+  non-transparent pixels to match the theme); an adaptive mipmap like ic_launcher
+  renders as a blank tile or is dropped entirely by some OEM skins.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#FFFFFFFF">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M21,3L3,3c-1.1,0 -2,0.9 -2,2v12c0,1.1 0.9,2 2,2h5v2h8v-2h5c1.1,0 2,-0.9 2,-2L23,5c0,-1.1 -0.9,-2 -2,-2zM21,17L3,17L3,5h18v12z" />
+</vector>

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -132,6 +132,9 @@
     <string name="companion_channel_description">Zeigt an, wenn der Companion-Server für TV-Verbindungen aktiv ist</string>
     <string name="companion_notification_title">WatchBuddy Companion</string>
     <string name="companion_notification_text">Bereit für TV-Verbindung</string>
+    <string name="companion_notification_permission_rationale_title">Benachrichtigungen erlauben</string>
+    <string name="companion_notification_permission_rationale_body">WatchBuddy zeigt während der TV-Verbindung eine dauerhafte Benachrichtigung, damit Android den Dienst nicht im Hintergrund beendet. Aktiviere Benachrichtigungen in den App-Einstellungen, um fortzufahren.</string>
+    <string name="companion_notification_permission_open_settings">Einstellungen öffnen</string>
 
     <!-- Show Detail -->
     <string name="show_detail_seasons">Staffeln</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -132,6 +132,9 @@
     <string name="companion_channel_description">Muestra cuando el servidor compañero está activo para conexiones de TV</string>
     <string name="companion_notification_title">WatchBuddy Companion</string>
     <string name="companion_notification_text">Listo para conexión con TV</string>
+    <string name="companion_notification_permission_rationale_title">Permitir notificaciones</string>
+    <string name="companion_notification_permission_rationale_body">WatchBuddy muestra una notificación persistente mientras el servicio compañero está en ejecución para que Android no lo detenga en segundo plano. Activa las notificaciones en los ajustes de la app para continuar.</string>
+    <string name="companion_notification_permission_open_settings">Abrir ajustes</string>
 
     <!-- Show Detail -->
     <string name="show_detail_seasons">Temporadas</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -132,6 +132,9 @@
     <string name="companion_channel_description">Indique quand le serveur compagnon est actif pour les connexions TV</string>
     <string name="companion_notification_title">WatchBuddy Companion</string>
     <string name="companion_notification_text">Prêt pour la connexion TV</string>
+    <string name="companion_notification_permission_rationale_title">Autoriser les notifications</string>
+    <string name="companion_notification_permission_rationale_body">WatchBuddy affiche une notification persistante pendant que le service compagnon fonctionne, afin qu\'Android ne l\'arrête pas en silence. Active les notifications dans les réglages de l\'application pour continuer.</string>
+    <string name="companion_notification_permission_open_settings">Ouvrir les réglages</string>
 
     <!-- Show Detail -->
     <string name="show_detail_seasons">Saisons</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -142,6 +142,9 @@
     <string name="companion_channel_description">Shows when the companion server is active for TV connections</string>
     <string name="companion_notification_title">WatchBuddy Companion</string>
     <string name="companion_notification_text">Ready for TV connection</string>
+    <string name="companion_notification_permission_rationale_title">Allow notifications</string>
+    <string name="companion_notification_permission_rationale_body">WatchBuddy shows a persistent notification while the companion service is running so Android doesn\'t silently stop it. Enable notifications in the app settings to start watching.</string>
+    <string name="companion_notification_permission_open_settings">Open settings</string>
 
     <!-- Model Download -->
     <string name="model_download_channel_name">Model Download</string>


### PR DESCRIPTION
## Summary

Closes #261. The companion foreground service's notification was silently dropped on Android 14+ because `POST_NOTIFICATIONS` was never requested at runtime and the small icon was an adaptive mipmap (which some OEM skins render blank or suppress entirely).

- **Runtime permission**: ask for `POST_NOTIFICATIONS` from `HomeScreen` the first time the *I am watching TV* toggle is switched on. If the user denies it, a rationale dialog deep-links into the app's notification settings so they can grant it manually.
- **Monochrome small icon**: swap `R.mipmap.ic_launcher` for a new `@drawable/ic_companion_notification` — a white-on-transparent vector the status bar can recolor.
- **Harden builder**: set `CATEGORY_SERVICE`, `VISIBILITY_PUBLIC`, `FOREGROUND_SERVICE_IMMEDIATE`, and a content intent that reopens `MainActivity` on tap.
- **Localization**: new rationale-dialog strings added to `values/`, `values-de/`, `values-fr/`, `values-es/`.

## Test plan

- [ ] Fresh install on Android 14+ → toggle *I am watching TV* → system prompt for notifications appears → grant → persistent "WatchBuddy Companion — Ready for TV connection" notification visible in the shade and on the lock screen.
- [ ] Deny the prompt → rationale dialog appears → *Open settings* deep-links to app notification settings.
- [ ] Tap the notification → `MainActivity` returns to the foreground.
- [ ] Toggle off → notification disappears immediately.
- [ ] Swipe the app from recents → `onTaskRemoved()` stops the service → notification disappears.
- [ ] CI build (`build-android.yml`) is green.

https://claude.ai/code/session_01WRMC8ihbgLcWZCsSH7Z8WX