### PR TITLE
chore(phone): extract shared handler for /scrobble/{start|pause|stop}

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -221,68 +221,39 @@ internal fun Application.configureCompanionRoutes(
             call.respond(TokenResponse(accessToken = token))
         }
 
-        post("/scrobble/start") {
-            val token = tokenRefreshManager.getValidAccessToken()
-                ?: return@post call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
-            val body = try { call.receive<ScrobbleRequestBody>() } catch (_: Exception) {
-                return@post call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid request body"))
-            }
-            try {
-                traktApiService.scrobbleStart(
-                    bearer = "Bearer $token",
-                    body = ScrobbleBody(show = body.show, episode = body.episode, progress = body.progress)
-                )
-                stateManager.onScrobbleEvent(
-                    ScrobbleDisplayEvent(ScrobbleAction.START, body.show, body.episode, body.progress, System.currentTimeMillis())
-                )
-                call.respond(ScrobbleActionResponse(success = true))
-            } catch (e: Exception) {
-                Log.e(TAG, "Scrobble start failed", e)
-                call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Scrobble failed"))
+        ScrobbleAction.entries.forEach { action ->
+            post("/scrobble/${action.name.lowercase()}") {
+                call.handleScrobble(action, tokenRefreshManager, traktApiService, stateManager)
             }
         }
+    }
+}
 
-        post("/scrobble/pause") {
-            val token = tokenRefreshManager.getValidAccessToken()
-                ?: return@post call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
-            val body = try { call.receive<ScrobbleRequestBody>() } catch (_: Exception) {
-                return@post call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid request body"))
-            }
-            try {
-                traktApiService.scrobblePause(
-                    bearer = "Bearer $token",
-                    body = ScrobbleBody(show = body.show, episode = body.episode, progress = body.progress)
-                )
-                stateManager.onScrobbleEvent(
-                    ScrobbleDisplayEvent(ScrobbleAction.PAUSE, body.show, body.episode, body.progress, System.currentTimeMillis())
-                )
-                call.respond(ScrobbleActionResponse(success = true))
-            } catch (e: Exception) {
-                Log.e(TAG, "Scrobble pause failed", e)
-                call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Scrobble failed"))
-            }
+private suspend fun ApplicationCall.handleScrobble(
+    action: ScrobbleAction,
+    tokenRefreshManager: TokenRefreshManager,
+    traktApiService: TraktApiService,
+    stateManager: CompanionStateManager,
+) {
+    val token = tokenRefreshManager.getValidAccessToken()
+        ?: return respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
+    val body = try { receive<ScrobbleRequestBody>() } catch (_: Exception) {
+        return respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid request body"))
+    }
+    try {
+        val scrobbleBody = ScrobbleBody(show = body.show, episode = body.episode, progress = body.progress)
+        when (action) {
+            ScrobbleAction.START -> traktApiService.scrobbleStart("Bearer $token", scrobbleBody)
+            ScrobbleAction.PAUSE -> traktApiService.scrobblePause("Bearer $token", scrobbleBody)
+            ScrobbleAction.STOP -> traktApiService.scrobbleStop("Bearer $token", scrobbleBody)
         }
-
-        post("/scrobble/stop") {
-            val token = tokenRefreshManager.getValidAccessToken()
-                ?: return@post call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
-            val body = try { call.receive<ScrobbleRequestBody>() } catch (_: Exception) {
-                return@post call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid request body"))
-            }
-            try {
-                traktApiService.scrobbleStop(
-                    bearer = "Bearer $token",
-                    body = ScrobbleBody(show = body.show, episode = body.episode, progress = body.progress)
-                )
-                stateManager.onScrobbleEvent(
-                    ScrobbleDisplayEvent(ScrobbleAction.STOP, body.show, body.episode, body.progress, System.currentTimeMillis())
-                )
-                call.respond(ScrobbleActionResponse(success = true))
-            } catch (e: Exception) {
-                Log.e(TAG, "Scrobble stop failed", e)
-                call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Scrobble failed"))
-            }
-        }
+        stateManager.onScrobbleEvent(
+            ScrobbleDisplayEvent(action, body.show, body.episode, body.progress, System.currentTimeMillis())
+        )
+        respond(ScrobbleActionResponse(success = true))
+    } catch (e: Exception) {
+        Log.e(TAG, "Scrobble ${action.name.lowercase()} failed", e)
+        respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Scrobble failed"))
     }
 }
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -2,6 +2,7 @@ package com.justb81.watchbuddy.phone.server
 
 import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.LlmBackend
+import com.justb81.watchbuddy.core.model.ScrobbleAction
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.model.TmdbEpisode
 import com.justb81.watchbuddy.core.model.TmdbShow
@@ -729,6 +730,69 @@ class CompanionHttpServerTest {
 
             assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
             assertFalse(response.bodyAsText().contains("Network error"))
+        }
+
+        @Test
+        fun `scrobble start updates stateManager with START action`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "token"
+            stubSuccessfulScrobbleStart()
+
+            client.post("/scrobble/start") {
+                contentType(ContentType.Application.Json)
+                setBody(scrobbleBody)
+            }
+
+            assertEquals(ScrobbleAction.START, stateManager.lastScrobbleEvent.value?.action)
+        }
+
+        @Test
+        fun `scrobble pause updates stateManager with PAUSE action`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "token"
+            stubSuccessfulScrobblePause()
+
+            client.post("/scrobble/pause") {
+                contentType(ContentType.Application.Json)
+                setBody(scrobbleBody)
+            }
+
+            assertEquals(ScrobbleAction.PAUSE, stateManager.lastScrobbleEvent.value?.action)
+        }
+
+        @Test
+        fun `scrobble stop updates stateManager with STOP action`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "token"
+            stubSuccessfulScrobbleStop()
+
+            client.post("/scrobble/stop") {
+                contentType(ContentType.Application.Json)
+                setBody(scrobbleBody)
+            }
+
+            assertEquals(ScrobbleAction.STOP, stateManager.lastScrobbleEvent.value?.action)
+        }
+
+        @Test
+        fun `scrobble pause returns 400 when body is invalid`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "token"
+
+            val response = client.post("/scrobble/pause") {
+                contentType(ContentType.Application.Json)
+                setBody("not-valid-json")
+            }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+        @Test
+        fun `scrobble stop returns 400 when body is invalid`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "token"
+
+            val response = client.post("/scrobble/stop") {
+                contentType(ContentType.Application.Json)
+                setBody("not-valid-json")
+            }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
         }
     }
 }


### PR DESCRIPTION
## Summary

Closes #275

- Replaces three near-identical `post("/scrobble/start|pause|stop")` route blocks with a single loop over `ScrobbleAction.entries` and a private `handleScrobble` extension on `ApplicationCall`
- Eliminates ~55 lines of copy-paste; token validation, body parsing, error handling, and `CompanionStateManager` update now have a single source of truth
- No change to the public HTTP contract or payload shape

## Test plan

- [x] All existing scrobble tests in `CompanionHttpServerTest` still pass (401, 400, 200, 503 scenarios for start/pause/stop)
- [x] New tests verify `stateManager.lastScrobbleEvent.action` is set to the correct `ScrobbleAction` for each endpoint
- [x] New 400-body tests added for pause and stop (gap in prior coverage)
- [x] `./gradlew :app-phone:testDebugUnitTest` green in CI

https://claude.ai/code/session_01Dd4kQ2P2nmU9LyzGW8qpu4