### PR TITLE
fix(release): restore full semver Play release name and upload native debug symbols

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,28 @@ jobs:
             [ -f "$aab" ] && cp "$aab" "release-assets/watchbuddy-tv-${VERSION}-release.aab"
           done
 
+          # Native debug symbols (AGP emits these when debugSymbolLevel is set).
+          # Play Console uses them to symbolicate native crashes / ANRs (#262).
+          # Keep per-module zips as GitHub-Release artefacts for sideloaders /
+          # crash-triage, and build a merged zip for the single Play upload step
+          # (r0adkll/upload-google-play accepts only one debugSymbols: file and
+          # applies it to every uploaded AAB in the release).
+          PHONE_SYMS="app-phone/build/outputs/native-debug-symbols/release/native-debug-symbols.zip"
+          TV_SYMS="app-tv/build/outputs/native-debug-symbols/release/native-debug-symbols.zip"
+          if [ -f "$PHONE_SYMS" ]; then
+            cp "$PHONE_SYMS" "release-assets/watchbuddy-phone-${VERSION}-native-debug-symbols.zip"
+          fi
+          if [ -f "$TV_SYMS" ]; then
+            cp "$TV_SYMS" "release-assets/watchbuddy-tv-${VERSION}-native-debug-symbols.zip"
+          fi
+          if [ -f "$PHONE_SYMS" ] || [ -f "$TV_SYMS" ]; then
+            rm -rf /tmp/native-debug-symbols-merged
+            mkdir -p /tmp/native-debug-symbols-merged
+            [ -f "$PHONE_SYMS" ] && unzip -oq "$PHONE_SYMS" -d /tmp/native-debug-symbols-merged
+            [ -f "$TV_SYMS" ]    && unzip -oq "$TV_SYMS"    -d /tmp/native-debug-symbols-merged
+            (cd /tmp/native-debug-symbols-merged && zip -qr "$GITHUB_WORKSPACE/release-assets/watchbuddy-${VERSION}-native-debug-symbols.zip" .)
+          fi
+
           ls -lh release-assets/
 
       # -- Upload to GitHub Release ----------------------------------------
