### PR TITLE
chore: remove unused @Named("isDebugBuild") Hilt qualifier

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
@@ -57,12 +57,6 @@ object AppModule {
     fun provideManagedBackendAvailable(): Boolean =
         BuildConfig.TOKEN_BACKEND_URL.isNotBlank() && BuildConfig.TRAKT_CLIENT_ID.isNotBlank()
 
-    /** Debug flag for NetworkModule (controls HTTP logging level). */
-    @Provides
-    @Singleton
-    @Named("isDebugBuild")
-    fun provideIsDebugBuild(): Boolean = BuildConfig.DEBUG
-
     /**
      * WorkManager singleton for injection into ViewModels.
      * Injecting rather than calling getInstance() directly keeps ViewModels testable.

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
@@ -1,6 +1,5 @@
 package com.justb81.watchbuddy.tv.di
 
-import com.justb81.watchbuddy.BuildConfig
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -12,16 +11,9 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object AppModule {
 
-    /** Debug-Flag für NetworkModule (steuert HTTP-Logging-Level). */
-    @Provides
-    @Singleton
-    @Named("isDebugBuild")
-    fun provideIsDebugBuild(): Boolean = BuildConfig.DEBUG
-
     /**
-     * URL des Token-Proxy-Backends — die TV-App nutzt keinen Token-Proxy,
-     * daher Leerstring. Wird von NetworkModule.provideTokenProxyRetrofit()
-     * benötigt; bei leerem String wird null zurückgegeben.
+     * Token proxy backend URL — the TV app uses no token proxy, so this is blank.
+     * NetworkModule.provideTokenProxyRetrofit() returns null when blank.
      */
     @Provides
     @Singleton

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,6 +9,10 @@ android {
     namespace = "com.justb81.watchbuddy.core"
     compileSdk = 35
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     defaultConfig {
         minSdk = 31
     }

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
@@ -23,7 +23,6 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideOkHttpClient(
-        @Named("isDebugBuild") isDebug: Boolean,
         @Named("traktClientId") traktClientId: String,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor { chain ->
@@ -36,7 +35,7 @@ object NetworkModule {
             chain.proceed(builder.build())
         }
         .addInterceptor(HttpLoggingInterceptor().apply {
-            level = if (isDebug) HttpLoggingInterceptor.Level.BODY
+            level = if (com.justb81.watchbuddy.core.BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
                     else HttpLoggingInterceptor.Level.NONE
         })
         .build()

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
@@ -2,6 +2,7 @@ package com.justb81.watchbuddy.core.network
 
 import okhttp3.OkHttpClient
 import okhttp3.Request
+import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
@@ -34,7 +35,7 @@ class NetworkModuleTest {
         @Test
         fun `adds Content-Type header`() {
             server.enqueue(MockResponse().setBody("{}"))
-            val client = NetworkModule.provideOkHttpClient(isDebug = false, traktClientId = "test-id")
+            val client = NetworkModule.provideOkHttpClient(traktClientId = "test-id")
             client.newCall(Request.Builder().url(server.url("/test")).build()).execute()
             val recorded = server.takeRequest()
             assertEquals("application/json", recorded.getHeader("Content-Type"))
@@ -43,7 +44,7 @@ class NetworkModuleTest {
         @Test
         fun `adds trakt-api-version header`() {
             server.enqueue(MockResponse().setBody("{}"))
-            val client = NetworkModule.provideOkHttpClient(isDebug = false, traktClientId = "test-id")
+            val client = NetworkModule.provideOkHttpClient(traktClientId = "test-id")
             client.newCall(Request.Builder().url(server.url("/test")).build()).execute()
             val recorded = server.takeRequest()
             assertEquals("2", recorded.getHeader("trakt-api-version"))
@@ -52,7 +53,7 @@ class NetworkModuleTest {
         @Test
         fun `adds trakt-api-key header when client id is provided`() {
             server.enqueue(MockResponse().setBody("{}"))
-            val client = NetworkModule.provideOkHttpClient(isDebug = false, traktClientId = "abc-123")
+            val client = NetworkModule.provideOkHttpClient(traktClientId = "abc-123")
             client.newCall(Request.Builder().url(server.url("/test")).build()).execute()
             val recorded = server.takeRequest()
             assertEquals("abc-123", recorded.getHeader("trakt-api-key"))
@@ -61,7 +62,7 @@ class NetworkModuleTest {
         @Test
         fun `omits trakt-api-key header when client id is blank`() {
             server.enqueue(MockResponse().setBody("{}"))
-            val client = NetworkModule.provideOkHttpClient(isDebug = false, traktClientId = "")
+            val client = NetworkModule.provideOkHttpClient(traktClientId = "")
             client.newCall(Request.Builder().url(server.url("/test")).build()).execute()
             val recorded = server.takeRequest()
             assertNull(recorded.getHeader("trakt-api-key"))
@@ -69,8 +70,22 @@ class NetworkModuleTest {
 
         @Test
         fun `does not apply certificate pinning`() {
-            val client = NetworkModule.provideOkHttpClient(isDebug = false, traktClientId = "test-id")
+            val client = NetworkModule.provideOkHttpClient(traktClientId = "test-id")
             assertTrue(client.certificatePinner.pins.isEmpty())
+        }
+
+        @Test
+        fun `logging interceptor level matches BuildConfig DEBUG`() {
+            val client = NetworkModule.provideOkHttpClient(traktClientId = "test-id")
+            val loggingInterceptor = client.interceptors
+                .filterIsInstance<HttpLoggingInterceptor>()
+                .firstOrNull()
+            assertNotNull(loggingInterceptor, "HttpLoggingInterceptor should be present")
+            val expectedLevel = if (com.justb81.watchbuddy.core.BuildConfig.DEBUG)
+                HttpLoggingInterceptor.Level.BODY
+            else
+                HttpLoggingInterceptor.Level.NONE
+            assertEquals(expectedLevel, loggingInterceptor!!.level)
         }
     }
 


### PR DESCRIPTION
## Summary

- Enable `buildConfig = true` in `core/build.gradle.kts` so `BuildConfig.DEBUG` is available in the core module
- Replace `@Named("isDebugBuild") isDebug: Boolean` parameter in `NetworkModule.provideOkHttpClient` with `com.justb81.watchbuddy.core.BuildConfig.DEBUG` directly
- Remove the `@Provides @Named("isDebugBuild")` provider from both `app-phone/di/AppModule.kt` and `app-tv/di/AppModule.kt`
- Fix German-language comment in `app-tv/di/AppModule.kt` (CLAUDE.md requires English throughout)
- Update `NetworkModuleTest` to remove the now-gone `isDebug` parameter and add a test verifying the logging interceptor level matches `BuildConfig.DEBUG`

Closes #280