### PR TITLE
ci: group Play Store releases by minor version name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,11 +230,13 @@ jobs:
         id: play-status
         run: |
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
           if [ "$MAJOR" -ge 1 ]; then
             echo "status=completed" >> "$GITHUB_OUTPUT"
           else
             echo "status=draft" >> "$GITHUB_OUTPUT"
           fi
+          echo "release-name=${MAJOR}.${MINOR}" >> "$GITHUB_OUTPUT"
 
       # -- Publish to Google Play Store ------------------------------------
       - name: Upload to Google Play Store
@@ -246,6 +248,7 @@ jobs:
           releaseFiles: release-assets/*-release.aab
           track: internal
           status: ${{ steps.play-status.outputs.status }}
+          releaseName: ${{ steps.play-status.outputs.release-name }}
           whatsNewDirectory: whatsnew
 
       - name: Upload release artifacts


### PR DESCRIPTION
## Summary

- Set `releaseName: ${MAJOR}.${MINOR}` on the `r0adkll/upload-google-play` step so all patch releases of a minor line share a single release name in the Play Console (e.g. `0.13.10`, `0.13.11`, `0.13.12` all appear as **"0.13"**) instead of each creating a separately named release entry.
- Existing major-based draft/completed status logic (`v<1` → draft, `v≥1` → completed) is preserved unchanged as a safety net.
- No new action version — `r0adkll/upload-google-play@v1.1.3` already supports `releaseName` (verified against the action's `action.yml`) and is still the latest upstream tag (Feb 2024).

## Background

Google Play's data model requires a unique `versionCode` per upload, so each patch will always be a distinct release entry on the track — a patch cannot technically be appended into an already-live minor release. Sharing a release **name** across a minor line is the closest approximation: patches remain independent uploads but appear grouped under the minor version in the Play Console UI.

### Effect after merge

| release-please tag | Before (release name) | After |
|--------------------|-----------------------|-------|
| `v0.13.10` | `0.13.10` | `0.13` |
| `v0.13.11` (patch) | `0.13.11` | `0.13` |
| `v0.14.0` (minor) | `0.14.0` | `0.14` |
| `v1.0.0` (major) | `1.0.0` | `1.0` |

## Test plan

- [ ] CI `build-android.yml` passes green on this PR
- [ ] After merge, the next release-please-generated release logs `release-name=<major>.<minor>` in the "Determine Play Store release status" step
- [ ] The subsequent Play Console internal-track upload shows the release under the name `${MAJOR}.${MINOR}` (e.g. `0.13`) rather than the full version string
- [ ] Multiple consecutive patch releases within the same minor line appear grouped under a shared release name in the Play Console

https://claude.ai/code/session_012m3kH9LcoskKWiz8Lex7iP