### PR TITLE
docs: reconcile inconsistent backend URL references

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Please make sure your PR:
 
 ## Privacy / Datenschutz
 
-WatchBuddy is designed with privacy in mind: no tracking SDKs, no analytics, no WatchBuddy-side user accounts. Trakt tokens stay in the Android Keystore on the phone, LLM recaps are generated entirely on-device, and the only server component (the optional token proxy at `watchbuddy.server.rang.it`) runs on an EU host and does not persist tokens.
+WatchBuddy is designed with privacy in mind: no tracking SDKs, no analytics, no WatchBuddy-side user accounts. Trakt tokens stay in the Android Keystore on the phone, LLM recaps are generated entirely on-device, and the only server component (the optional token proxy at `watchbuddy.server.rang.it`) runs on an EU host and does not persist tokens. The URL is injected at build time via `TOKEN_BACKEND_URL`; self-hosters can override it in `local.properties`.
 
 The full privacy policy is available in two language versions:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -264,7 +264,7 @@ this flow and shows a "Now Watching" card with the show title, episode number, a
 - `client_secret` lives ONLY on the token proxy backend
 - APK contains only `client_id` (public)
 - 3 auth modes (configurable in Advanced Settings):
-  1. **Managed** → `https://api.watchbuddy.app/trakt/token` (default)
+  1. **Managed** → `https://watchbuddy.server.rang.it/trakt/token` (default; injected at build time via `TOKEN_BACKEND_URL`, self-hosters can override it in `local.properties`)
   2. **Self-hosted** → user enters own proxy URL
   3. **Direct** → user enters own Client ID + Secret (stored in Keystore)
 

--- a/docs/trakt-flow.md
+++ b/docs/trakt-flow.md
@@ -277,7 +277,7 @@ WatchBuddy supports three authentication modes, configurable in Advanced Setting
 
 ```mermaid
 flowchart LR
-    Phone["Phone"] -->|"POST /trakt/token\n{ code }"| Backend["WatchBuddy Backend\napi.watchbuddy.app\nInjects client_secret"]
+    Phone["Phone"] -->|"POST /trakt/token\n{ code }"| Backend["WatchBuddy Backend\nwatchbuddy.server.rang.it\nInjects client_secret"]
     Backend -->|"POST /oauth/device/token\n{ code, client_id, client_secret }"| Trakt["Trakt API"]
 ```
 


### PR DESCRIPTION
## Summary

Closes #290

- Replace stale `api.watchbuddy.app` with the canonical managed-backend URL `watchbuddy.server.rang.it` in `docs/architecture.md` and `docs/trakt-flow.md`, matching what `README.md` and the privacy policies already state.
- Add a sentence clarifying that the URL is injected at build time via `TOKEN_BACKEND_URL` and can be overridden in `local.properties` for self-hosters.

## Changes

| File | Change |
|------|--------|
| `docs/architecture.md` | Replace `api.watchbuddy.app/trakt/token` → `watchbuddy.server.rang.it/trakt/token`; add `TOKEN_BACKEND_URL` override note |
| `docs/trakt-flow.md` | Replace `api.watchbuddy.app` → `watchbuddy.server.rang.it` in the Mermaid diagram |
| `README.md` | Add the `TOKEN_BACKEND_URL` override note next to the existing backend URL mention |

## Verification

- `rg 'api\.watchbuddy\.app' docs/ README.md CLAUDE.md` returns no results.
- All internal doc links still resolve.
- No code changes; CI build validates only Android build (docs-only change).

## Test plan

- [x] Grep for `api.watchbuddy.app` across all docs — no matches
- [x] Grep for `watchbuddy.server.rang.it` — single consistent value in all three files
- [x] Self-host instructions still reference `TOKEN_BACKEND_URL` override mechanism

https://claude.ai/code/session_01VMmNTnLwHdHxH9bCX6AVLu