@@ -147,7 +169,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for file in release-assets/*.apk release-assets/*.aab; do
+          for file in release-assets/*.apk release-assets/*.aab release-assets/*-native-debug-symbols.zip; do
             [ -f "$file" ] && gh release upload "${TAG}" "$file" --clobber
           done
 
@@ -230,15 +252,17 @@ jobs:
         id: play-status
         run: |
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
           if [ "$MAJOR" -ge 1 ]; then
             echo "status=completed" >> "$GITHUB_OUTPUT"
           else
             echo "status=draft" >> "$GITHUB_OUTPUT"
           fi
-          echo "release-name=${MAJOR}.${MINOR}" >> "$GITHUB_OUTPUT"
 
       # -- Publish to Google Play Store ------------------------------------
+      # Phone + TV AABs ship as one release on the internal track so Play can
+      # serve the correct bundle per device type.  The merged native-debug-
+      # symbols.zip is attached to every uploaded AAB (r0adkll/upload-google-
+      # play accepts a single debugSymbols: file per invocation).
       - name: Upload to Google Play Store
         if: steps.keystore.outputs.available == 'true' && steps.play-store.outputs.available == 'true'
         uses: r0adkll/upload-google-play@v1.1.3
@@ -246,9 +270,9 @@ jobs:
           serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: com.justb81.watchbuddy
           releaseFiles: release-assets/*-release.aab
+          debugSymbols: release-assets/watchbuddy-${{ env.VERSION }}-native-debug-symbols.zip
           track: internal
           status: ${{ steps.play-status.outputs.status }}
-          releaseName: ${{ steps.play-status.outputs.release-name }}
           whatsNewDirectory: whatsnew
 
       - name: Upload release artifacts
@@ -258,6 +282,7 @@ jobs:
           path: |
             release-assets/*.apk
             release-assets/*.aab
+            release-assets/*-native-debug-symbols.zip
 
   update-stable:
     name: Update stable branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,8 +152,9 @@ The `release-please--` prefix is reserved for the automated release-please bot â
 
 ### Distribution
 - **Google Play Store:** AABs are automatically uploaded to the **internal** track on each release. Promote to production via Google Play Console.
-- **GitHub Releases:** Signed APKs and AABs are attached to each GitHub Release for sideloading.
+- **GitHub Releases:** Signed APKs, AABs, and per-module `native-debug-symbols.zip` files are attached to each GitHub Release for sideloading and crash triage.
 - **Multi-APK delivery:** Both apps share `applicationId = com.justb81.watchbuddy` with a multiplier-based versionCode scheme (`run_number * 10 + 1` for phone, `run_number * 10 + 2` for TV) to guarantee no collisions. The TV manifest requires `android.software.leanback` so Google Play serves the correct AAB per device type.
+- **Native debug symbols:** Release AABs use `debugSymbolLevel = "FULL"`. AGP-emitted `native-debug-symbols.zip` is uploaded to Play per AAB via the Play upload action's `debugSymbols:` input so native crashes/ANRs are symbolicated (#262).
 - **CI secrets for Play Store:** `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` (Google Cloud service account key with Google Play Android Developer API access). If not set, the Play Store upload step is skipped gracefully.
 
 ### Localization

--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -51,10 +51,12 @@ android {
 
         // Package native debug symbols into the AAB so Google Play Console can
         // symbolicate native stack traces.  LiteRT-LM, AICore and Tink all ship
-        // .so libraries; SYMBOL_TABLE yields readable frames without inflating
-        // the bundle the way FULL (with line numbers) would.
+        // .so libraries.  FULL is required — SYMBOL_TABLE strips line numbers
+        // and Play Console still flags the bundle as "no symbols for debugging"
+        // (#262).  AGP also emits native-debug-symbols.zip alongside the AAB,
+        // which CI uploads to Play and attaches to the GitHub Release.
         ndk {
-            debugSymbolLevel = "SYMBOL_TABLE"
+            debugSymbolLevel = "FULL"
         }
     }
 

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -28,10 +28,12 @@ android {
 
         // Package native debug symbols into the AAB so Google Play Console can
         // symbolicate native stack traces (Tink via security-crypto is the main
-        // contributor on TV).  SYMBOL_TABLE yields readable frames without the
-        // size overhead of FULL (which also includes line numbers).
+        // contributor on TV).  FULL is required — SYMBOL_TABLE strips line
+        // numbers and Play Console still flags the bundle as "no symbols for
+        // debugging" (#262).  AGP also emits native-debug-symbols.zip alongside
+        // the AAB, which CI uploads to Play and attaches to the GitHub Release.
         ndk {
-            debugSymbolLevel = "SYMBOL_TABLE"
+            debugSymbolLevel = "FULL"
         }
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,6 +224,8 @@ this flow and shows a "Now Watching" card with the show title, episode number, a
 | touchscreen required | true | false |
 | 64-bit (Aug 2026) | ✅ | ✅ |
 
+Release AABs are built with `debugSymbolLevel = "FULL"`. AGP emits a per-module `native-debug-symbols.zip` alongside each AAB; CI uploads it with the matching AAB to the Play Store (via `r0adkll/upload-google-play`'s `debugSymbols:` input) and attaches it to the GitHub Release so native crashes and ANRs can be symbolicated.
+
 ## Deep Links
 
 | Service | Package | Link Template |


### PR DESCRIPTION
## Summary

- Revert #267: drop `releaseName: ${MAJOR}.${MINOR}` on the Play Store upload step. Grouping patch releases under a shared `0.X` name appears to have blocked Play from delivering updates to installed devices — restore the default behaviour so each release carries its full semver on the Play track.
- Implement #262: ship full native debug symbols with each Play Store and GitHub Release.
  - Bump `android.buildTypes.release.ndk.debugSymbolLevel` from `SYMBOL_TABLE` to `FULL` in both `app-phone` and `app-tv`. Play Console flags `SYMBOL_TABLE` as "no symbols for debugging" because it strips line numbers; `FULL` includes DWARF info and resolves the warning.
  - Collect the AGP-emitted `native-debug-symbols.zip` per module and attach both per-module zips to the GitHub Release for sideloaders / crash triage.
  - Build a merged symbols zip spanning phone + TV and pass it as `debugSymbols:` to the single `r0adkll/upload-google-play` step. A single upload keeps phone + TV AABs in one Play release (multi-AAB delivery), while the merged zip ensures both bundles are symbolicated — `r0adkll/upload-google-play` accepts only one `debugSymbols:` file per invocation and applies it to every uploaded AAB.
- Sync `CLAUDE.md` and `docs/architecture.md` Distribution notes.

Closes #262.

## Test plan

- [x] `build-android.yml` is green on the PR.
- [ ] After merge, the next release-please-triggered release uploads with its full semver name (e.g. `0.16.2`, not `0.16`) and installed devices receive the update.
- [ ] Google Play Console → App bundle explorer → Downloads → Native debug symbols shows **Present** for both phone and TV AABs of the new release.
- [ ] Play Console warning "Dieses App Bundle enthält nativen Code und du hast keine Symbole zum Debuggen hochgeladen" no longer appears for the new release.
- [ ] GitHub Release for the new version lists both `watchbuddy-phone-<v>-native-debug-symbols.zip` and `watchbuddy-tv-<v>-native-debug-symbols.zip` among the assets.

https://claude.ai/code/session_01CJ5Dd4KyPjVm4P1wqxwHpC