### PR TITLE
chore(phone): remove defensive empty-flow exception handling in HomeViewModel (#283)

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
@@ -18,8 +18,10 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -61,12 +63,25 @@ class HomeViewModel @Inject constructor(
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     init {
+        assertTokenAccessible()
         observeShows()
         loadShows()
         checkServiceConnections()
         observeCompanionState()
         observeScrobbleEvents()
         observeWifiState()
+    }
+
+    private fun assertTokenAccessible() {
+        runCatching { tokenRepository.getAccessToken() }
+            .onFailure { e ->
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = getApplication<Application>().getString(R.string.home_sync_failed, e.message)
+                    )
+                }
+            }
     }
 
     private fun observeShows() {
@@ -96,18 +111,19 @@ class HomeViewModel @Inject constructor(
 
     private fun observeCompanionState() {
         viewModelScope.launch {
-            val settingsFlow = try {
-                settingsRepository.settings
-            } catch (_: Exception) {
-                flowOf()
-            }
-            settingsFlow.collect { settings ->
-                val wasWatching = _uiState.value.isWatchingTv
-                _uiState.update { it.copy(isWatchingTv = settings.companionEnabled) }
-                if (settings.companionEnabled && !wasWatching) {
-                    CompanionService.start(getApplication<Application>())
+            flow { emitAll(settingsRepository.settings) }
+                .catch { e ->
+                    _uiState.update {
+                        it.copy(error = getApplication<Application>().getString(R.string.home_sync_failed, e.message))
+                    }
                 }
-            }
+                .collect { settings ->
+                    val wasWatching = _uiState.value.isWatchingTv
+                    _uiState.update { it.copy(isWatchingTv = settings.companionEnabled) }
+                    if (settings.companionEnabled && !wasWatching) {
+                        CompanionService.start(getApplication<Application>())
+                    }
+                }
         }
     }
 
@@ -158,8 +174,6 @@ class HomeViewModel @Inject constructor(
             try {
                 val token = tokenRepository.getAccessToken()
                     ?: throw IllegalStateException("No access token available")
-                // Touch token to surface keystore exceptions here so catch translates them into UI error.
-                @Suppress("UNUSED_VARIABLE") val _t = token
                 showRepository.getShows() // Result flows into observeShows() via StateFlow.
                 _uiState.update {
                     it.copy(

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModelTest.kt
@@ -18,6 +18,7 @@ import okhttp3.ResponseBody
 import retrofit2.HttpException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -291,6 +292,33 @@ class HomeViewModelTest {
             advanceUntilIdle()
 
             assertNotNull(vm)
+        }
+    }
+
+    @Nested
+    @DisplayName("observeCompanionState error handling")
+    inner class CompanionStateErrorTest {
+
+        @Test
+        fun `sets error when settings property throws on access`() = runTest {
+            every { settingsRepository.settings } throws RuntimeException("Settings unavailable")
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertNotNull(vm.uiState.value.error)
+        }
+
+        @Test
+        fun `sets error when settings flow emits error during collection`() = runTest {
+            every { settingsRepository.settings } returns flow {
+                throw RuntimeException("DataStore corrupted")
+            }
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            assertNotNull(vm.uiState.value.error)
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #283.

- Replace the silent `flowOf()` fallback in `observeCompanionState()` with a `flow { emitAll(...) }.catch { }` pipeline that surfaces exceptions in `HomeUiState.error` instead of swallowing them
- Add `assertTokenAccessible()` called synchronously from `init` to explicitly map Keystore failures to a UI error state, replacing the fragile `@Suppress("UNUSED_VARIABLE") val _t = token` token-touch trick in `loadShows()`
- Remove `import kotlinx.coroutines.flow.flowOf` (no longer used); add `flow`, `emitAll`, and `catch` imports

## Test plan

- [ ] Existing `HomeViewModelTest` suite passes — all `LoadShowsTest`, `SyncTest`, `InitResilience`, `CompanionServiceTest`, and `WifiGate` cases unaffected
- [ ] New `CompanionStateErrorTest.sets error when settings property throws on access` — verifies the `flow { emitAll(...) }` wrapper catches property-access exceptions and maps them to `uiState.error`
- [ ] New `CompanionStateErrorTest.sets error when settings flow emits error during collection` — verifies the `.catch {}` operator catches collection-time exceptions and maps them to `uiState.error`
- [ ] `./gradlew :app-phone:testDebugUnitTest` passes locally

https://claude.ai/code/session_01XB1CvM3p26r3YU6irkM7cd