### PR TITLE
chore(core): consolidate duplicated Json configuration into shared WatchBuddyJson instance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ watchbuddy/
 │   └── src/main/java/com/justb81/watchbuddy/core/
 │       ├── locale/     LocaleHelper (LLM language resolution)
 │       ├── model/      Data models (Kotlin Serialization)
-│       ├── network/    NetworkModule (Hilt, OkHttp, Retrofit)
+│       ├── network/    NetworkModule (Hilt, OkHttp, Retrofit), SharedJson (WatchBuddyJson shared instance)
 │       ├── tmdb/       TmdbApiService
 │       └── trakt/      TraktApiService, TokenProxyService
 ├── backend/            Node.js token proxy (Docker)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -27,9 +27,9 @@ import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
+import com.justb81.watchbuddy.core.network.WatchBuddyJson
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -107,7 +107,7 @@ internal fun Application.configureCompanionRoutes(
     stateManager: CompanionStateManager
 ) {
     install(ContentNegotiation) {
-        json(Json { ignoreUnknownKeys = true })
+        json(WatchBuddyJson)
     }
     routing {
         get("/capability") {

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
@@ -18,8 +18,8 @@ import com.justb81.watchbuddy.phone.ui.settings.AuthMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
+import com.justb81.watchbuddy.core.network.WatchBuddyJson
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -78,10 +78,8 @@ class OnboardingViewModel @Inject constructor(
     private var countdownJob: Job? = null
     private var pollingJob: Job? = null
 
-    private val json = Json { ignoreUnknownKeys = true }
-
     private fun saveDeviceCodeToState(response: DeviceCodeResponse) {
-        savedStateHandle[KEY_DEVICE_CODE_JSON] = json.encodeToString(response)
+        savedStateHandle[KEY_DEVICE_CODE_JSON] = WatchBuddyJson.encodeToString(response)
         savedStateHandle[KEY_DEVICE_CODE_TIMESTAMP] = System.currentTimeMillis()
     }
 
@@ -89,7 +87,7 @@ class OnboardingViewModel @Inject constructor(
         val jsonStr = savedStateHandle.get<String>(KEY_DEVICE_CODE_JSON) ?: return null
         val timestamp = savedStateHandle.get<Long>(KEY_DEVICE_CODE_TIMESTAMP) ?: return null
         return try {
-            val response = json.decodeFromString<DeviceCodeResponse>(jsonStr)
+            val response = WatchBuddyJson.decodeFromString<DeviceCodeResponse>(jsonStr)
             val elapsedSeconds = ((System.currentTimeMillis() - timestamp) / 1000).toInt()
             val remainingSeconds = response.expires_in - elapsedSeconds
             if (remainingSeconds > 0) {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiClientFactory.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiClientFactory.kt
@@ -1,6 +1,6 @@
 package com.justb81.watchbuddy.tv.discovery
 
-import kotlinx.serialization.json.Json
+import com.justb81.watchbuddy.core.network.WatchBuddyJson
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -12,12 +12,6 @@ import javax.inject.Singleton
 class PhoneApiClientFactory @Inject constructor(
     private val httpClient: OkHttpClient
 ) {
-    private val json = Json {
-        ignoreUnknownKeys = true
-        isLenient = true
-        coerceInputValues = true
-    }
-
     private val cache = mutableMapOf<String, PhoneApiService>()
 
     fun createClient(baseUrl: String): PhoneApiService =
@@ -25,7 +19,7 @@ class PhoneApiClientFactory @Inject constructor(
             Retrofit.Builder()
                 .baseUrl(baseUrl)
                 .client(httpClient)
-                .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+                .addConverterFactory(WatchBuddyJson.asConverterFactory("application/json".toMediaType()))
                 .build()
                 .create(PhoneApiService::class.java)
         }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModel.kt
@@ -4,22 +4,17 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.network.WatchBuddyJson
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import com.justb81.watchbuddy.tv.discovery.RecapResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
 import javax.inject.Inject
-
-@Serializable
-private data class RecapResponse(val html: String)
-
-private val lenientJson = Json { ignoreUnknownKeys = true }
 
 sealed class RecapUiState {
     object Idle : RecapUiState()
@@ -76,7 +71,7 @@ class RecapViewModel @Inject constructor(
 
                     if (response.isSuccessful) {
                         val body = response.body?.string() ?: ""
-                        val recap = lenientJson.decodeFromString<RecapResponse>(body)
+                        val recap = WatchBuddyJson.decodeFromString<RecapResponse>(body)
                         _state.value = RecapUiState.Ready(recap.html)
                         return@launch
                     }

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
@@ -7,7 +7,6 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -20,12 +19,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
-
-    private val json = Json {
-        ignoreUnknownKeys = true
-        isLenient = true
-        coerceInputValues = true
-    }
 
     @Provides
     @Singleton
@@ -70,7 +63,7 @@ object NetworkModule {
     fun provideTraktRetrofit(client: OkHttpClient): Retrofit = Retrofit.Builder()
         .baseUrl("https://api.trakt.tv/")
         .client(client)
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+        .addConverterFactory(WatchBuddyJson.asConverterFactory("application/json".toMediaType()))
         .build()
 
     @Provides
@@ -79,7 +72,7 @@ object NetworkModule {
     fun provideTmdbRetrofit(client: OkHttpClient): Retrofit = Retrofit.Builder()
         .baseUrl("https://api.themoviedb.org/3/")
         .client(client)
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+        .addConverterFactory(WatchBuddyJson.asConverterFactory("application/json".toMediaType()))
         .build()
 
     @Provides
@@ -115,7 +108,7 @@ object NetworkModule {
         return Retrofit.Builder()
             .baseUrl(url)
             .client(client)
-            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .addConverterFactory(WatchBuddyJson.asConverterFactory("application/json".toMediaType()))
             .build()
     }
 

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/SharedJson.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/SharedJson.kt
@@ -1,0 +1,13 @@
+package com.justb81.watchbuddy.core.network
+
+import kotlinx.serialization.json.Json
+
+/**
+ * Single lenient [Json] instance shared across all Retrofit/Ktor converters.
+ * Centralises serialisation behaviour so changes propagate uniformly.
+ */
+val WatchBuddyJson: Json = Json {
+    ignoreUnknownKeys = true
+    isLenient = true
+    coerceInputValues = true
+}

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/TokenProxyServiceFactory.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/TokenProxyServiceFactory.kt
@@ -1,7 +1,6 @@
 package com.justb81.watchbuddy.core.network
 
 import com.justb81.watchbuddy.core.trakt.TokenProxyService
-import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -18,18 +17,12 @@ import javax.inject.Singleton
 @Singleton
 class TokenProxyServiceFactory @Inject constructor() {
 
-    private val json = Json {
-        ignoreUnknownKeys = true
-        isLenient = true
-        coerceInputValues = true
-    }
-
     fun create(baseUrl: String): TokenProxyService {
         val url = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
         return Retrofit.Builder()
             .baseUrl(url)
             .client(OkHttpClient())
-            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .addConverterFactory(WatchBuddyJson.asConverterFactory("application/json".toMediaType()))
             .build()
             .create(TokenProxyService::class.java)
     }

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/SharedJsonTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/SharedJsonTest.kt
@@ -1,0 +1,74 @@
+package com.justb81.watchbuddy.core.network
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("WatchBuddyJson")
+class SharedJsonTest {
+
+    @Serializable
+    private data class Sample(val name: String, val value: Int = 0)
+
+    @Nested
+    @DisplayName("ignoreUnknownKeys")
+    inner class IgnoreUnknownKeysTest {
+        @Test
+        fun `ignores extra fields in JSON`() {
+            val json = """{"name":"test","unknown":"extra","value":1}"""
+            val result = WatchBuddyJson.decodeFromString<Sample>(json)
+            assertEquals(Sample("test", 1), result)
+        }
+    }
+
+    @Nested
+    @DisplayName("isLenient")
+    inner class LenientTest {
+        @Test
+        fun `accepts unquoted string values`() {
+            val json = """{"name":unquoted,"value":42}"""
+            val result = WatchBuddyJson.decodeFromString<Sample>(json)
+            assertEquals(Sample("unquoted", 42), result)
+        }
+    }
+
+    @Nested
+    @DisplayName("coerceInputValues")
+    inner class CoerceInputValuesTest {
+        @Test
+        fun `coerces null to default for non-nullable field`() {
+            val json = """{"name":"test","value":null}"""
+            val result = WatchBuddyJson.decodeFromString<Sample>(json)
+            assertEquals(Sample("test", 0), result)
+        }
+    }
+
+    @Nested
+    @DisplayName("singleton identity")
+    inner class SingletonTest {
+        @Test
+        fun `WatchBuddyJson is the same instance on repeated access`() {
+            assertSame(WatchBuddyJson, WatchBuddyJson)
+        }
+
+        @Test
+        fun `WatchBuddyJson is not the default Json instance`() {
+            assertNotSame(Json.Default, WatchBuddyJson)
+        }
+    }
+
+    @Nested
+    @DisplayName("round-trip encoding")
+    inner class RoundTripTest {
+        @Test
+        fun `encodes and decodes correctly`() {
+            val original = Sample("hello", 99)
+            val encoded = WatchBuddyJson.encodeToString(Sample.serializer(), original)
+            val decoded = WatchBuddyJson.decodeFromString<Sample>(encoded)
+            assertEquals(original, decoded)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `WatchBuddyJson` in `core/src/main/java/com/justb81/watchbuddy/core/network/SharedJson.kt` with the superset configuration (`ignoreUnknownKeys = true`, `isLenient = true`, `coerceInputValues = true`)
- Replaces all six per-site `Json { }` constructions in `NetworkModule`, `TokenProxyServiceFactory`, `PhoneApiClientFactory`, `RecapViewModel`, `OnboardingViewModel`, and `CompanionHttpServer`
- Removes the private `RecapResponse` duplicate in `RecapViewModel` in favour of the canonical type declared in `PhoneApiService`
- Adds `SharedJsonTest` verifying all three Json settings, singleton identity, and round-trip encoding
- Updates `CLAUDE.md` repository structure to document the new `SharedJson` file

Closes #274

## Test plan

- [ ] `./gradlew :core:test` — `SharedJsonTest` passes (ignoreUnknownKeys, isLenient, coerceInputValues, singleton identity, round-trip)
- [ ] `./gradlew :app-phone:testDebugUnitTest` — no regressions
- [ ] `./gradlew :app-tv:testDebugUnitTest` — no regressions
- [ ] `./gradlew assembleDebug` — both APKs build successfully
- [ ] Verify no remaining `Json {` blocks outside of `SharedJson.kt`: `rg "Json \{" core/ app-phone/ app-tv/` returns only `SharedJson.kt`

https://claude.ai/code/session_01V6Jv5E97gFme5v4bQTMsA3