### PR TITLE
fix(release): upload per-AAB R8 mapping files to Play Store (#273)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,10 +142,10 @@ jobs:
 
           # Native debug symbols (AGP emits these when debugSymbolLevel is set).
           # Play Console uses them to symbolicate native crashes / ANRs (#262).
-          # Keep per-module zips as GitHub-Release artefacts for sideloaders /
-          # crash-triage, and build a merged zip for the single Play upload step
-          # (r0adkll/upload-google-play accepts only one debugSymbols: file and
-          # applies it to every uploaded AAB in the release).
+          # AGP embeds the per-AAB symbols under BUNDLE-METADATA when
+          # debugSymbolLevel = "FULL", so Play auto-associates them. The merged
+          # and per-module zips here are kept as GitHub-Release artefacts for
+          # sideloaders and manual crash triage.
           PHONE_SYMS="app-phone/build/outputs/native-debug-symbols/release/native-debug-symbols.zip"
           TV_SYMS="app-tv/build/outputs/native-debug-symbols/release/native-debug-symbols.zip"
           if [ -f "$PHONE_SYMS" ]; then
@@ -162,14 +162,58 @@ jobs:
             (cd /tmp/native-debug-symbols-merged && zip -qr "$GITHUB_WORKSPACE/release-assets/watchbuddy-${VERSION}-native-debug-symbols.zip" .)
           fi
 
+          # ProGuard/R8 mapping files — Play Console needs these to de-obfuscate
+          # stack traces (#273). Keep per-module copies as GitHub-Release
+          # artefacts; the Play upload consumes them from play-artifacts/.
+          PHONE_MAPPING="app-phone/build/outputs/mapping/release/mapping.txt"
+          TV_MAPPING="app-tv/build/outputs/mapping/release/mapping.txt"
+          if [ -f "$PHONE_MAPPING" ]; then
+            cp "$PHONE_MAPPING" "release-assets/watchbuddy-phone-${VERSION}-mapping.txt"
+          fi
+          if [ -f "$TV_MAPPING" ]; then
+            cp "$TV_MAPPING" "release-assets/watchbuddy-tv-${VERSION}-mapping.txt"
+          fi
+
           ls -lh release-assets/
+
+      # -- Stage artefacts for the Play upload ----------------------------
+      # Gradle Play Publisher's artifactDir mode uploads every AAB it finds
+      # in the given directory as part of one atomic Play edit.  For each
+      # AAB it pairs a sibling `<name>.mapping.txt` as the deobfuscation
+      # file uploaded per versionCode (#273), so phone and TV crashes are
+      # symbolicated with their respective R8 mappings.
+      - name: Stage Play artifacts
+        if: steps.keystore.outputs.available == 'true'
+        run: |
+          mkdir -p play-artifacts
+          PHONE_AAB="app-phone/build/outputs/bundle/release/app-phone-release.aab"
+          TV_AAB="app-tv/build/outputs/bundle/release/app-tv-release.aab"
+          # Be forgiving about AGP's bundle naming — fall back to glob.
+          [ -f "$PHONE_AAB" ] || PHONE_AAB=$(ls app-phone/build/outputs/bundle/release/*.aab 2>/dev/null | head -n1 || true)
+          [ -f "$TV_AAB" ]    || TV_AAB=$(ls    app-tv/build/outputs/bundle/release/*.aab    2>/dev/null | head -n1 || true)
+
+          if [ -n "$PHONE_AAB" ] && [ -f "$PHONE_AAB" ]; then
+            cp "$PHONE_AAB" "play-artifacts/phone.aab"
+            if [ -f "app-phone/build/outputs/mapping/release/mapping.txt" ]; then
+              cp "app-phone/build/outputs/mapping/release/mapping.txt" "play-artifacts/phone.mapping.txt"
+            fi
+          fi
+
+          if [ -n "$TV_AAB" ] && [ -f "$TV_AAB" ]; then
+            cp "$TV_AAB" "play-artifacts/tv.aab"
+            if [ -f "app-tv/build/outputs/mapping/release/mapping.txt" ]; then
+              cp "app-tv/build/outputs/mapping/release/mapping.txt" "play-artifacts/tv.mapping.txt"
+            fi
+          fi
+
+          ls -lh play-artifacts/
 
       # -- Upload to GitHub Release ----------------------------------------
       - name: Upload release assets to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for file in release-assets/*.apk release-assets/*.aab release-assets/*-native-debug-symbols.zip; do
+          for file in release-assets/*.apk release-assets/*.aab release-assets/*-native-debug-symbols.zip release-assets/*-mapping.txt; do
             [ -f "$file" ] && gh release upload "${TAG}" "$file" --clobber
           done
 
@@ -234,18 +278,19 @@ jobs:
           fi
 
           # Write locale files — all locales get the same English text
-          # (matches supported languages: EN, DE, FR, ES). Filenames must use the
-          # `whatsnew-<locale>` convention expected by r0adkll/upload-google-play.
-          mkdir -p whatsnew
+          # (matches supported languages: EN, DE, FR, ES). Gradle Play Publisher
+          # reads per-locale release notes from `src/main/play/release-notes/<locale>/default.txt`.
+          NOTES_DIR="app-phone/src/main/play/release-notes"
           for LOCALE in en-US de-DE fr-FR es-ES; do
-            echo "$NOTES" > "whatsnew/whatsnew-${LOCALE}"
+            mkdir -p "${NOTES_DIR}/${LOCALE}"
+            echo "$NOTES" > "${NOTES_DIR}/${LOCALE}/default.txt"
           done
 
           echo "--- Play Store changelog (en-US) ---"
-          cat whatsnew/whatsnew-en-US
+          cat "${NOTES_DIR}/en-US/default.txt"
           echo "--- ${#NOTES} characters ---"
-          echo "--- files in whatsnew/ ---"
-          ls -la whatsnew/
+          echo "--- files in ${NOTES_DIR}/ ---"
+          ls -la "${NOTES_DIR}"/*/
 
       # -- Determine Play Store release status ------------------------------
       - name: Determine Play Store release status
@@ -253,27 +298,33 @@ jobs:
         run: |
           MAJOR=$(echo "$VERSION" | cut -d. -f1)
           if [ "$MAJOR" -ge 1 ]; then
-            echo "status=completed" >> "$GITHUB_OUTPUT"
+            echo "status=COMPLETED" >> "$GITHUB_OUTPUT"
           else
-            echo "status=draft" >> "$GITHUB_OUTPUT"
+            echo "status=DRAFT" >> "$GITHUB_OUTPUT"
           fi
 
-      # -- Publish to Google Play Store ------------------------------------
-      # Phone + TV AABs ship as one release on the internal track so Play can
-      # serve the correct bundle per device type.  The merged native-debug-
-      # symbols.zip is attached to every uploaded AAB (r0adkll/upload-google-
-      # play accepts a single debugSymbols: file per invocation).
-      - name: Upload to Google Play Store
+      # -- Write Play service-account credentials to disk -------------------
+      # Gradle Play Publisher reads the service account JSON from a file
+      # pointed to by GOOGLE_PLAY_SERVICE_ACCOUNT_FILE (consumed by the
+      # `play { }` block in app-phone/build.gradle.kts).
+      - name: Write Play service account file
         if: steps.keystore.outputs.available == 'true' && steps.play-store.outputs.available == 'true'
-        uses: r0adkll/upload-google-play@v1.1.3
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: com.justb81.watchbuddy
-          releaseFiles: release-assets/*-release.aab
-          debugSymbols: release-assets/watchbuddy-${{ env.VERSION }}-native-debug-symbols.zip
-          track: internal
-          status: ${{ steps.play-status.outputs.status }}
-          whatsNewDirectory: whatsnew
+        env:
+          GOOGLE_PLAY_KEY: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          printf '%s' "$GOOGLE_PLAY_KEY" > /tmp/gpp-sa.json
+          chmod 600 /tmp/gpp-sa.json
+          echo "GOOGLE_PLAY_SERVICE_ACCOUNT_FILE=/tmp/gpp-sa.json" >> "$GITHUB_ENV"
+
+      # -- Publish to Google Play Store ------------------------------------
+      # Gradle Play Publisher uploads every AAB it finds under `artifactDir`
+      # (play-artifacts/) as part of a single atomic Play edit, pairing each
+      # AAB with its sibling `<name>.mapping.txt` as the deobfuscation file
+      # per versionCode. This addresses #273: phone and TV crashes are now
+      # symbolicated with their respective R8 mappings.
+      - name: Publish to Google Play via GPP
+        if: steps.keystore.outputs.available == 'true' && steps.play-store.outputs.available == 'true'
+        run: ./gradlew :app-phone:publishReleaseBundle -PplayTrack=internal -PplayStatus=${{ steps.play-status.outputs.status }}
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v7
@@ -283,6 +334,7 @@ jobs:
             release-assets/*.apk
             release-assets/*.aab
             release-assets/*-native-debug-symbols.zip
+            release-assets/*-mapping.txt
 
   update-stable:
     name: Update stable branch

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ secrets.properties
 google-services.json
 local.defaults.properties
 
+# Play Store publishing (populated by CI)
+play-artifacts/
+app-phone/src/main/play/release-notes/
+
 # Node.js (backend)
 node_modules/
 dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,11 +151,14 @@ The `release-please--` prefix is reserved for the automated release-please bot â
 - release-please opens its own PR (`release-please--branches--main`) to bump the version and update `CHANGELOG.md` â€” merge it to trigger a GitHub Release with signed APKs and AABs
 
 ### Distribution
-- **Google Play Store:** AABs are automatically uploaded to the **internal** track on each release. Promote to production via Google Play Console.
-- **GitHub Releases:** Signed APKs, AABs, and per-module `native-debug-symbols.zip` files are attached to each GitHub Release for sideloading and crash triage.
+- **Google Play Store:** AABs are automatically uploaded to the **internal** track on each release via [Gradle Play Publisher (GPP)](https://github.com/Triple-T/gradle-play-publisher) configured in `app-phone/build.gradle.kts`. Promote to production via Google Play Console.
+- **GitHub Releases:** Signed APKs, AABs, per-module `native-debug-symbols.zip` files, and per-module `mapping.txt` files are attached to each GitHub Release for sideloading and crash triage.
 - **Multi-APK delivery:** Both apps share `applicationId = com.justb81.watchbuddy` with a multiplier-based versionCode scheme (`run_number * 10 + 1` for phone, `run_number * 10 + 2` for TV) to guarantee no collisions. The TV manifest requires `android.software.leanback` so Google Play serves the correct AAB per device type.
-- **Native debug symbols:** Release AABs use `debugSymbolLevel = "FULL"`. AGP-emitted `native-debug-symbols.zip` is uploaded to Play per AAB via the Play upload action's `debugSymbols:` input so native crashes/ANRs are symbolicated (#262).
-- **CI secrets for Play Store:** `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` (Google Cloud service account key with Google Play Android Developer API access). If not set, the Play Store upload step is skipped gracefully.
+- **Atomic multi-AAB upload:** Phone + TV AABs are staged into a top-level `play-artifacts/` directory in CI; GPP's `artifactDir` mode uploads both AABs in one atomic Play edit. Running `./gradlew :app-phone:publishReleaseBundle` on CI publishes the whole release.
+- **Native debug symbols:** Release AABs use `debugSymbolLevel = "FULL"`, so AGP embeds per-AAB symbols under `BUNDLE-METADATA` and Play auto-associates them for native crash/ANR symbolication (#262). Per-module `native-debug-symbols.zip` files are still attached to the GitHub Release for manual symbolication.
+- **R8 mapping (deobfuscation) files:** Both apps enable `isMinifyEnabled = true`. AGP embeds `mapping.txt` inside each AAB so Play Console can de-obfuscate stack traces per versionCode (#273). Per-module `mapping.txt` files are also attached to the GitHub Release as `watchbuddy-{phone,tv}-<version>-mapping.txt` for manual triage.
+- **Release-notes source:** GPP reads Play Store "What's new" text from `app-phone/src/main/play/release-notes/<locale>/default.txt`. CI generates these files per release from the release-please body across `en-US`, `de-DE`, `fr-FR`, `es-ES`.
+- **CI secrets for Play Store:** `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` (Google Cloud service account key with Google Play Android Developer API access). The workflow writes this to `/tmp/gpp-sa.json` and points `GOOGLE_PLAY_SERVICE_ACCOUNT_FILE` at it, which the `play { }` block consumes. If the secret is unset, the Play Store upload step is skipped gracefully.
 
 ### Localization
 - Supported languages: English (default), German, French, Spanish

--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -1,9 +1,13 @@
+import com.github.triplet.gradle.androidpublisher.ReleaseStatus
+import com.github.triplet.gradle.androidpublisher.ResolutionStrategy
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.gradle.play.publisher)
 }
 
 android {
@@ -202,4 +206,37 @@ kotlin {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+// Gradle Play Publisher — uploads phone + TV AABs as one atomic Play edit.
+// The workflow stages both AABs into play-artifacts/; GPP's artifactDir mode
+// uploads every AAB found there under a single edit. Each AAB carries its own
+// R8 mapping.txt embedded by AGP at BUNDLE-METADATA/com.android.tools.build.
+// obfuscation/proguard.map, which Play reads per versionCode for stack-trace
+// de-obfuscation (#273). Keeping the plugin on app-phone only means there is
+// a single `publishReleaseBundle` task, not one per module — the shared
+// applicationId requires a single release on the track.
+play {
+    serviceAccountCredentials.set(
+        layout.file(
+            providers.environmentVariable("GOOGLE_PLAY_SERVICE_ACCOUNT_FILE")
+                .orElse("/dev/null")
+                .map { file(it) }
+        )
+    )
+
+    track.set(providers.gradleProperty("playTrack").orElse("internal"))
+
+    releaseStatus.set(
+        providers.gradleProperty("playStatus")
+            .orElse("COMPLETED")
+            .map { ReleaseStatus.valueOf(it) }
+    )
+
+    defaultToAppBundles.set(true)
+    resolutionStrategy.set(ResolutionStrategy.FAIL)
+
+    // Upload AABs from the workflow's staging dir rather than this module's
+    // own output, so both phone and TV AABs ship in the same Play edit.
+    artifactDir.set(rootProject.layout.projectDirectory.dir("play-artifacts"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.gradle.play.publisher) apply false
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,7 +224,9 @@ this flow and shows a "Now Watching" card with the show title, episode number, a
 | touchscreen required | true | false |
 | 64-bit (Aug 2026) | ✅ | ✅ |
 
-Release AABs are built with `debugSymbolLevel = "FULL"`. AGP emits a per-module `native-debug-symbols.zip` alongside each AAB; CI uploads it with the matching AAB to the Play Store (via `r0adkll/upload-google-play`'s `debugSymbols:` input) and attaches it to the GitHub Release so native crashes and ANRs can be symbolicated.
+Release AABs are built with `debugSymbolLevel = "FULL"`, so AGP embeds per-AAB native debug symbols under `BUNDLE-METADATA` and Play Console auto-associates them for native crash/ANR symbolication. A per-module `native-debug-symbols.zip` is also attached to the GitHub Release for manual triage.
+
+Release AABs likewise enable R8 (`isMinifyEnabled = true`), and AGP embeds the resulting `mapping.txt` inside each AAB so Play Console can de-obfuscate stack traces per versionCode. The Play upload is performed by [Gradle Play Publisher](https://github.com/Triple-T/gradle-play-publisher) (`./gradlew :app-phone:publishReleaseBundle`) in `artifactDir` mode, which uploads the phone + TV AABs as one atomic Play edit. Per-module `mapping.txt` files are also attached to the GitHub Release for manual symbolication.
 
 ## Deep Links
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ robolectric = "4.13"
 androidx-test-core = "1.6.1"
 androidx-arch-core = "2.2.0"
 errorprone-annotations = "2.36.0"
+gradlePlayPublisher = "4.0.0"
 
 [libraries]
 # AndroidX Core
@@ -113,3 +114,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+gradle-play-publisher = { id = "com.github.triplet.play", version.ref = "gradlePlayPublisher" }


### PR DESCRIPTION
## Summary

Closes #273 — Google Play Console warned *"Mit diesem App Bundle ist keine Offenlegungsdatei verknüpft"* ("No deobfuscation file is associated with this App Bundle") on every release.

R8 is already enabled on both `app-phone` and `app-tv` release builds, so `mapping.txt` is generated — the gap was that the upload side never shipped it to Play Console. The existing `r0adkll/upload-google-play` action can only attach a single `mappingFile:` per invocation and applies it to every AAB in the release, which is wrong for a two-AAB (phone + TV) release where each has its own distinct R8 output.

### What changed

- **Upload mechanism:** replaced `r0adkll/upload-google-play` with **[Gradle Play Publisher](https://github.com/Triple-T/gradle-play-publisher) 4.0.0** in `artifactDir` mode.
  - The workflow stages both AABs into a top-level `play-artifacts/` directory.
  - `./gradlew :app-phone:publishReleaseBundle` uploads both AABs as **one atomic Play edit** on the internal track.
  - Each AAB carries its own R8 mapping embedded by AGP at `BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map`; Play reads it per versionCode.
- **`app-phone/build.gradle.kts`:** applies `com.github.triplet.play`, adds a `play { }` block wired to env var `GOOGLE_PLAY_SERVICE_ACCOUNT_FILE`, Gradle properties `playTrack` / `playStatus`, and `artifactDir = $rootDir/play-artifacts`. Plugin is applied only to `app-phone` because both apps share `applicationId` and must ship in a single release.
- **Workflow (`.github/workflows/release.yml`):**
  - New *Stage Play artifacts* step copies both AABs (+ their mapping files) into `play-artifacts/`.
  - New *Write Play service account file* step persists the JSON secret to `/tmp/gpp-sa.json` and exports `GOOGLE_PLAY_SERVICE_ACCOUNT_FILE`.
  - *Generate Play Store changelog* now writes to `app-phone/src/main/play/release-notes/<locale>/default.txt` (GPP's layout) instead of the r0adkll `whatsnew/` convention.
  - GitHub Release assets gain `watchbuddy-{phone,tv}-<version>-mapping.txt` for manual re-symbolication.
- **Docs:** `CLAUDE.md` + `docs/architecture.md` updated to document GPP, per-AAB mapping, and the new release-notes layout.
- **`.gitignore`:** ignore the CI-generated `play-artifacts/` and `app-phone/src/main/play/release-notes/`.

### Why this approach

Per issue discussion, four options were considered: (a) pass phone's mapping only [mis-symbolicates TV], (b) chain r0adkll calls via `existingEditId` [fragile, action has no edit-id output], (c) custom Play API script, or (d) switch to GPP. Option (d) is the industry-standard Gradle-native path and cleanly handles multi-AAB atomic releases via `artifactDir`.

## Test plan

- [x] `./gradlew :app-phone:help` — configuration succeeds with GPP 4.0.0 (3.12.1 fails because AGP 9 renamed `BaseAppModuleExtension` → `ApplicationExtension`).
- [x] `./gradlew :app-phone:tasks --group=publishing` — `publishReleaseBundle` task is registered with `--track` / `--release-status` flags.
- [x] `./gradlew :app-tv:help :core:help` — other modules still load.
- [ ] **End-to-end verification after merge:** trigger a release via release-please and confirm in Play Console → App bundle explorer that the "no deobfuscation file" warning is gone for both phone (`run_number*10+1`) and TV (`run_number*10+2`) versionCodes. Inspect a symbolicated crash report.
- [ ] Confirm `watchbuddy-{phone,tv}-<version>-mapping.txt` appear on the tagged GitHub Release alongside existing AABs/APKs.

## Rollback

If the GPP upload fails on the first post-merge release, revert this PR. The prior r0adkll step is trivially restorable; mapping files will still be present on the GitHub Release for manual re-symbolication in the meantime.

https://claude.ai/code/session_01DkXhiYDKbWhBhwrQLNJASY