### PR TITLE
chore(tv): deduplicate TvScrobbleDispatcher start/pause/stop methods

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
@@ -6,10 +6,14 @@ import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher
 import com.justb81.watchbuddy.tv.discovery.DiscoveryConstants
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
+import com.justb81.watchbuddy.tv.discovery.PhoneApiService
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import com.justb81.watchbuddy.tv.discovery.PhoneScrobbleRequest
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -30,6 +34,8 @@ class TvScrobbleDispatcher @Inject constructor(
         private const val TAG = "TvScrobbleDispatcher"
     }
 
+    internal enum class ScrobbleAction { START, PAUSE, STOP }
+
     private fun availablePhones(): List<PhoneDiscoveryManager.DiscoveredPhone> {
         val now = System.currentTimeMillis()
         return phoneDiscovery.discoveredPhones.value
@@ -37,10 +43,15 @@ class TvScrobbleDispatcher @Inject constructor(
             .filter { now - it.lastSuccessfulCheck < DiscoveryConstants.PRESENCE_STALENESS_MS }
     }
 
-    override suspend fun dispatchStart(show: TraktShow, episode: TraktEpisode, progress: Float) {
+    private suspend fun dispatch(
+        action: ScrobbleAction,
+        show: TraktShow,
+        episode: TraktEpisode,
+        progress: Float,
+    ) {
         val phones = availablePhones()
         if (phones.isEmpty()) {
-            Log.w(TAG, "No phones available — scrobble start skipped")
+            Log.w(TAG, "No phones available — scrobble ${action.name.lowercase()} skipped")
             return
         }
         val request = PhoneScrobbleRequest(show = show, episode = episode, progress = progress)
@@ -48,49 +59,39 @@ class TvScrobbleDispatcher @Inject constructor(
             phones.forEach { phone ->
                 launch {
                     try {
-                        phoneApiClientFactory.createClient(phone.baseUrl).scrobbleStart(request)
-                        Log.i(TAG, "Scrobble start via ${phone.baseUrl}: ${show.title} S${episode.season}E${episode.number}")
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Scrobble start failed for ${phone.baseUrl}", e)
+                        val client = phoneApiClientFactory.createClient(phone.baseUrl)
+                        when (action) {
+                            ScrobbleAction.START -> {
+                                client.scrobbleStart(request)
+                                Log.i(TAG, "Scrobble start via ${phone.baseUrl}: ${show.title} S${episode.season}E${episode.number}")
+                            }
+                            ScrobbleAction.PAUSE -> {
+                                client.scrobblePause(request)
+                                Log.i(TAG, "Scrobble pause via ${phone.baseUrl}: ${show.title}")
+                            }
+                            ScrobbleAction.STOP -> {
+                                client.scrobbleStop(request)
+                                Log.i(TAG, "Scrobble stop via ${phone.baseUrl}: ${show.title} S${episode.season}E${episode.number}")
+                            }
+                        }
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: IOException) {
+                        Log.e(TAG, "Scrobble ${action.name.lowercase()} failed for ${phone.baseUrl}", e)
+                    } catch (e: HttpException) {
+                        Log.e(TAG, "Scrobble ${action.name.lowercase()} HTTP error for ${phone.baseUrl}: ${e.code()}", e)
                     }
                 }
             }
         }
     }
 
-    override suspend fun dispatchPause(show: TraktShow, episode: TraktEpisode, progress: Float) {
-        val phones = availablePhones()
-        if (phones.isEmpty()) return
-        val request = PhoneScrobbleRequest(show = show, episode = episode, progress = progress)
-        coroutineScope {
-            phones.forEach { phone ->
-                launch {
-                    try {
-                        phoneApiClientFactory.createClient(phone.baseUrl).scrobblePause(request)
-                        Log.i(TAG, "Scrobble pause via ${phone.baseUrl}: ${show.title}")
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Scrobble pause failed for ${phone.baseUrl}", e)
-                    }
-                }
-            }
-        }
-    }
+    override suspend fun dispatchStart(show: TraktShow, episode: TraktEpisode, progress: Float) =
+        dispatch(ScrobbleAction.START, show, episode, progress)
 
-    override suspend fun dispatchStop(show: TraktShow, episode: TraktEpisode, progress: Float) {
-        val phones = availablePhones()
-        if (phones.isEmpty()) return
-        val request = PhoneScrobbleRequest(show = show, episode = episode, progress = progress)
-        coroutineScope {
-            phones.forEach { phone ->
-                launch {
-                    try {
-                        phoneApiClientFactory.createClient(phone.baseUrl).scrobbleStop(request)
-                        Log.i(TAG, "Scrobble stop via ${phone.baseUrl}: ${show.title} S${episode.season}E${episode.number}")
-                    } catch (e: Exception) {
-                        Log.e(TAG, "Scrobble stop failed for ${phone.baseUrl}", e)
-                    }
-                }
-            }
-        }
-    }
+    override suspend fun dispatchPause(show: TraktShow, episode: TraktEpisode, progress: Float) =
+        dispatch(ScrobbleAction.PAUSE, show, episode, progress)
+
+    override suspend fun dispatchStop(show: TraktShow, episode: TraktEpisode, progress: Float) =
+        dispatch(ScrobbleAction.STOP, show, episode, progress)
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import java.io.IOException
 
 @DisplayName("TvScrobbleDispatcher")
 class TvScrobbleDispatcherTest {
@@ -161,7 +162,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `failure on one phone does not prevent dispatch to others`() = runTest {
+        fun `IOException on one phone does not prevent dispatch to others`() = runTest {
             val apiService1: PhoneApiService = mockk()
             val apiService2: PhoneApiService = mockk()
             val phone1 = makePhone(baseUrl = "http://phone1:8765/", name = "phone1")
@@ -169,10 +170,10 @@ class TvScrobbleDispatcherTest {
             phonesFlow.value = listOf(phone1, phone2)
             coEvery { phoneApiClientFactory.createClient("http://phone1:8765/") } returns apiService1
             coEvery { phoneApiClientFactory.createClient("http://phone2:8765/") } returns apiService2
-            coEvery { apiService1.scrobbleStart(any()) } throws RuntimeException("network error")
+            coEvery { apiService1.scrobbleStart(any()) } throws IOException("connection refused")
             coEvery { apiService2.scrobbleStart(any()) } returns mockk()
 
-            // Should not throw even when one phone fails.
+            // Should not throw even when one phone fails with IOException.
             dispatcher.dispatchStart(
                 TestFixtures.traktShow(),
                 TestFixtures.traktEpisode(),
@@ -180,6 +181,93 @@ class TvScrobbleDispatcherTest {
             )
 
             coVerify { apiService2.scrobbleStart(any()) }
+        }
+    }
+
+    // ── action routing ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("action routing")
+    inner class ActionRoutingTest {
+
+        @Test
+        fun `dispatchPause calls scrobblePause on available phones`() = runTest {
+            val phone = makePhone()
+            phonesFlow.value = listOf(phone)
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobblePause(any()) } returns mockk()
+
+            dispatcher.dispatchPause(
+                TestFixtures.traktShow(),
+                TestFixtures.traktEpisode(),
+                50f
+            )
+
+            coVerify { phoneApiService.scrobblePause(any()) }
+            coVerify(exactly = 0) { phoneApiService.scrobbleStart(any()) }
+            coVerify(exactly = 0) { phoneApiService.scrobbleStop(any()) }
+        }
+
+        @Test
+        fun `dispatchStop calls scrobbleStop on available phones`() = runTest {
+            val phone = makePhone()
+            phonesFlow.value = listOf(phone)
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobbleStop(any()) } returns mockk()
+
+            dispatcher.dispatchStop(
+                TestFixtures.traktShow(),
+                TestFixtures.traktEpisode(),
+                90f
+            )
+
+            coVerify { phoneApiService.scrobbleStop(any()) }
+            coVerify(exactly = 0) { phoneApiService.scrobbleStart(any()) }
+            coVerify(exactly = 0) { phoneApiService.scrobblePause(any()) }
+        }
+
+        @Test
+        fun `dispatchPause skips dispatch when phone list is empty`() = runTest {
+            phonesFlow.value = emptyList()
+
+            dispatcher.dispatchPause(
+                TestFixtures.traktShow(),
+                TestFixtures.traktEpisode(),
+                50f
+            )
+
+            coVerify(exactly = 0) { phoneApiClientFactory.createClient(any()) }
+        }
+
+        @Test
+        fun `dispatchStop skips dispatch when phone list is empty`() = runTest {
+            phonesFlow.value = emptyList()
+
+            dispatcher.dispatchStop(
+                TestFixtures.traktShow(),
+                TestFixtures.traktEpisode(),
+                90f
+            )
+
+            coVerify(exactly = 0) { phoneApiClientFactory.createClient(any()) }
+        }
+
+        @Test
+        fun `dispatchStart calls scrobbleStart not pause or stop`() = runTest {
+            val phone = makePhone()
+            phonesFlow.value = listOf(phone)
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobbleStart(any()) } returns mockk()
+
+            dispatcher.dispatchStart(
+                TestFixtures.traktShow(),
+                TestFixtures.traktEpisode(),
+                10f
+            )
+
+            coVerify { phoneApiService.scrobbleStart(any()) }
+            coVerify(exactly = 0) { phoneApiService.scrobblePause(any()) }
+            coVerify(exactly = 0) { phoneApiService.scrobbleStop(any()) }
         }
     }
 }


### PR DESCRIPTION
## Summary

- Introduce `internal enum class ScrobbleAction { START, PAUSE, STOP }` in `TvScrobbleDispatcher`
- Replace the three near-identical `dispatchStart`/`dispatchPause`/`dispatchStop` method bodies with a single private `dispatch()` helper that uses a `when (action)` to call the correct `PhoneApiService` endpoint
- Public `dispatchStart`/`dispatchPause`/`dispatchStop` become one-line delegates to `dispatch()`
- Narrow broad `catch (e: Exception)` to `catch (e: IOException)` and `catch (e: HttpException)` with explicit `CancellationException` re-throw so coroutine cancellation is never silently swallowed
- Add action-routing unit tests for `dispatchPause` and `dispatchStop` verifying correct endpoint dispatch and isolation from other actions
- Update the failure-isolation test to use `IOException` (matching the narrowed handler) instead of `RuntimeException`

Closes #276

## Test plan

- [x] `./gradlew :app-tv:testDebugUnitTest` passes with new action-routing tests
- [x] Existing staleness-filtering tests continue to pass unchanged
- [x] `IOException` on one phone does not prevent scrobbling to other phones (isolation test updated)
- [x] `dispatchPause` and `dispatchStop` verified to call only their respective endpoints

https://claude.ai/code/session_019PGET8TD7YVHVKU6dYLNpc