### PR TITLE
chore(tv): replace reflection-based test access with @VisibleForTesting helpers (#285)

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiClientFactory.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiClientFactory.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.tv.discovery
 
+import androidx.annotation.VisibleForTesting
 import com.justb81.watchbuddy.core.network.WatchBuddyJson
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
@@ -23,4 +24,7 @@ class PhoneApiClientFactory @Inject constructor(
                 .build()
                 .create(PhoneApiService::class.java)
         }
+
+    @VisibleForTesting
+    internal fun cacheSize(): Int = cache.size
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -9,6 +9,7 @@ import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import android.net.wifi.WifiManager
 import android.util.Log
+import androidx.annotation.VisibleForTesting
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.model.LlmBackend
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -415,7 +416,8 @@ class PhoneDiscoveryManager @Inject constructor(
      * it, and silent returns were observed to mask the root cause in the
      * field (see #259).
      */
-    private fun parseTxtRecord(serviceInfo: NsdServiceInfo): PhoneTxtRecord? {
+    @VisibleForTesting
+    internal fun parseTxtRecord(serviceInfo: NsdServiceInfo): PhoneTxtRecord? {
         return try {
             val attrs = serviceInfo.attributes ?: emptyMap()
             val decoded = attrs.mapValues { (_, v) ->
@@ -459,6 +461,11 @@ class PhoneDiscoveryManager @Inject constructor(
             Log.w(TAG, "parseTxtRecord: unexpected error", e)
             null
         }
+    }
+
+    @VisibleForTesting
+    internal fun setDiscoveredPhonesForTest(phones: List<DiscoveredPhone>) {
+        _discoveredPhones.value = phones
     }
 
     private fun addOrUpdatePhone(phone: DiscoveredPhone) {
@@ -527,7 +534,8 @@ class PhoneDiscoveryManager @Inject constructor(
      * When only TXT records are available (capability fetch failed), modelQuality from
      * TXT records is used directly with no RAM bonus.
      */
-    private fun calculateScore(txt: PhoneTxtRecord?, cap: DeviceCapability?): Int {
+    @VisibleForTesting
+    internal fun calculateScore(txt: PhoneTxtRecord?, cap: DeviceCapability?): Int {
         if (cap != null) {
             val ramBonus = when {
                 cap.freeRamMb >= 6_000 -> 10

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneApiClientFactoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneApiClientFactoryTest.kt
@@ -1,6 +1,5 @@
 package com.justb81.watchbuddy.tv.discovery
 
-import io.mockk.mockk
 import okhttp3.OkHttpClient
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -43,11 +42,6 @@ class PhoneApiClientFactoryTest {
         factory.createClient("http://host1:8765/")
         factory.createClient("http://host2:8765/")
         factory.createClient("http://host1:8765/")
-        // Verify cache via accessing the private field
-        val cacheField = PhoneApiClientFactory::class.java.getDeclaredField("cache")
-        cacheField.isAccessible = true
-        @Suppress("UNCHECKED_CAST")
-        val cache = cacheField.get(factory) as Map<String, PhoneApiService>
-        assertEquals(2, cache.size)
+        assertEquals(2, factory.cacheSize())
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
@@ -64,11 +64,7 @@ class PhoneDiscoveryManagerTest {
     inner class GetBestPhoneTest {
 
         private fun setPhones(vararg phones: PhoneDiscoveryManager.DiscoveredPhone) {
-            val field = PhoneDiscoveryManager::class.java.getDeclaredField("_discoveredPhones")
-            field.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            val flow = field.get(manager) as kotlinx.coroutines.flow.MutableStateFlow<List<PhoneDiscoveryManager.DiscoveredPhone>>
-            flow.value = phones.toList()
+            manager.setDiscoveredPhonesForTest(phones.toList())
         }
 
         @Test
@@ -138,15 +134,7 @@ class PhoneDiscoveryManagerTest {
         private fun calculateScore(
             txt: PhoneDiscoveryManager.PhoneTxtRecord?,
             cap: DeviceCapability?
-        ): Int {
-            val method = PhoneDiscoveryManager::class.java.getDeclaredMethod(
-                "calculateScore",
-                PhoneDiscoveryManager.PhoneTxtRecord::class.java,
-                DeviceCapability::class.java
-            )
-            method.isAccessible = true
-            return method.invoke(manager, txt, cap) as Int
-        }
+        ): Int = manager.calculateScore(txt, cap)
 
         @Test
         fun `returns 0 when both txt and capability are null`() {
@@ -209,14 +197,8 @@ class PhoneDiscoveryManagerTest {
     @DisplayName("parseTxtRecord")
     inner class ParseTxtRecordTest {
 
-        private fun parseTxtRecord(serviceInfo: NsdServiceInfo): PhoneDiscoveryManager.PhoneTxtRecord? {
-            val method = PhoneDiscoveryManager::class.java.getDeclaredMethod(
-                "parseTxtRecord", NsdServiceInfo::class.java
-            )
-            method.isAccessible = true
-            @Suppress("UNCHECKED_CAST")
-            return method.invoke(manager, serviceInfo) as PhoneDiscoveryManager.PhoneTxtRecord?
-        }
+        private fun parseTxtRecord(serviceInfo: NsdServiceInfo): PhoneDiscoveryManager.PhoneTxtRecord? =
+            manager.parseTxtRecord(serviceInfo)
 
         private fun mockServiceInfo(attrs: Map<String, ByteArray>): NsdServiceInfo {
             val info = mockk<NsdServiceInfo>()


### PR DESCRIPTION
## Summary

Closes #285.

- Mark `calculateScore` and `parseTxtRecord` in `PhoneDiscoveryManager` as `internal` with `@VisibleForTesting`, so tests can call them without reflection
- Add `setDiscoveredPhonesForTest(phones: List<DiscoveredPhone>)` helper to `PhoneDiscoveryManager` to write `_discoveredPhones` without reflection
- Add `cacheSize(): Int` helper to `PhoneApiClientFactory` to inspect the cache size without reflection
- Remove all `getDeclaredField` / `getDeclaredMethod` / `isAccessible = true` reflection calls from `PhoneDiscoveryManagerTest` and `PhoneApiClientFactoryTest`
- Remove unused `io.mockk.mockk` import from `PhoneApiClientFactoryTest`

## Test plan

- [ ] `./gradlew :app-tv:testDebugUnitTest` — all existing tests pass with no reflection in the test code
- [ ] Rename `calculateScore` in `PhoneDiscoveryManager`; verify the test fails to compile (not silently at runtime) — confirms the reflection coupling is gone

https://claude.ai/code/session_01UzhiMwkmy5HAqeGPkLybyP