### PR TITLE
chore(tv): scope ScrobbleViewModel.dismissedEpisodes and log streaming prefs errors (#298)

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModel.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.tv.ui.scrobble
 
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.core.model.ScrobbleCandidate
@@ -26,7 +27,8 @@ class ScrobbleViewModel @Inject constructor(
     private val _pendingCandidate = MutableStateFlow<ScrobbleCandidate?>(null)
     val pendingCandidate: StateFlow<ScrobbleCandidate?> = _pendingCandidate.asStateFlow()
 
-    private val dismissedEpisodes = mutableSetOf<String>()
+    @VisibleForTesting
+    internal val dismissedEpisodes = mutableSetOf<String>()
 
     init {
         viewModelScope.launch {
@@ -51,6 +53,11 @@ class ScrobbleViewModel @Inject constructor(
         val candidate = _pendingCandidate.value ?: return
         dismissedEpisodes.add(candidateKey(candidate))
         _pendingCandidate.value = null
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        dismissedEpisodes.clear()
     }
 
     private fun candidateKey(candidate: ScrobbleCandidate): String =

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsViewModel.kt
@@ -2,6 +2,7 @@ package com.justb81.watchbuddy.tv.ui.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.KNOWN_STREAMING_SERVICES
 import com.justb81.watchbuddy.core.model.StreamingService
 import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
@@ -24,6 +25,10 @@ class StreamingSettingsViewModel @Inject constructor(
     private val repository: StreamingPreferencesRepository
 ) : ViewModel() {
 
+    companion object {
+        private const val TAG = "StreamingSettingsViewModel"
+    }
+
     private val _uiState = MutableStateFlow(StreamingSettingsUiState())
     val uiState: StateFlow<StreamingSettingsUiState> = _uiState.asStateFlow()
 
@@ -32,7 +37,9 @@ class StreamingSettingsViewModel @Inject constructor(
      * flow doesn't force-close the TV Settings screen. Same pattern as the phone
      * SettingsViewModel in #224.
      */
-    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, _ -> }
+    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        DiagnosticLog.error(TAG, "streaming prefs write failed", throwable)
+    }
 
     private fun launchSafe(block: suspend CoroutineScope.() -> Unit): Job =
         viewModelScope.launch(coroutineExceptionHandler, block = block)
@@ -40,7 +47,7 @@ class StreamingSettingsViewModel @Inject constructor(
     init {
         launchSafe {
             repository.subscribedServiceIds
-                .catch { }
+                .catch { e -> DiagnosticLog.error(TAG, "streaming prefs observation failed", e) }
                 .collect { ids ->
                     _uiState.update {
                         it.copy(subscribedIds = ids.toSet(), orderedIds = ids)

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModelTest.kt
@@ -110,13 +110,19 @@ class ScrobbleViewModelTest {
     @DisplayName("DismissedEpisodesCleanup")
     inner class DismissedEpisodesCleanupTest {
 
+        private fun invokeOnCleared() {
+            val method = viewModel.javaClass.getDeclaredMethod("onCleared")
+            method.isAccessible = true
+            method.invoke(viewModel)
+        }
+
         @Test
         fun `dismissedEpisodes cleared on onCleared`() = runTest {
             pendingFlow.emit(testCandidate)
             viewModel.dismissScrobble()
             assertTrue(viewModel.dismissedEpisodes.isNotEmpty())
 
-            viewModel.onCleared()
+            invokeOnCleared()
 
             assertTrue(viewModel.dismissedEpisodes.isEmpty())
         }
@@ -134,7 +140,7 @@ class ScrobbleViewModelTest {
             }
             assertEquals(3, viewModel.dismissedEpisodes.size)
 
-            viewModel.onCleared()
+            invokeOnCleared()
 
             assertTrue(viewModel.dismissedEpisodes.isEmpty())
         }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModelTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -103,5 +104,39 @@ class ScrobbleViewModelTest {
         // Different episode should appear
         pendingFlow.emit(candidate2)
         assertNotNull(viewModel.pendingCandidate.value)
+    }
+
+    @Nested
+    @DisplayName("DismissedEpisodesCleanup")
+    inner class DismissedEpisodesCleanupTest {
+
+        @Test
+        fun `dismissedEpisodes cleared on onCleared`() = runTest {
+            pendingFlow.emit(testCandidate)
+            viewModel.dismissScrobble()
+            assertTrue(viewModel.dismissedEpisodes.isNotEmpty())
+
+            viewModel.onCleared()
+
+            assertTrue(viewModel.dismissedEpisodes.isEmpty())
+        }
+
+        @Test
+        fun `dismissing multiple episodes all cleared on onCleared`() = runTest {
+            val episodes = listOf(
+                testCandidate,
+                testCandidate.copy(matchedEpisode = TraktEpisode(season = 1, number = 2)),
+                testCandidate.copy(matchedEpisode = TraktEpisode(season = 2, number = 1)),
+            )
+            episodes.forEach { candidate ->
+                pendingFlow.emit(candidate)
+                viewModel.dismissScrobble()
+            }
+            assertEquals(3, viewModel.dismissedEpisodes.size)
+
+            viewModel.onCleared()
+
+            assertTrue(viewModel.dismissedEpisodes.isEmpty())
+        }
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsViewModelTest.kt
@@ -1,11 +1,15 @@
 package com.justb81.watchbuddy.tv.ui.settings
 
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.tv.MainDispatcherRule
 import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -28,9 +32,15 @@ class StreamingSettingsViewModelTest {
 
     @BeforeEach
     fun setUp() {
+        DiagnosticLog.clear()
         every { repository.subscribedServiceIds } returns flowOf(emptyList())
         coEvery { repository.setSubscribedServices(any()) } just runs
         viewModel = StreamingSettingsViewModel(repository)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        DiagnosticLog.clear()
     }
 
     @Nested
@@ -119,5 +129,45 @@ class StreamingSettingsViewModelTest {
         assertEquals(7, state.services.size) // KNOWN_STREAMING_SERVICES
         assertTrue(state.subscribedIds.isEmpty())
         assertTrue(state.orderedIds.isEmpty())
+    }
+
+    @Nested
+    @DisplayName("ErrorLogging")
+    inner class ErrorLoggingTest {
+
+        @Test
+        fun `flow observation failure logs via DiagnosticLog`() = runTest {
+            val error = RuntimeException("DataStore read failed")
+            every { repository.subscribedServiceIds } returns flow { throw error }
+
+            viewModel = StreamingSettingsViewModel(repository)
+            advanceUntilIdle()
+
+            val errors = DiagnosticLog.snapshot().filter {
+                it.level == DiagnosticLog.Level.ERROR
+            }
+            assertTrue(errors.isNotEmpty(), "Expected an error entry in DiagnosticLog")
+            assertTrue(
+                errors.any { it.message.contains("streaming prefs observation failed") },
+                "Expected 'streaming prefs observation failed' in log"
+            )
+        }
+
+        @Test
+        fun `write failure logs via DiagnosticLog`() = runTest {
+            coEvery { repository.setSubscribedServices(any()) } throws RuntimeException("DataStore write failed")
+
+            viewModel.toggleService("netflix")
+            advanceUntilIdle()
+
+            val errors = DiagnosticLog.snapshot().filter {
+                it.level == DiagnosticLog.Level.ERROR
+            }
+            assertTrue(errors.isNotEmpty(), "Expected an error entry in DiagnosticLog")
+            assertTrue(
+                errors.any { it.message.contains("streaming prefs write failed") },
+                "Expected 'streaming prefs write failed' in log"
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary

Closes #298.

- Add `onCleared()` to `ScrobbleViewModel` that clears `dismissedEpisodes`, preventing unbounded growth during long TV sessions. The set was previously held for the entire ViewModel lifetime with no cleanup; since the VM is scoped to the scrobble screen, `onCleared()` is the natural cleanup point.
- Expose `dismissedEpisodes` as `internal @VisibleForTesting` so unit tests can assert on it directly (consistent with the `@VisibleForTesting` pattern introduced in #285).
- Replace the silent `CoroutineExceptionHandler { _, _ -> }` in `StreamingSettingsViewModel` with one that logs via `DiagnosticLog.error` — DataStore failures will now appear in the user-facing diagnostic share bundle.
- Replace `.catch { }` no-op in the `subscribedServiceIds` flow observation with a logging variant for the same reason.

Note: `TvScrobbleDispatcher` and `TvHomeViewModel` already re-throw `CancellationException` correctly; no change needed there.

## Test plan

- [x] `ScrobbleViewModelTest.DismissedEpisodesCleanupTest.dismissedEpisodes cleared on onCleared` — verifies the set is empty after `onCleared()` is called
- [x] `ScrobbleViewModelTest.DismissedEpisodesCleanupTest.dismissing multiple episodes all cleared on onCleared` — verifies all dismissed entries are gone after `onCleared()`
- [x] `StreamingSettingsViewModelTest.ErrorLoggingTest.flow observation failure logs via DiagnosticLog` — verifies a flow error lands in `DiagnosticLog` with the expected message
- [x] `StreamingSettingsViewModelTest.ErrorLoggingTest.write failure logs via DiagnosticLog` — verifies a DataStore write failure fires the `CoroutineExceptionHandler` and lands in `DiagnosticLog`
- [x] All existing `StreamingSettingsViewModelTest` and `ScrobbleViewModelTest` cases unaffected
- [x] `./gradlew :app-tv:testDebugUnitTest`

https://claude.ai/code/session_01Rj8RanAkHmeueBsgLd9WTJ