### PR TITLE
fix: sort shows by last-watched DESC and episodes by number DESC (#326)

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
@@ -8,6 +8,7 @@ import com.justb81.watchbuddy.core.model.TmdbShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.model.TraktWatchedEpisode
 import com.justb81.watchbuddy.core.model.TraktWatchedSeason
+import com.justb81.watchbuddy.core.progress.ShowProgressCalculator
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
@@ -51,6 +52,10 @@ class ShowRepository @Inject constructor(
 
     private var lastFetch: Long = 0L
 
+    private val showComparator = compareByDescending<EnrichedShowEntry> {
+        ShowProgressCalculator.latestWatchedInstant(it.entry)
+    }.thenBy { it.entry.show.title.lowercase() }
+
     suspend fun getShows(): List<EnrichedShowEntry> {
         val now = System.currentTimeMillis()
         val cached = _shows.value
@@ -59,7 +64,7 @@ class ShowRepository @Inject constructor(
                 ?: return cached
             try {
                 val trakt = traktApi.getWatchedShows("Bearer $token")
-                _shows.value = enrich(trakt)
+                _shows.value = enrich(trakt).sortedWith(showComparator)
                 lastFetch = now
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch shows from Trakt; serving ${cached.size} cached entries", e)
@@ -91,7 +96,9 @@ class ShowRepository @Inject constructor(
         }
         if (updatedSeasons === existing.entry.seasons) return
         val updatedEntry = existing.copy(entry = existing.entry.copy(seasons = updatedSeasons))
-        _shows.value = current.toMutableList().also { it[index] = updatedEntry }
+        _shows.value = current.toMutableList()
+            .also { it[index] = updatedEntry }
+            .sortedWith(showComparator)
     }
 
     private fun addEpisode(

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModel.kt
@@ -119,7 +119,7 @@ class ShowDetailViewModel @Inject constructor(
             .map { season ->
                 val watchedEpisodes = watchedIndex[season.number].orEmpty()
                 val episodes = season.episodes
-                    .sortedBy { it.number }
+                    .sortedByDescending { it.number }
                     .map { ep ->
                         EpisodeUi(
                             season = season.number,

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
@@ -4,6 +4,8 @@ import com.justb81.watchbuddy.core.model.TmdbShow
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.model.TraktWatchedEpisode
+import com.justb81.watchbuddy.core.model.TraktWatchedSeason
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
@@ -132,6 +134,41 @@ class ShowRepositoryTest {
     }
 
     @Test
+    fun `getShows emits shows sorted by last-watched DESC with unwatched at bottom`() = runTest {
+        val entries = listOf(
+            watchedEntry(trakt = 1, title = "Old", lastWatchedAt = "2026-04-10T10:00:00Z"),
+            watchedEntry(trakt = 2, title = "Newest", lastWatchedAt = "2026-04-15T10:00:00Z"),
+            watchedEntry(trakt = 3, title = "Never", lastWatchedAt = null)
+        )
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+        coEvery { traktApi.getWatchedShows(any()) } returns entries
+
+        val result = repository.getShows()
+
+        assertEquals(listOf(2, 1, 3), result.map { it.entry.show.ids.trakt })
+        assertEquals(listOf(2, 1, 3), repository.shows.value.map { it.entry.show.ids.trakt })
+    }
+
+    @Test
+    fun `updateLocalWatched re-sorts so a toggled older show moves to the top`() = runTest {
+        val entries = listOf(
+            watchedEntry(trakt = 1, title = "Old", lastWatchedAt = "2026-04-10T10:00:00Z"),
+            watchedEntry(trakt = 2, title = "Newest", lastWatchedAt = "2026-04-15T10:00:00Z")
+        )
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+        coEvery { traktApi.getWatchedShows(any()) } returns entries
+        repository.getShows()
+
+        assertEquals(listOf(2, 1), repository.shows.value.map { it.entry.show.ids.trakt })
+
+        // Marking a new episode on the older show "Old" should push it to the top:
+        // the freshly generated Instant.now() is newer than the other show's timestamp.
+        repository.updateLocalWatched(traktShowId = 1, season = 2, episode = 1, watched = true)
+
+        assertEquals(listOf(1, 2), repository.shows.value.map { it.entry.show.ids.trakt })
+    }
+
+    @Test
     fun `getShows tolerates per-show TMDB failures`() = runTest {
         every { settingsRepository.getTmdbApiKey() } returns flowOf("api-key")
         coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
@@ -146,4 +183,18 @@ class ShowRepositoryTest {
         assertNull(result[1].posterPath)
         assertNull(result[1].tmdb)
     }
+
+    private fun watchedEntry(
+        trakt: Int,
+        title: String,
+        lastWatchedAt: String?
+    ): TraktWatchedEntry = TraktWatchedEntry(
+        show = TraktShow(title, 2024, TraktIds(trakt = trakt, tmdb = trakt * 100)),
+        seasons = if (lastWatchedAt == null) emptyList() else listOf(
+            TraktWatchedSeason(
+                number = 1,
+                episodes = listOf(TraktWatchedEpisode(number = 1, last_watched_at = lastWatchedAt))
+            )
+        )
+    )
 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModelTest.kt
@@ -196,6 +196,50 @@ class ShowDetailViewModelTest {
     }
 
     @Nested
+    @DisplayName("episode ordering")
+    inner class EpisodeOrderingTest {
+
+        @Test
+        fun `episodes within a season sort DESC by number`() = runTest {
+            seedLibrary()
+            coEvery { episodeRepository.getSeasonsWithEpisodes(any()) } returns seasonsPayload(
+                mapOf(1 to 5)
+            )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val episodes = vm.uiState.value.seasons.first { it.number == 1 }.episodes
+            assertEquals(listOf(5, 4, 3, 2, 1), episodes.map { it.number })
+        }
+
+        @Test
+        fun `DESC episode order preserved after pinned current season is chosen`() = runTest {
+            // S1 fully watched, S2 mid-watched. Current-season rule pins S2 on top and
+            // keeps S1 below; both seasons' episode lists must still be DESC by number.
+            seedLibrary(
+                watchedSeasons = listOf(
+                    TraktWatchedSeason(1, listOf(
+                        TraktWatchedEpisode(1), TraktWatchedEpisode(2), TraktWatchedEpisode(3)
+                    )),
+                    TraktWatchedSeason(2, listOf(TraktWatchedEpisode(1)))
+                )
+            )
+            coEvery { episodeRepository.getSeasonsWithEpisodes(any()) } returns seasonsPayload(
+                mapOf(1 to 3, 2 to 4)
+            )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val seasons = vm.uiState.value.seasons
+            assertEquals(2, seasons.first().number, "current-season rule should pin S2 on top")
+            assertEquals(listOf(4, 3, 2, 1), seasons.first { it.number == 2 }.episodes.map { it.number })
+            assertEquals(listOf(3, 2, 1), seasons.first { it.number == 1 }.episodes.map { it.number })
+        }
+    }
+
+    @Nested
     @DisplayName("toggleEpisodeWatched")
     inner class ToggleTest {
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -128,7 +128,11 @@ class TvHomeViewModel @Inject constructor(
                 val hasMore = newShows.size >= PAGE_SIZE
                 loadedOffset = currentOffset + newShows.size
 
-                val allShows = if (append) _uiState.value.shows + newShows else newShows
+                val allShows = if (append) {
+                    (_uiState.value.shows + newShows).sortedByLastWatched()
+                } else {
+                    newShows.sortedByLastWatched()
+                }
 
                 fallbackCache = allShows
                 fallbackCacheTimestamp = System.currentTimeMillis()
@@ -214,3 +218,15 @@ class TvHomeViewModel @Inject constructor(
         phoneDiscovery.stopDiscovery()
     }
 }
+
+/**
+ * Defensive DESC-by-last-watched sort applied on top of the phone's already-sorted
+ * pagination, so older phone builds (or a future phone-side regression) still yield
+ * a consistent order on the TV grid. Tie-break by title to match [ShowRepository].
+ */
+internal fun List<EnrichedShowEntry>.sortedByLastWatched(): List<EnrichedShowEntry> =
+    sortedWith(
+        compareByDescending<EnrichedShowEntry> {
+            ShowProgressCalculator.latestWatchedInstant(it.entry)
+        }.thenBy { it.entry.show.title.lowercase() }
+    )

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
@@ -366,8 +366,56 @@ class TvHomeViewModelTest {
             viewModel.loadMoreShows()
             advanceUntilIdle()
 
-            val allShows = page1 + page2
+            val allShows = (page1 + page2).sortedByLastWatched()
             verify { tvShowCache.updateShows(allShows.map { it.entry }) }
+        }
+    }
+
+    @Nested
+    @DisplayName("sort order")
+    inner class SortOrderTest {
+
+        @Test
+        fun `sortedByLastWatched sorts DESC by latest watched with null at bottom`() {
+            val a = EnrichedShowEntry(
+                entry = TraktWatchedEntry(
+                    show = TraktShow("Old", 2020, TraktIds(trakt = 1)),
+                    seasons = listOf(
+                        com.justb81.watchbuddy.core.model.TraktWatchedSeason(
+                            number = 1,
+                            episodes = listOf(
+                                com.justb81.watchbuddy.core.model.TraktWatchedEpisode(
+                                    number = 1,
+                                    last_watched_at = "2026-04-10T10:00:00Z"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+            val b = EnrichedShowEntry(
+                entry = TraktWatchedEntry(
+                    show = TraktShow("Newest", 2020, TraktIds(trakt = 2)),
+                    seasons = listOf(
+                        com.justb81.watchbuddy.core.model.TraktWatchedSeason(
+                            number = 1,
+                            episodes = listOf(
+                                com.justb81.watchbuddy.core.model.TraktWatchedEpisode(
+                                    number = 1,
+                                    last_watched_at = "2026-04-15T10:00:00Z"
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+            val c = EnrichedShowEntry(
+                entry = TraktWatchedEntry(show = TraktShow("Never", 2020, TraktIds(trakt = 3)))
+            )
+
+            val sorted = listOf(a, c, b).sortedByLastWatched()
+
+            assertEquals(listOf(2, 1, 3), sorted.map { it.entry.show.ids.trakt })
         }
     }
 }

--- a/core/src/main/java/com/justb81/watchbuddy/core/progress/ShowProgressCalculator.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/progress/ShowProgressCalculator.kt
@@ -116,6 +116,10 @@ object ShowProgressCalculator {
         }
     }
 
+    /** Timestamp of the most recently watched non-special episode, or null if none. */
+    fun latestWatchedInstant(entry: TraktWatchedEntry): Instant? =
+        latestWatched(entry)?.instant
+
     private data class WatchedRef(val season: Int, val episode: Int, val instant: Instant) {
         val label: String get() = formatLabel(season, episode)
     }


### PR DESCRIPTION
Implements the plan from #326.

## Summary

- Home list on both phone and TV now surfaces the **most-recently-watched show on top** (DESC by latest episode `last_watched_at`, tie-broken by title).
- Phone Show Detail screen lists episodes within each season **DESC by number**; the pinned-current-season behavior is preserved.

## Changes

- **`ShowProgressCalculator.latestWatchedInstant(entry)`** — promoted the existing private `latestWatched(...)` lookup to a public helper so phone and TV share one definition of "latest watched".
- **`ShowRepository`** — sorts every emission of the `shows` `StateFlow` with `compareByDescending(latestWatchedInstant).thenBy(title.lowercase())`. Re-sort runs on the initial Trakt fetch *and* on `updateLocalWatched(...)`, so toggling an older show's newest episode promotes it to the top instantly without a round-trip.
- **`TvHomeViewModel`** — applies the same comparator client-side after merging paginated batches. Idempotent for current phone builds; defensive against older phones / a future phone-side regression. Exposed as a top-level `sortedByLastWatched()` helper for unit testing. Pagination stays correct because both phone and TV sort the underlying list before any `drop`/`take`.
- **`ShowDetailViewModel.buildSeasonUis`** — flips the episode list to `sortedByDescending { it.number }`. Season ordering and `reorder()`'s current-season pin are unchanged.

## Test plan

- [x] `ShowRepositoryTest` — new assertions for DESC-by-last-watched ordering (with null-timestamp entry sinking to the bottom) and for `updateLocalWatched` re-sorting so a toggled older show moves to the top.
- [x] `ShowDetailViewModelTest` — new `episode ordering` nested class: DESC within a season, and DESC preserved after the pinned-current-season rule fires. Existing tests for default expansion / toggles untouched.
- [x] `TvHomeViewModelTest` — added `sortedByLastWatched` unit test and updated the pagination-`TvShowCache` verify to expect the sorted projection.
- [ ] CI `build-android.yml` (green gate).
- [ ] Manual on phone: after syncing, the most-recently-played show is on top; watching a new episode of an older show promotes it on next tick.
- [ ] Manual on phone detail: each season's episode list shows the highest episode number first; "current season" still lands on top of the season list.
- [ ] Manual on TV: Home grid order matches the phone order; scrolling past `PAGE_SIZE` keeps the DESC order without duplicates.

Closes #326.

https://claude.ai/code/session_01DqBRbJMWcPA6hC7hborm4G