### PR TITLE
chore(phone): simplify OnboardingViewModel HTTP error when-block (#293)

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
@@ -2,7 +2,6 @@ package com.justb81.watchbuddy.phone.ui.onboarding
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.network.TokenProxyServiceFactory
@@ -18,8 +17,6 @@ import com.justb81.watchbuddy.phone.ui.settings.AuthMode
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
-import com.justb81.watchbuddy.core.network.WatchBuddyJson
-import kotlinx.serialization.encodeToString
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -63,7 +60,6 @@ sealed class OnboardingState {
 @HiltViewModel
 class OnboardingViewModel @Inject constructor(
     application: Application,
-    private val savedStateHandle: SavedStateHandle,
     private val traktApi: TraktApiService,
     private val tokenProxy: TokenProxyService?,
     @param:Named("traktClientId") private val buildConfigClientId: String,
@@ -78,33 +74,23 @@ class OnboardingViewModel @Inject constructor(
     private var countdownJob: Job? = null
     private var pollingJob: Job? = null
 
-    private fun saveDeviceCodeToState(response: DeviceCodeResponse) {
-        savedStateHandle[KEY_DEVICE_CODE_JSON] = WatchBuddyJson.encodeToString(response)
-        savedStateHandle[KEY_DEVICE_CODE_TIMESTAMP] = System.currentTimeMillis()
-    }
+    // Holds the active device code for the current OAuth session within this process lifetime.
+    // Not persisted across process death; if the process is killed, the user restarts OAuth.
+    private var currentDeviceCode: DeviceCodeResponse? = null
 
-    private fun restoreDeviceCodeFromState(): DeviceCodeResponse? {
-        val jsonStr = savedStateHandle.get<String>(KEY_DEVICE_CODE_JSON) ?: return null
-        val timestamp = savedStateHandle.get<Long>(KEY_DEVICE_CODE_TIMESTAMP) ?: return null
-        return try {
-            val response = WatchBuddyJson.decodeFromString<DeviceCodeResponse>(jsonStr)
-            val elapsedSeconds = ((System.currentTimeMillis() - timestamp) / 1000).toInt()
-            val remainingSeconds = response.expires_in - elapsedSeconds
-            if (remainingSeconds > 0) {
-                response.copy(expires_in = remainingSeconds)
-            } else {
-                clearSavedDeviceCode()
-                null
-            }
-        } catch (_: Exception) {
-            clearSavedDeviceCode()
-            null
-        }
-    }
+    // Terminal polling errors keyed by HTTP status code.
+    private val httpErrorMessages = mapOf(
+        401 to R.string.onboarding_error_auth_failed,
+        403 to R.string.onboarding_error_auth_failed,
+        409 to R.string.onboarding_code_expired,
+        410 to R.string.onboarding_code_expired,
+        418 to R.string.onboarding_error_denied,
+    )
 
-    private fun clearSavedDeviceCode() {
-        savedStateHandle.remove<String>(KEY_DEVICE_CODE_JSON)
-        savedStateHandle.remove<Long>(KEY_DEVICE_CODE_TIMESTAMP)
+    private fun failPolling(message: String) {
+        countdownJob?.cancel()
+        currentDeviceCode = null
+        _state.value = OnboardingState.Error(message)
     }
 
     /**
@@ -155,12 +141,9 @@ class OnboardingViewModel @Inject constructor(
                     return@launch
                 }
 
-                val restored = restoreDeviceCodeFromState()
-                val response = if (restored != null) {
-                    restored
-                } else {
+                val response = currentDeviceCode ?: run {
                     val fresh = traktApi.requestDeviceCode(DeviceCodeRequest(clientId))
-                    saveDeviceCodeToState(fresh)
+                    currentDeviceCode = fresh
                     fresh
                 }
 
@@ -190,7 +173,7 @@ class OnboardingViewModel @Inject constructor(
                 delay(1_000)
                 remaining--
             }
-            clearSavedDeviceCode()
+            currentDeviceCode = null
             _state.value = OnboardingState.Error(
                 getApplication<Application>().getString(R.string.onboarding_code_expired)
             )
@@ -255,28 +238,15 @@ class OnboardingViewModel @Inject constructor(
                     )
                     val profile = traktApi.getProfile("Bearer $accessToken")
                     countdownJob?.cancel()
-                    clearSavedDeviceCode()
+                    currentDeviceCode = null
                     _state.value = OnboardingState.Success(profile.username)
                     return@launch
                 } catch (e: Exception) {
                     val httpCode = (e as? HttpException)?.code()
                     when (httpCode) {
-                        400 -> {
-                            // Pending — user hasn't authorized yet, keep polling
-                            consecutiveNetworkFailures = 0
-                        }
-                        401, 403 -> {
-                            // Auth failure — invalid client ID / revoked credentials
-                            countdownJob?.cancel()
-                            clearSavedDeviceCode()
-                            _state.value = OnboardingState.Error(
-                                getApplication<Application>().getString(R.string.onboarding_error_auth_failed)
-                            )
-                            return@launch
-                        }
+                        400 -> consecutiveNetworkFailures = 0
+                        429 -> delay(response.interval * 1_000L)
                         503 -> {
-                            countdownJob?.cancel()
-                            clearSavedDeviceCode()
                             val msg = if ((e as? HttpException)?.isServerMisconfigured() == true) {
                                 getApplication<Application>().getString(
                                     R.string.onboarding_error_server_misconfigured
@@ -286,46 +256,18 @@ class OnboardingViewModel @Inject constructor(
                                     R.string.onboarding_error_polling_network
                                 )
                             }
-                            _state.value = OnboardingState.Error(msg)
+                            failPolling(msg)
                             return@launch
-                        }
-                        410 -> {
-                            // Expired — stop immediately
-                            countdownJob?.cancel()
-                            clearSavedDeviceCode()
-                            _state.value = OnboardingState.Error(
-                                getApplication<Application>().getString(R.string.onboarding_code_expired)
-                            )
-                            return@launch
-                        }
-                        418 -> {
-                            // Denied — user explicitly refused
-                            countdownJob?.cancel()
-                            clearSavedDeviceCode()
-                            _state.value = OnboardingState.Error(
-                                getApplication<Application>().getString(R.string.onboarding_error_denied)
-                            )
-                            return@launch
-                        }
-                        409 -> {
-                            // Already used — code was consumed elsewhere
-                            countdownJob?.cancel()
-                            clearSavedDeviceCode()
-                            _state.value = OnboardingState.Error(
-                                getApplication<Application>().getString(R.string.onboarding_code_expired)
-                            )
-                            return@launch
-                        }
-                        429 -> {
-                            // Slow down — increase delay, don't count as failure
-                            delay(response.interval * 1_000L)
                         }
                         else -> {
+                            val errorRes = httpErrorMessages[httpCode]
+                            if (errorRes != null) {
+                                failPolling(getApplication<Application>().getString(errorRes))
+                                return@launch
+                            }
                             consecutiveNetworkFailures++
                             if (consecutiveNetworkFailures >= 3) {
-                                countdownJob?.cancel()
-                                clearSavedDeviceCode()
-                                _state.value = OnboardingState.Error(
+                                failPolling(
                                     getApplication<Application>().getString(
                                         R.string.onboarding_error_polling_network
                                     )
@@ -338,10 +280,5 @@ class OnboardingViewModel @Inject constructor(
                 attempts++
             }
         }
-    }
-
-    private companion object {
-        const val KEY_DEVICE_CODE_JSON = "device_code_json"
-        const val KEY_DEVICE_CODE_TIMESTAMP = "device_code_timestamp"
     }
 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelRetryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelRetryTest.kt
@@ -1,7 +1,6 @@
 package com.justb81.watchbuddy.phone.ui.onboarding
 
 import android.app.Application
-import androidx.lifecycle.SavedStateHandle
 import com.justb81.watchbuddy.core.network.TokenProxyServiceFactory
 import com.justb81.watchbuddy.core.trakt.DeviceCodeResponse
 import com.justb81.watchbuddy.core.trakt.ProxyTokenResponse
@@ -78,7 +77,6 @@ class OnboardingViewModelRetryTest {
 
     private fun createViewModel() = OnboardingViewModel(
         application = application,
-        savedStateHandle = SavedStateHandle(),
         traktApi = traktApi,
         tokenProxy = tokenProxy,
         buildConfigClientId = BUILD_CLIENT_ID,

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelTest.kt
@@ -1,7 +1,6 @@
 package com.justb81.watchbuddy.phone.ui.onboarding
 
 import android.app.Application
-import androidx.lifecycle.SavedStateHandle
 import com.justb81.watchbuddy.core.network.TokenProxyServiceFactory
 import com.justb81.watchbuddy.core.trakt.DeviceCodeResponse
 import com.justb81.watchbuddy.core.trakt.DeviceTokenResponse
@@ -20,8 +19,6 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
@@ -72,10 +69,8 @@ class OnboardingViewModelTest {
     private fun createViewModel(
         buildClientId: String = BUILD_CLIENT_ID,
         proxy: TokenProxyService? = tokenProxy,
-        savedStateHandle: SavedStateHandle = SavedStateHandle()
     ): OnboardingViewModel = OnboardingViewModel(
         application = application,
-        savedStateHandle = savedStateHandle,
         traktApi = traktApi,
         tokenProxy = proxy,
         buildConfigClientId = buildClientId,
@@ -361,6 +356,57 @@ class OnboardingViewModelTest {
         }
 
         @Test
+        fun `shows Error immediately on HTTP 410 during polling`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+            coEvery { tokenProxy.exchangeDeviceCode(any()) } throws
+                HttpException(Response.error<Any>(410, "".toResponseBody()))
+            every { application.getString(any<Int>()) } returns "Expired"
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            assertTrue(vm.state.value is OnboardingState.Error)
+        }
+
+        @Test
+        fun `shows Error immediately on HTTP 418 during polling`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+            coEvery { tokenProxy.exchangeDeviceCode(any()) } throws
+                HttpException(Response.error<Any>(418, "".toResponseBody()))
+            every { application.getString(any<Int>()) } returns "Denied"
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            assertTrue(vm.state.value is OnboardingState.Error)
+        }
+
+        @Test
+        fun `shows Error immediately on HTTP 409 during polling`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+            coEvery { tokenProxy.exchangeDeviceCode(any()) } throws
+                HttpException(Response.error<Any>(409, "".toResponseBody()))
+            every { application.getString(any<Int>()) } returns "Expired"
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            assertTrue(vm.state.value is OnboardingState.Error)
+        }
+
+        @Test
         fun `shows Error after 3 consecutive network failures during polling`() = runTest {
             every { settingsRepository.settings } returns flowOf(
                 AppSettings(authMode = AuthMode.MANAGED)
@@ -435,57 +481,55 @@ class OnboardingViewModelTest {
     }
 
     @Nested
-    @DisplayName("Process death survival")
-    inner class ProcessDeathSurvival {
-
-        private val json = Json { ignoreUnknownKeys = true }
-
-        private fun savedStateWithCode(
-            response: DeviceCodeResponse = deviceCodeResponse,
-            timestamp: Long = System.currentTimeMillis()
-        ): SavedStateHandle = SavedStateHandle(
-            mapOf(
-                "device_code_json" to json.encodeToString(response),
-                "device_code_timestamp" to timestamp
-            )
-        )
+    @DisplayName("Device code in-memory caching")
+    inner class DeviceCodeCaching {
 
         @Test
-        fun `restores saved device code instead of requesting a new one`() = runTest {
+        fun `reuses in-memory device code on second requestDeviceCode call within same session`() = runTest {
             every { settingsRepository.settings } returns flowOf(
                 AppSettings(authMode = AuthMode.MANAGED)
             )
             coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
 
-            val handle = savedStateWithCode()
-            val vm = createViewModel(savedStateHandle = handle)
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            // State is WaitingForPin; code is cached in currentDeviceCode
+
+            // Second call must NOT re-fetch a new device code
             vm.requestDeviceCode()
 
-            val state = vm.state.value
-            assertTrue(state is OnboardingState.WaitingForPin)
-            assertEquals("ABC123", (state as OnboardingState.WaitingForPin).userCode)
-            coVerify(exactly = 0) { traktApi.requestDeviceCode(any()) }
-        }
-
-        @Test
-        fun `requests new code when saved code has expired`() = runTest {
-            every { settingsRepository.settings } returns flowOf(
-                AppSettings(authMode = AuthMode.MANAGED)
-            )
-            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
-
-            val expiredTimestamp = System.currentTimeMillis() - 700_000L // 700s ago, code was 600s
-            val handle = savedStateWithCode(timestamp = expiredTimestamp)
-            val vm = createViewModel(savedStateHandle = handle)
-            vm.requestDeviceCode()
-
-            val state = vm.state.value
-            assertTrue(state is OnboardingState.WaitingForPin)
             coVerify(exactly = 1) { traktApi.requestDeviceCode(any()) }
+            assertTrue(vm.state.value is OnboardingState.WaitingForPin || vm.state.value is OnboardingState.LoadingCode)
         }
 
         @Test
-        fun `clears saved state on successful authentication`() = runTest {
+        fun `fetches new device code after terminal polling failure clears the cached code`() = runTest {
+            every { settingsRepository.settings } returns flowOf(
+                AppSettings(authMode = AuthMode.MANAGED)
+            )
+            coEvery { traktApi.requestDeviceCode(any()) } returns deviceCodeResponse
+            coEvery { tokenProxy.exchangeDeviceCode(any()) } throws
+                HttpException(Response.error<Any>(410, "".toResponseBody()))
+            every { application.getString(any<Int>()) } returns "Expired"
+
+            val vm = createViewModel()
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            // After 410 failPolling clears currentDeviceCode
+            assertTrue(vm.state.value is OnboardingState.Error)
+
+            // Retry must request a fresh code
+            coEvery { tokenProxy.exchangeDeviceCode(any()) } throws
+                HttpException(Response.error<Any>(400, "".toResponseBody()))
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            coVerify(exactly = 2) { traktApi.requestDeviceCode(any()) }
+        }
+
+        @Test
+        fun `clears cached device code on successful authentication`() = runTest {
             every { settingsRepository.settings } returns flowOf(
                 AppSettings(authMode = AuthMode.MANAGED)
             )
@@ -499,14 +543,19 @@ class OnboardingViewModelTest {
             )
             coEvery { traktApi.getProfile(any()) } returns TraktUserProfile(username = "user1")
 
-            val handle = SavedStateHandle()
-            val vm = createViewModel(savedStateHandle = handle)
+            val vm = createViewModel()
             vm.requestDeviceCode()
             advanceUntilIdle()
 
             assertTrue(vm.state.value is OnboardingState.Success)
-            assertNull(handle.get<String>("device_code_json"))
-            assertNull(handle.get<Long>("device_code_timestamp"))
+
+            // A fresh requestDeviceCode after success must fetch a new code, not reuse the old one
+            coEvery { tokenProxy.exchangeDeviceCode(any()) } throws
+                HttpException(Response.error<Any>(400, "".toResponseBody()))
+            vm.requestDeviceCode()
+            advanceUntilIdle()
+
+            coVerify(exactly = 2) { traktApi.requestDeviceCode(any()) }
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #293.

- Extract `failPolling(message)` helper that cancels the countdown job, clears the in-memory device code, and emits `Error` state — replacing ~4 sets of identical `cancel/clear/error` triplets scattered through the polling `when`-block
- Replace individual `when` branches for HTTP 401, 403, 409, 410, 418 with a single `httpErrorMessages` map lookup; the 400/429/503/`else` cases still need their own branches due to distinct control flow
- Remove `SavedStateHandle`-based `saveDeviceCodeToState` / `restoreDeviceCodeFromState` / `clearSavedDeviceCode`; store the active device code as `private var currentDeviceCode` instead — process-death survival for a 2-minute OAuth flow window is not worth the complexity, and polling is already tied to `viewModelScope`
- Remove unused dependencies: `savedStateHandle`, `WatchBuddyJson`, `encodeToString`

## Test plan

- [x] Remove `ProcessDeathSurvival` nested class (behaviour intentionally removed)
- [x] Add `DeviceCodeCaching` nested class:
  - `reuses in-memory device code on second requestDeviceCode call within same session` — verifies `traktApi.requestDeviceCode` called exactly once
  - `fetches new device code after terminal polling failure clears the cached code` — verifies 410 clears `currentDeviceCode` so a retry re-fetches
  - `clears cached device code on successful authentication` — verifies success path clears the cache
- [x] Add explicit tests for HTTP 409, 410, 418 terminal paths (previously implicit)
- [x] All existing `ManagedMode`, `SelfHostedMode`, `DirectMode`, `ErrorHandling`, `PollingErrorHandling` tests updated and passing
- [x] `OnboardingViewModelRetryTest` — updated `createViewModel()` to remove the now-unused `SavedStateHandle` parameter
- [x] `./gradlew :app-phone:testDebugUnitTest`

https://claude.ai/code/session_01R4Qtq8uQdidpDvULDJqEUF