### PR TITLE
chore(tv): extract discovery/scrobble timeout constants into DiscoveryConstants

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/DiscoveryConstants.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/DiscoveryConstants.kt
@@ -1,0 +1,22 @@
+package com.justb81.watchbuddy.tv.discovery
+
+/**
+ * Timing and threshold constants shared between discovery and scrobble staleness checks.
+ *
+ * Invariant: PRESENCE_STALENESS_MS must be strictly greater than HEARTBEAT_INTERVAL_MS so that
+ * a single missed heartbeat tick does not immediately evict a healthy phone from the list.
+ */
+internal object DiscoveryConstants {
+    /** How often the TV re-fetches /capability for each known phone. */
+    const val HEARTBEAT_INTERVAL_MS = 60_000L
+
+    /**
+     * A phone is considered stale (and excluded from scrobbling) if no successful /capability
+     * response has been received within this window. Set to 2× the heartbeat interval so that
+     * exactly one missed heartbeat is tolerated before the phone is treated as unreachable.
+     */
+    const val PRESENCE_STALENESS_MS = 2 * HEARTBEAT_INTERVAL_MS
+
+    /** Number of consecutive /capability failures before a phone is removed from the list. */
+    const val MAX_CONSECUTIVE_FAILURES = 3
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -48,8 +48,6 @@ class PhoneDiscoveryManager @Inject constructor(
         const val SERVICE_TYPE = "_watchbuddy._tcp."
         const val CAPABILITY_PATH = "/capability"
         private const val TAG = "PhoneDiscoveryManager"
-        private const val HEARTBEAT_INTERVAL_MS = 60_000L
-        private const val MAX_FAIL_COUNT = 3
         /** Back-off before retrying a stop+start cycle after FAILURE_ALREADY_ACTIVE. */
         private const val RESTART_BACKOFF_MS = 500L
     }
@@ -289,7 +287,7 @@ class PhoneDiscoveryManager @Inject constructor(
     private fun startHeartbeat() {
         heartbeatJob = heartbeatScope.launch {
             while (true) {
-                delay(HEARTBEAT_INTERVAL_MS)
+                delay(DiscoveryConstants.HEARTBEAT_INTERVAL_MS)
                 checkAllPhones()
             }
         }
@@ -330,8 +328,8 @@ class PhoneDiscoveryManager @Inject constructor(
                 )
             } catch (e: Exception) {
                 val newFailCount = phone.failCount + 1
-                if (newFailCount >= MAX_FAIL_COUNT) {
-                    Log.i(TAG, "Removing phone ${phone.baseUrl} after $MAX_FAIL_COUNT failed heartbeats")
+                if (newFailCount >= DiscoveryConstants.MAX_CONSECUTIVE_FAILURES) {
+                    Log.i(TAG, "Removing phone ${phone.baseUrl} after ${DiscoveryConstants.MAX_CONSECUTIVE_FAILURES} failed heartbeats")
                     null
                 } else {
                     phone.copy(failCount = newFailCount)

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher
+import com.justb81.watchbuddy.tv.discovery.DiscoveryConstants
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import com.justb81.watchbuddy.tv.discovery.PhoneScrobbleRequest
@@ -27,14 +28,13 @@ class TvScrobbleDispatcher @Inject constructor(
 
     companion object {
         private const val TAG = "TvScrobbleDispatcher"
-        private const val PRESENCE_STALENESS_MS = 2 * 60_000L
     }
 
     private fun availablePhones(): List<PhoneDiscoveryManager.DiscoveredPhone> {
         val now = System.currentTimeMillis()
         return phoneDiscovery.discoveredPhones.value
             .filter { it.capability?.isAvailable == true }
-            .filter { now - it.lastSuccessfulCheck < PRESENCE_STALENESS_MS }
+            .filter { now - it.lastSuccessfulCheck < DiscoveryConstants.PRESENCE_STALENESS_MS }
     }
 
     override suspend fun dispatchStart(show: TraktShow, episode: TraktEpisode, progress: Float) {

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
@@ -384,4 +384,34 @@ class PhoneDiscoveryManagerTest {
     fun `stopDiscovery does not throw`() {
         manager.stopDiscovery()
     }
+
+    // ── DiscoveryConstants ─────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("DiscoveryConstants")
+    inner class DiscoveryConstantsTest {
+
+        @Test
+        fun `PRESENCE_STALENESS_MS is strictly greater than HEARTBEAT_INTERVAL_MS`() {
+            assertTrue(
+                DiscoveryConstants.PRESENCE_STALENESS_MS > DiscoveryConstants.HEARTBEAT_INTERVAL_MS,
+                "A single missed heartbeat must not immediately evict a healthy phone"
+            )
+        }
+
+        @Test
+        fun `HEARTBEAT_INTERVAL_MS is 60 seconds`() {
+            assertEquals(60_000L, DiscoveryConstants.HEARTBEAT_INTERVAL_MS)
+        }
+
+        @Test
+        fun `PRESENCE_STALENESS_MS is 2x the heartbeat interval`() {
+            assertEquals(2 * DiscoveryConstants.HEARTBEAT_INTERVAL_MS, DiscoveryConstants.PRESENCE_STALENESS_MS)
+        }
+
+        @Test
+        fun `MAX_CONSECUTIVE_FAILURES is 3`() {
+            assertEquals(3, DiscoveryConstants.MAX_CONSECUTIVE_FAILURES)
+        }
+    }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
@@ -1,0 +1,185 @@
+package com.justb81.watchbuddy.tv.scrobbler
+
+import android.net.nsd.NsdServiceInfo
+import com.justb81.watchbuddy.core.model.LlmBackend
+import com.justb81.watchbuddy.tv.TestFixtures
+import com.justb81.watchbuddy.tv.discovery.DiscoveryConstants
+import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
+import com.justb81.watchbuddy.tv.discovery.PhoneApiService
+import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import io.mockk.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("TvScrobbleDispatcher")
+class TvScrobbleDispatcherTest {
+
+    private val phoneDiscovery: PhoneDiscoveryManager = mockk()
+    private val phoneApiClientFactory: PhoneApiClientFactory = mockk()
+    private val phoneApiService: PhoneApiService = mockk()
+    private lateinit var dispatcher: TvScrobbleDispatcher
+
+    private val phonesFlow = MutableStateFlow<List<PhoneDiscoveryManager.DiscoveredPhone>>(emptyList())
+
+    @BeforeEach
+    fun setUp() {
+        every { phoneDiscovery.discoveredPhones } returns phonesFlow
+        dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory)
+    }
+
+    private fun makePhone(
+        baseUrl: String = "http://192.168.1.1:8765/",
+        isAvailable: Boolean = true,
+        lastSuccessfulCheck: Long = System.currentTimeMillis(),
+        name: String = "test-phone"
+    ): PhoneDiscoveryManager.DiscoveredPhone {
+        val serviceInfo = mockk<NsdServiceInfo>()
+        every { serviceInfo.serviceName } returns name
+        val capability = TestFixtures.deviceCapability(isAvailable = isAvailable)
+        val txt = PhoneDiscoveryManager.PhoneTxtRecord(
+            version = "1.0.0",
+            modelQuality = 75,
+            llmBackend = LlmBackend.LITERT
+        )
+        return PhoneDiscoveryManager.DiscoveredPhone(
+            serviceInfo = serviceInfo,
+            txtRecord = txt,
+            capability = capability,
+            score = 75,
+            baseUrl = baseUrl,
+            lastSuccessfulCheck = lastSuccessfulCheck
+        )
+    }
+
+    // ── staleness filtering ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("staleness filtering")
+    inner class StalenessFilteringTest {
+
+        @Test
+        fun `dispatches to a fresh phone`() = runTest {
+            val phone = makePhone()
+            phonesFlow.value = listOf(phone)
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobbleStart(any()) } returns mockk()
+
+            dispatcher.dispatchStart(
+                TestFixtures.traktShow(),
+                TestFixtures.traktEpisode(),
+                50f
+            )
+
+            coVerify { phoneApiService.scrobbleStart(any()) }
+        }
+
+        @Test
+        fun `skips a stale phone whose lastSuccessfulCheck exceeds PRESENCE_STALENESS_MS`() = runTest {
+            val staleTime = System.currentTimeMillis() - DiscoveryConstants.PRESENCE_STALENESS_MS - 1_000L
+            val phone = makePhone(lastSuccessfulCheck = staleTime)
+            phonesFlow.value = listOf(phone)
+
+            dispatcher.dispatchStart(
+                TestFixtures.traktShow(),
+                TestFixtures.traktEpisode(),
+                50f
+            )
+
+            coVerify(exactly = 0) { phoneApiClientFactory.createClient(any()) }
+        }
+
+        @Test
+        fun `includes a phone whose lastSuccessfulCheck is exactly at the staleness boundary`() = runTest {
+            // A check that happened exactly at the boundary should still be considered fresh.
+            val boundaryTime = System.currentTimeMillis() - DiscoveryConstants.PRESENCE_STALENESS_MS + 100L
+            val phone = makePhone(lastSuccessfulCheck = boundaryTime)
+            phonesFlow.value = listOf(phone)
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobbleStart(any()) } returns mockk()
+
+            dispatcher.dispatchStart(
+                TestFixtures.traktShow(),
+                TestFixtures.traktEpisode(),
+                50f
+            )
+
+            coVerify { phoneApiService.scrobbleStart(any()) }
+        }
+
+        @Test
+        fun `skips a phone marked as unavailable even when fresh`() = runTest {
+            val phone = makePhone(isAvailable = false)
+            phonesFlow.value = listOf(phone)
+
+            dispatcher.dispatchStart(
+                TestFixtures.traktShow(),
+                TestFixtures.traktEpisode(),
+                50f
+            )
+
+            coVerify(exactly = 0) { phoneApiClientFactory.createClient(any()) }
+        }
+
+        @Test
+        fun `skips dispatch when phone list is empty`() = runTest {
+            phonesFlow.value = emptyList()
+
+            dispatcher.dispatchStart(
+                TestFixtures.traktShow(),
+                TestFixtures.traktEpisode(),
+                50f
+            )
+
+            coVerify(exactly = 0) { phoneApiClientFactory.createClient(any()) }
+        }
+
+        @Test
+        fun `dispatches to all fresh phones in parallel`() = runTest {
+            val apiService1: PhoneApiService = mockk()
+            val apiService2: PhoneApiService = mockk()
+            val phone1 = makePhone(baseUrl = "http://phone1:8765/", name = "phone1")
+            val phone2 = makePhone(baseUrl = "http://phone2:8765/", name = "phone2")
+            phonesFlow.value = listOf(phone1, phone2)
+            coEvery { phoneApiClientFactory.createClient("http://phone1:8765/") } returns apiService1
+            coEvery { phoneApiClientFactory.createClient("http://phone2:8765/") } returns apiService2
+            coEvery { apiService1.scrobbleStart(any()) } returns mockk()
+            coEvery { apiService2.scrobbleStart(any()) } returns mockk()
+
+            dispatcher.dispatchStart(
+                TestFixtures.traktShow(),
+                TestFixtures.traktEpisode(),
+                50f
+            )
+
+            coVerify { apiService1.scrobbleStart(any()) }
+            coVerify { apiService2.scrobbleStart(any()) }
+        }
+
+        @Test
+        fun `failure on one phone does not prevent dispatch to others`() = runTest {
+            val apiService1: PhoneApiService = mockk()
+            val apiService2: PhoneApiService = mockk()
+            val phone1 = makePhone(baseUrl = "http://phone1:8765/", name = "phone1")
+            val phone2 = makePhone(baseUrl = "http://phone2:8765/", name = "phone2")
+            phonesFlow.value = listOf(phone1, phone2)
+            coEvery { phoneApiClientFactory.createClient("http://phone1:8765/") } returns apiService1
+            coEvery { phoneApiClientFactory.createClient("http://phone2:8765/") } returns apiService2
+            coEvery { apiService1.scrobbleStart(any()) } throws RuntimeException("network error")
+            coEvery { apiService2.scrobbleStart(any()) } returns mockk()
+
+            // Should not throw even when one phone fails.
+            dispatcher.dispatchStart(
+                TestFixtures.traktShow(),
+                TestFixtures.traktEpisode(),
+                50f
+            )
+
+            coVerify { apiService2.scrobbleStart(any()) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Extracts `HEARTBEAT_INTERVAL_MS`, `MAX_CONSECUTIVE_FAILURES` (was `MAX_FAIL_COUNT`) from `PhoneDiscoveryManager` and `PRESENCE_STALENESS_MS` from `TvScrobbleDispatcher` into a new `internal object DiscoveryConstants`
- Documents the invariant: `PRESENCE_STALENESS_MS` must be `> HEARTBEAT_INTERVAL_MS` so a single missed heartbeat does not evict a healthy phone; expressed as `2 * HEARTBEAT_INTERVAL_MS` in code
- Adds `TvScrobbleDispatcherTest` covering staleness filtering, parallel fan-out, and failure isolation
- Adds `DiscoveryConstants` nested test suite to `PhoneDiscoveryManagerTest` to assert the heartbeat/staleness invariant

Closes #286

## Test plan

- [ ] `./gradlew :app-tv:testDebugUnitTest` passes (new `TvScrobbleDispatcherTest` + updated `PhoneDiscoveryManagerTest` including `DiscoveryConstants` suite)
- [ ] `./gradlew :app-tv:assembleDebug` compiles without errors
- [ ] No behaviour change: staleness threshold remains 120 s (2 × 60 s heartbeat interval)