### PR TITLE
fix: sort shows by last-watched DESC and episodes by number DESC

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
@@ -6,6 +6,7 @@ import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.TmdbProgressHint
 import com.justb81.watchbuddy.core.model.TmdbShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.progress.ShowProgressCalculator
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
@@ -46,7 +47,7 @@ class ShowRepository @Inject constructor(
                 ?: return emptyList()
             try {
                 val trakt = traktApi.getWatchedShows("Bearer $token")
-                cachedShows = enrich(trakt)
+                cachedShows = enrich(trakt).sortedWith(SHOW_COMPARATOR)
                 lastFetch = now
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to fetch shows from Trakt; serving ${cachedShows.size} cached entries", e)
@@ -87,6 +88,9 @@ class ShowRepository @Inject constructor(
 
     private companion object {
         const val CACHE_TTL = 5 * 60 * 1000L // 5 minutes
+        val SHOW_COMPARATOR: Comparator<EnrichedShowEntry> = compareByDescending<EnrichedShowEntry> {
+            ShowProgressCalculator.latestWatchedInstant(it.entry)
+        }.thenBy { it.entry.show.title.lowercase() }
     }
 }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModel.kt
@@ -69,7 +69,9 @@ class ShowDetailViewModel @Inject constructor(
                 _uiState.value = ShowDetailUiState(
                     isLoading = false,
                     show = entry.show,
-                    watchedSeasons = entry.seasons.sortedBy { it.number }
+                    watchedSeasons = entry.seasons
+                    .sortedBy { it.number }
+                    .map { s -> s.copy(episodes = s.episodes.sortedByDescending { it.number }) }
                 )
 
                 entry.show.ids.tmdb?.let { tmdbId -> loadTmdbDetails(tmdbId) }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
@@ -4,6 +4,8 @@ import com.justb81.watchbuddy.core.model.TmdbShow
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.model.TraktWatchedEpisode
+import com.justb81.watchbuddy.core.model.TraktWatchedSeason
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
@@ -129,6 +131,51 @@ class ShowRepositoryTest {
 
         assertEquals("/one.jpg", result[0].posterPath)
         assertEquals("/two.jpg", result[1].posterPath)
+    }
+
+    @Test
+    fun `getShows returns shows sorted by last-watched DESC`() = runTest {
+        val early = TraktWatchedEntry(
+            show = TraktShow("Early Show", 2020, TraktIds(trakt = 10)),
+            seasons = listOf(
+                TraktWatchedSeason(1, listOf(TraktWatchedEpisode(1, last_watched_at = "2026-04-10T10:00:00.000Z")))
+            )
+        )
+        val recent = TraktWatchedEntry(
+            show = TraktShow("Recent Show", 2021, TraktIds(trakt = 11)),
+            seasons = listOf(
+                TraktWatchedSeason(1, listOf(TraktWatchedEpisode(1, last_watched_at = "2026-04-15T10:00:00.000Z")))
+            )
+        )
+        val noWatch = TraktWatchedEntry(
+            show = TraktShow("Unwatched Show", 2022, TraktIds(trakt = 12)),
+            seasons = emptyList()
+        )
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+        coEvery { traktApi.getWatchedShows(any()) } returns listOf(early, noWatch, recent)
+
+        val result = repository.getShows()
+
+        assertEquals(listOf("Recent Show", "Early Show", "Unwatched Show"), result.map { it.entry.show.title })
+    }
+
+    @Test
+    fun `getShows breaks ties alphabetically when last-watched timestamps match`() = runTest {
+        val ts = "2026-04-15T10:00:00.000Z"
+        val showA = TraktWatchedEntry(
+            show = TraktShow("Zebra", 2020, TraktIds(trakt = 20)),
+            seasons = listOf(TraktWatchedSeason(1, listOf(TraktWatchedEpisode(1, last_watched_at = ts))))
+        )
+        val showB = TraktWatchedEntry(
+            show = TraktShow("Alpha", 2020, TraktIds(trakt = 21)),
+            seasons = listOf(TraktWatchedSeason(1, listOf(TraktWatchedEpisode(1, last_watched_at = ts))))
+        )
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+        coEvery { traktApi.getWatchedShows(any()) } returns listOf(showA, showB)
+
+        val result = repository.getShows()
+
+        assertEquals(listOf("Alpha", "Zebra"), result.map { it.entry.show.title })
     }
 
     @Test

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModelTest.kt
@@ -153,6 +153,29 @@ class ShowDetailViewModelTest {
         }
 
         @Test
+        fun `loads episodes within each season sorted by number descending`() = runTest {
+            val entry = makeEntry(
+                seasons = listOf(
+                    TraktWatchedSeason(
+                        number = 1,
+                        episodes = listOf(
+                            TraktWatchedEpisode(number = 1),
+                            TraktWatchedEpisode(number = 5),
+                            TraktWatchedEpisode(number = 3)
+                        )
+                    )
+                )
+            )
+            coEvery { traktApi.getWatchedShows(any()) } returns listOf(entry)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val episodes = vm.uiState.value.watchedSeasons.first().episodes
+            assertEquals(listOf(5, 3, 1), episodes.map { it.number })
+        }
+
+        @Test
         fun `loads TMDB poster URL when tmdbId and key are available`() = runTest {
             val vm = createViewModel()
             advanceUntilIdle()

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -120,7 +120,8 @@ class TvHomeViewModel @Inject constructor(
                 val hasMore = newShows.size >= PAGE_SIZE
                 loadedOffset = currentOffset + newShows.size
 
-                val allShows = if (append) _uiState.value.shows + newShows else newShows
+                val allShows = (if (append) _uiState.value.shows + newShows else newShows)
+                    .sortedByLastWatched()
 
                 cachedShows = allShows
                 cacheTimestamp = System.currentTimeMillis()
@@ -207,3 +208,9 @@ class TvHomeViewModel @Inject constructor(
         phoneDiscovery.stopDiscovery()
     }
 }
+
+internal fun List<EnrichedShowEntry>.sortedByLastWatched(): List<EnrichedShowEntry> =
+    sortedWith(
+        compareByDescending<EnrichedShowEntry> { ShowProgressCalculator.latestWatchedInstant(it.entry) }
+            .thenBy { it.entry.show.title.lowercase() }
+    )

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
@@ -4,6 +4,8 @@ import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.model.TraktWatchedEpisode
+import com.justb81.watchbuddy.core.model.TraktWatchedSeason
 import com.justb81.watchbuddy.tv.MainDispatcherRule
 import com.justb81.watchbuddy.tv.data.TvShowCache
 import com.justb81.watchbuddy.tv.data.UserSessionRepository
@@ -127,10 +129,40 @@ class TvHomeViewModelTest {
 
         val state = viewModel.uiState.value
         assertEquals(2, state.shows.size)
-        assertEquals("Show 1", state.shows[0].entry.show.title)
         assertFalse(state.isLoading)
         assertFalse(state.phoneApiError)
         assertFalse(state.noPhoneConnected)
+    }
+
+    @Test
+    fun `loadShows sorts shows by last-watched descending`() = runTest {
+        val phone = mockk<PhoneDiscoveryManager.DiscoveredPhone>()
+        every { phone.baseUrl } returns "http://192.168.1.1:8765/"
+        every { phoneDiscovery.getBestPhone() } returns phone
+        every { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+
+        val recent = EnrichedShowEntry(
+            entry = TraktWatchedEntry(
+                show = TraktShow("Recent", 2024, TraktIds(trakt = 1)),
+                seasons = listOf(
+                    TraktWatchedSeason(1, listOf(TraktWatchedEpisode(1, last_watched_at = "2026-04-15T10:00:00.000Z")))
+                )
+            )
+        )
+        val older = EnrichedShowEntry(
+            entry = TraktWatchedEntry(
+                show = TraktShow("Older", 2023, TraktIds(trakt = 2)),
+                seasons = listOf(
+                    TraktWatchedSeason(1, listOf(TraktWatchedEpisode(1, last_watched_at = "2026-04-01T10:00:00.000Z")))
+                )
+            )
+        )
+        coEvery { phoneApiService.getShows(any(), any()) } returns listOf(older, recent)
+
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        assertEquals(listOf("Recent", "Older"), viewModel.uiState.value.shows.map { it.entry.show.title })
     }
 
     @Test

--- a/core/src/main/java/com/justb81/watchbuddy/core/progress/ShowProgressCalculator.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/progress/ShowProgressCalculator.kt
@@ -120,6 +120,8 @@ object ShowProgressCalculator {
         val label: String get() = formatLabel(season, episode)
     }
 
+    fun latestWatchedInstant(entry: TraktWatchedEntry): Instant? = latestWatched(entry)?.instant
+
     private fun latestWatched(entry: TraktWatchedEntry): WatchedRef? {
         var best: WatchedRef? = null
         for (season in entry.seasons) {


### PR DESCRIPTION
Fixes #326.

## Summary

- **`ShowProgressCalculator`**: Exposes a new public `latestWatchedInstant(entry)` helper that returns the most-recent `Instant` across all watched episodes for a given entry (wraps the existing private `latestWatched()`).
- **`ShowRepository`**: Applies a comparator after every Trakt fetch — shows sorted DESC by `latestWatchedInstant`, ties broken alphabetically by title.
- **`TvHomeViewModel`**: Applies the same sort client-side after assembling each paginated batch via a new `sortedByLastWatched()` extension, protecting against older phone builds that send unsorted data.
- **`ShowDetailViewModel`**: Episodes within each watched season are now sorted DESC by episode number (newest first); season ordering and TMDB enrichment are unchanged.

## Test plan

- [ ] `ShowRepositoryTest` — new cases: 3-entry list with mixed timestamps returns them in `[most-recent, older, no-timestamp]` order; alphabetical tiebreak for same-timestamp entries.
- [ ] `ShowDetailViewModelTest` — new case: episodes `[1, 5, 3]` in a watched season are returned as `[5, 3, 1]`.
- [ ] `TvHomeViewModelTest` — new case: API returns `[older, recent]`, UI state shows `[recent, older]`.
- [ ] `./gradlew :core:test :app-phone:testDebugUnitTest :app-tv:testDebugUnitTest` — all green.
- [ ] `./gradlew assembleDebug` — both APKs build.

https://claude.ai/code/session_016JuqCoWFBtLgUMkFQSGr8P