### PR TITLE
feat: in-app diagnostics view + Settings version footer (#331, #330)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ watchbuddy/
 │       ├── server/     CompanionHttpServer (Ktor, port 8765), DeviceCapabilityProvider, ShowRepository (reactive `shows` StateFlow), EpisodeRepository (10-min per-show TTL + sync/history writes)
 │       ├── settings/   AppSettings, SettingsRepository (DataStore)
 │       ├── ui/         MainActivity, PhoneNavGraph
+│       │   ├── diagnostics/ DiagnosticsScreen, DiagnosticsViewModel (Wi-Fi / NSD / HTTP / BLE live health + Share diagnostics)
 │       │   ├── home/       HomeScreen, HomeViewModel
 │       │   ├── navigation/ PhoneNavGraph
 │       │   ├── onboarding/ OnboardingScreen, OnboardingViewModel
@@ -35,6 +36,7 @@ watchbuddy/
 │       │   ├── home/       TvHomeScreen, TvHomeViewModel
 │       │   ├── navigation/ TvNavGraph
 │       │   ├── recap/      RecapScreen, RecapViewModel
+│       │   ├── diagnostics/ TvDiagnosticsScreen, TvDiagnosticsViewModel (discovery / BLE / discovered-phones health + Share diagnostics)
 │       │   ├── scrobble/   ScrobbleOverlay, ScrobbleViewModel
 │       │   ├── settings/   StreamingSettingsScreen, StreamingSettingsViewModel
 │       │   ├── showdetail/ ShowDetailScreen, ShowDetailViewModel
@@ -198,6 +200,7 @@ For the authoritative HTTP API table, NSD TXT-record contract (`version`, `model
 - **Auth modes:** Managed backend (default), self-hosted proxy, or direct Trakt credentials.
 - **Multi-user:** Multiple phones can connect to one TV simultaneously; scrobbling records the episode for each connected user independently; shared watch mode avoids recap spoilers.
 - **Manual episode marking (phone):** Tapping a show on HomeScreen opens `ShowDetailScreen`, which fetches the full season/episode structure via `EpisodeRepository.getSeasonsWithEpisodes` (Trakt `shows/:id/seasons?extended=episodes`, 10-min per-show cache). Each episode has a checkbox; toggling calls `sync/history` add or remove through `EpisodeRepository`, optimistically flips the UI, and on success calls `ShowRepository.updateLocalWatched(...)`. That mutates the in-memory `shows` `StateFlow` so `HomeViewModel` counters update without a round-trip (#216). The layout pulls the season the user is currently mid-watching to the top, expanded; all other seasons appear below, collapsed.
+- **Diagnostics view:** Settings → Diagnostics on both apps renders live phone↔TV connection health from the existing shared singletons (`CompanionStateManager` on phone, `PhoneDiscoveryManager` on TV) — Wi-Fi / multicast lock / NSD state / HTTP bind / BLE state on the phone; discovery active / heartbeat age / BLE scan state / per-phone score + failCount on the TV (#331). Status dots are color-coded (green/yellow/red) so users can tell "AP isolation" (no phones at all) apart from "`/capability` 500" (discovered but broken). A "Share diagnostics" button funnels through `DiagnosticShare.launchShare()` so the `DiagnosticLog` snapshot + any pending crash reports can be exported via the system share sheet. Available in release builds; no new build variant.
 
 ## Documentation Maintenance
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ watchbuddy/
 - **Multi-user** — multiple phones/users sync to one TV; shared watch mode avoids spoilers
 - **RAM-adaptive LLM** — AICore (Gemini Nano) if available, otherwise LiteRT-LM with auto-selected Gemma model based on free RAM
 - **Resilient pairing** — NSD/mDNS with a parallel BLE fallback so phone ↔ TV discovery keeps working on guest Wi-Fi, mesh routers, and other networks where multicast is blocked
+- **In-app diagnostics** — Settings → Diagnostics on both apps shows live connection health (Wi-Fi / NSD / HTTP / BLE on the phone; discovery / heartbeat / discovered phones on the TV) with a one-tap "Share diagnostics" button that exports the `DiagnosticLog` and any pending crash reports for bug reports
 
 ## Module Structure
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/diagnostics/DiagnosticsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/diagnostics/DiagnosticsScreen.kt
@@ -1,0 +1,276 @@
+package com.justb81.watchbuddy.phone.ui.diagnostics
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.logging.DiagnosticShare
+import com.justb81.watchbuddy.service.CompanionStateManager
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DiagnosticsScreen(
+    onBack: () -> Unit,
+    viewModel: DiagnosticsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.diagnostics_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.settings_cd_back),
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.background,
+                ),
+            )
+        },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            DiagnosticsSection(stringResource(R.string.diagnostics_section_connectivity)) {
+                DiagnosticsRow(
+                    label = stringResource(R.string.diagnostics_row_wifi),
+                    value = yesNo(uiState.isOnWifi),
+                    status = if (uiState.isOnWifi) Status.OK else Status.FAIL,
+                )
+                DiagnosticsRow(
+                    label = stringResource(R.string.diagnostics_row_ipv4),
+                    value = uiState.wifiIpv4 ?: stringResource(R.string.diagnostics_value_unknown),
+                    status = if (uiState.wifiIpv4 != null) Status.OK else Status.WARN,
+                )
+                DiagnosticsRow(
+                    label = stringResource(R.string.diagnostics_row_multicast_lock),
+                    value = yesNo(uiState.multicastLockHeld),
+                    status = if (uiState.multicastLockHeld) Status.OK
+                             else if (uiState.serviceRunning) Status.FAIL else Status.NEUTRAL,
+                )
+            }
+
+            DiagnosticsSection(stringResource(R.string.diagnostics_section_nsd)) {
+                DiagnosticsRow(
+                    label = stringResource(R.string.diagnostics_row_service_running),
+                    value = yesNo(uiState.serviceRunning),
+                    status = if (uiState.serviceRunning) Status.OK else Status.NEUTRAL,
+                )
+                DiagnosticsRow(
+                    label = stringResource(R.string.diagnostics_row_nsd_state),
+                    value = uiState.nsdState.name,
+                    status = when (uiState.nsdState) {
+                        CompanionStateManager.NsdRegistrationState.REGISTERED -> Status.OK
+                        CompanionStateManager.NsdRegistrationState.FAILED -> Status.FAIL
+                        CompanionStateManager.NsdRegistrationState.IDLE -> Status.NEUTRAL
+                        else -> Status.WARN
+                    },
+                )
+                uiState.nsdErrorCode?.let { code ->
+                    DiagnosticsRow(
+                        label = stringResource(R.string.diagnostics_row_nsd_error),
+                        value = code.toString(),
+                        status = Status.FAIL,
+                    )
+                }
+            }
+
+            DiagnosticsSection(stringResource(R.string.diagnostics_section_http)) {
+                DiagnosticsRow(
+                    label = stringResource(R.string.diagnostics_row_http_binding),
+                    value = uiState.httpServerBinding ?: stringResource(R.string.diagnostics_value_stopped),
+                    status = if (uiState.httpServerBinding != null) Status.OK else Status.NEUTRAL,
+                )
+                DiagnosticsRow(
+                    label = stringResource(R.string.diagnostics_row_last_capability_poll),
+                    value = formatAge(uiState.lastCapabilityCheckMs),
+                    status = capabilityStatus(uiState.lastCapabilityCheckMs, uiState.serviceRunning),
+                )
+            }
+
+            DiagnosticsSection(stringResource(R.string.diagnostics_section_ble)) {
+                DiagnosticsRow(
+                    label = stringResource(R.string.diagnostics_row_ble_state),
+                    value = uiState.bleState.name,
+                    status = when (uiState.bleState) {
+                        CompanionStateManager.BleAdvertiseState.ADVERTISING -> Status.OK
+                        CompanionStateManager.BleAdvertiseState.FAILED -> Status.FAIL
+                        CompanionStateManager.BleAdvertiseState.IDLE -> Status.NEUTRAL
+                    },
+                )
+                uiState.bleErrorCode?.let { code ->
+                    DiagnosticsRow(
+                        label = stringResource(R.string.diagnostics_row_ble_error),
+                        value = code.toString(),
+                        status = Status.FAIL,
+                    )
+                }
+            }
+
+            DiagnosticsSection(stringResource(R.string.diagnostics_section_scrobble)) {
+                val scrobble = uiState.lastScrobble
+                if (scrobble != null) {
+                    DiagnosticsRow(
+                        label = stringResource(R.string.diagnostics_row_scrobble_show),
+                        value = "${scrobble.show.title} S${scrobble.episode.season}E${scrobble.episode.number}",
+                        status = Status.OK,
+                    )
+                    DiagnosticsRow(
+                        label = stringResource(R.string.diagnostics_row_scrobble_progress),
+                        value = "%.0f%%".format(scrobble.progress),
+                        status = Status.NEUTRAL,
+                    )
+                    DiagnosticsRow(
+                        label = stringResource(R.string.diagnostics_row_scrobble_time),
+                        value = formatAge(scrobble.timestamp),
+                        status = Status.NEUTRAL,
+                    )
+                } else {
+                    DiagnosticsRow(
+                        label = stringResource(R.string.diagnostics_row_scrobble_show),
+                        value = stringResource(R.string.diagnostics_value_none),
+                        status = Status.NEUTRAL,
+                    )
+                }
+            }
+
+            DiagnosticsSection(stringResource(R.string.diagnostics_section_build)) {
+                DiagnosticsRow(
+                    label = stringResource(R.string.diagnostics_row_version_name),
+                    value = uiState.versionName,
+                    status = Status.NEUTRAL,
+                )
+                DiagnosticsRow(
+                    label = stringResource(R.string.diagnostics_row_version_code),
+                    value = uiState.versionCode.toString(),
+                    status = Status.NEUTRAL,
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+            Button(
+                onClick = { DiagnosticShare.launchShare(context) },
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.diagnostics_share_button))
+            }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun yesNo(value: Boolean): String =
+    if (value) stringResource(R.string.diagnostics_value_yes)
+    else stringResource(R.string.diagnostics_value_no)
+
+private fun capabilityStatus(lastPollMs: Long, serviceRunning: Boolean): Status {
+    if (!serviceRunning) return Status.NEUTRAL
+    if (lastPollMs == 0L) return Status.WARN
+    val ageMs = System.currentTimeMillis() - lastPollMs
+    return when {
+        ageMs < 2 * 60_000 -> Status.OK
+        ageMs < 5 * 60_000 -> Status.WARN
+        else -> Status.FAIL
+    }
+}
+
+private fun formatAge(timestampMs: Long): String {
+    if (timestampMs == 0L) return "—"
+    val seconds = (System.currentTimeMillis() - timestampMs) / 1000
+    return when {
+        seconds < 0 -> "—"
+        seconds < 60 -> "${seconds}s ago"
+        seconds < 3_600 -> "${seconds / 60}m ago"
+        else -> "${seconds / 3_600}h ago"
+    }
+}
+
+private enum class Status { OK, WARN, FAIL, NEUTRAL }
+
+@Composable
+private fun DiagnosticsSection(title: String, content: @Composable ColumnScope.() -> Unit) {
+    Text(
+        text = title.uppercase(),
+        style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Bold,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(top = 4.dp, bottom = 4.dp, start = 4.dp),
+    )
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
+    ) {
+        Column(content = content)
+    }
+}
+
+@Composable
+private fun DiagnosticsRow(label: String, value: String, status: Status) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .size(10.dp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Surface(
+                    shape = MaterialTheme.shapes.small,
+                    color = statusColor(status),
+                    modifier = Modifier.fillMaxSize(),
+                ) {}
+            }
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        }
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f),
+        )
+    }
+}
+
+@Composable
+private fun statusColor(status: Status): Color = when (status) {
+    Status.OK -> Color(0xFF2E7D32)
+    Status.WARN -> Color(0xFFF9A825)
+    Status.FAIL -> MaterialTheme.colorScheme.error
+    Status.NEUTRAL -> MaterialTheme.colorScheme.outline
+}

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/diagnostics/DiagnosticsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/diagnostics/DiagnosticsViewModel.kt
@@ -1,0 +1,111 @@
+package com.justb81.watchbuddy.phone.ui.diagnostics
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.justb81.watchbuddy.BuildConfig
+import com.justb81.watchbuddy.core.model.ScrobbleDisplayEvent
+import com.justb81.watchbuddy.phone.network.WifiStateProvider
+import com.justb81.watchbuddy.service.CompanionStateManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class DiagnosticsUiState(
+    val isOnWifi: Boolean = false,
+    val wifiIpv4: String? = null,
+    val multicastLockHeld: Boolean = false,
+    val serviceRunning: Boolean = false,
+    val nsdState: CompanionStateManager.NsdRegistrationState = CompanionStateManager.NsdRegistrationState.IDLE,
+    val nsdErrorCode: Int? = null,
+    val httpServerBinding: String? = null,
+    val lastCapabilityCheckMs: Long = 0L,
+    val bleState: CompanionStateManager.BleAdvertiseState = CompanionStateManager.BleAdvertiseState.IDLE,
+    val bleErrorCode: Int? = null,
+    val lastScrobble: ScrobbleDisplayEvent? = null,
+    val versionName: String = BuildConfig.VERSION_NAME,
+    val versionCode: Int = BuildConfig.VERSION_CODE,
+)
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class DiagnosticsViewModel @Inject constructor(
+    wifiStateProvider: WifiStateProvider,
+    stateManager: CompanionStateManager,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(DiagnosticsUiState())
+    val uiState: StateFlow<DiagnosticsUiState> = _uiState.asStateFlow()
+
+    init {
+        // Fan-in: eight independent flows from the shared state manager + Wi-Fi provider.
+        // `combine` only fires after every flow has emitted once, which is fine because
+        // each source is a StateFlow with a defined initial value.
+        val partA = combine(
+            wifiStateProvider.isOnWifi,
+            stateManager.wifiIpv4,
+            stateManager.multicastLockHeld,
+            stateManager.isServiceRunning,
+        ) { onWifi, ipv4, lockHeld, running ->
+            DiagnosticsPartA(onWifi, ipv4, lockHeld, running)
+        }
+        val partB = combine(
+            stateManager.nsdRegistrationState,
+            stateManager.nsdErrorCode,
+            stateManager.httpServerBinding,
+            stateManager.lastCapabilityCheck,
+        ) { nsd, nsdErr, http, lastCapCheck ->
+            DiagnosticsPartB(nsd, nsdErr, http, lastCapCheck)
+        }
+        val partC = combine(
+            stateManager.bleAdvertiseState,
+            stateManager.bleAdvertiseErrorCode,
+            stateManager.lastScrobbleEvent,
+        ) { ble, bleErr, scrobble ->
+            DiagnosticsPartC(ble, bleErr, scrobble)
+        }
+
+        viewModelScope.launch {
+            combine(partA, partB, partC) { a, b, c ->
+                DiagnosticsUiState(
+                    isOnWifi = a.onWifi,
+                    wifiIpv4 = a.ipv4,
+                    multicastLockHeld = a.lockHeld,
+                    serviceRunning = a.running,
+                    nsdState = b.nsd,
+                    nsdErrorCode = b.nsdErrorCode,
+                    httpServerBinding = b.httpBinding,
+                    lastCapabilityCheckMs = b.lastCapCheck,
+                    bleState = c.ble,
+                    bleErrorCode = c.bleErrorCode,
+                    lastScrobble = c.scrobble,
+                )
+            }.map { it }.collect { _uiState.value = it }
+        }
+    }
+
+    private data class DiagnosticsPartA(
+        val onWifi: Boolean,
+        val ipv4: String?,
+        val lockHeld: Boolean,
+        val running: Boolean,
+    )
+
+    private data class DiagnosticsPartB(
+        val nsd: CompanionStateManager.NsdRegistrationState,
+        val nsdErrorCode: Int?,
+        val httpBinding: String?,
+        val lastCapCheck: Long,
+    )
+
+    private data class DiagnosticsPartC(
+        val ble: CompanionStateManager.BleAdvertiseState,
+        val bleErrorCode: Int?,
+        val scrobble: ScrobbleDisplayEvent?,
+    )
+}

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/navigation/PhoneNavGraph.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
+import com.justb81.watchbuddy.phone.ui.diagnostics.DiagnosticsScreen
 import com.justb81.watchbuddy.phone.ui.home.HomeScreen
 import com.justb81.watchbuddy.phone.ui.onboarding.OnboardingScreen
 import com.justb81.watchbuddy.phone.ui.settings.SettingsScreen
@@ -16,6 +17,7 @@ sealed class PhoneRoute(val route: String) {
     object Home        : PhoneRoute("home")
     object Settings    : PhoneRoute("settings")
     object Connect     : PhoneRoute("connect")
+    object Diagnostics : PhoneRoute("diagnostics")
     object ShowDetail  : PhoneRoute("show_detail/{traktShowId}") {
         fun route(traktShowId: Int) = "show_detail/$traktShowId"
     }
@@ -65,8 +67,13 @@ fun PhoneNavGraph(
                         popUpTo(navController.graph.id) { inclusive = true }
                     }
                 },
-                onConnectClick = { navController.navigate(PhoneRoute.Connect.route) }
+                onConnectClick = { navController.navigate(PhoneRoute.Connect.route) },
+                onDiagnosticsClick = { navController.navigate(PhoneRoute.Diagnostics.route) }
             )
+        }
+
+        composable(PhoneRoute.Diagnostics.route) {
+            DiagnosticsScreen(onBack = { navController.popBackStack() })
         }
 
         composable(PhoneRoute.Connect.route) {

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -14,9 +14,11 @@ import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.justb81.watchbuddy.BuildConfig
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
 
@@ -303,6 +305,20 @@ fun SettingsScreen(
             }
 
             Spacer(Modifier.height(32.dp))
+
+            Text(
+                text = stringResource(
+                    R.string.settings_version_footer,
+                    BuildConfig.VERSION_NAME,
+                    BuildConfig.VERSION_CODE,
+                ),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp, bottom = 16.dp)
+            )
         }
     }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -26,6 +26,7 @@ fun SettingsScreen(
     onBack: () -> Unit,
     onDisconnected: () -> Unit,
     onConnectClick: () -> Unit,
+    onDiagnosticsClick: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel()
 ) {
     LaunchedEffect(Unit) {
@@ -72,6 +73,31 @@ fun SettingsScreen(
                 .padding(horizontal = 16.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
+            // ── Diagnostics entry point ──────────────────────────────────────
+            SettingsSectionHeader(stringResource(R.string.settings_diagnostics))
+
+            SettingsCard {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable(onClick = onDiagnosticsClick)
+                        .padding(horizontal = 16.dp, vertical = 14.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        stringResource(R.string.settings_diagnostics_row),
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        "›",
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+                    )
+                }
+            }
+
             // ── Account Section ───────────────────────────────────────────────
             SettingsSectionHeader(stringResource(R.string.settings_account))
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionBleAdvertiser.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionBleAdvertiser.kt
@@ -30,6 +30,7 @@ import javax.inject.Singleton
 @Singleton
 class CompanionBleAdvertiser @Inject constructor(
     @param:ApplicationContext private val context: Context,
+    private val stateManager: CompanionStateManager,
 ) {
     companion object {
         private const val TAG = "CompanionBleAdvertiser"
@@ -113,10 +114,15 @@ class CompanionBleAdvertiser @Inject constructor(
                     "advertising started: ip=${ipv4.hostAddress} port=$port " +
                         "quality=$modelQuality backend=$llmBackendOrdinal"
                 )
+                stateManager.setBleAdvertiseState(CompanionStateManager.BleAdvertiseState.ADVERTISING)
             }
 
             override fun onStartFailure(errorCode: Int) {
                 Log.e(TAG, "advertising failed: ${errorName(errorCode)}")
+                stateManager.setBleAdvertiseState(
+                    CompanionStateManager.BleAdvertiseState.FAILED,
+                    errorCode = errorCode,
+                )
                 // Drop our reference so a later start() attempt can retry
                 // cleanly instead of tripping over a stale callback.
                 synchronized(this@CompanionBleAdvertiser) {
@@ -156,6 +162,7 @@ class CompanionBleAdvertiser @Inject constructor(
                 advertiser = null
                 activeCallback = null
             }
+            stateManager.setBleAdvertiseState(CompanionStateManager.BleAdvertiseState.IDLE)
             return
         }
         runCatching { adv.stopAdvertising(cb) }
@@ -164,6 +171,7 @@ class CompanionBleAdvertiser @Inject constructor(
             advertiser = null
             activeCallback = null
         }
+        stateManager.setBleAdvertiseState(CompanionStateManager.BleAdvertiseState.IDLE)
         Log.i(TAG, "advertising stopped")
     }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
@@ -141,6 +141,8 @@ class CompanionService : Service() {
         }
         acquireMulticastLock()
         companionHttpServer.start()
+        stateManager.setHttpServerBinding("0.0.0.0:${CompanionHttpServer.PORT}")
+        stateManager.setWifiIpv4(wifiIpv4Address()?.hostAddress)
         registerNsd()
         startBleAdvertising()
         stateManager.setServiceRunning(true)
@@ -156,6 +158,8 @@ class CompanionService : Service() {
         bleAdvertiser.stop()
         releaseMulticastLock()
         companionHttpServer.stop()
+        stateManager.setHttpServerBinding(null)
+        stateManager.setWifiIpv4(null)
         stateManager.setServiceRunning(false)
         serviceScope.cancel()
         super.onDestroy()
@@ -309,6 +313,7 @@ class CompanionService : Service() {
             setReferenceCounted(false)
             acquire()
         }
+        stateManager.setMulticastLockHeld(true)
         Log.i(TAG, "Multicast lock acquired")
     }
 
@@ -317,6 +322,7 @@ class CompanionService : Service() {
             runCatching { it.release() }
         }
         multicastLock = null
+        stateManager.setMulticastLockHeld(false)
     }
 
     // ── NSD ──────────────────────────────────────────────────────────────────
@@ -332,6 +338,7 @@ class CompanionService : Service() {
             }
             nsdState = NsdState.REGISTERING
         }
+        stateManager.setNsdRegistrationState(CompanionStateManager.NsdRegistrationState.REGISTERING)
 
         val llmConfig = llmOrchestrator.selectConfig()
         val txtAttributes = buildTxtAttributes(BuildConfig.VERSION_NAME, llmConfig)
@@ -351,6 +358,7 @@ class CompanionService : Service() {
             override fun onServiceRegistered(info: NsdServiceInfo) {
                 Log.i(TAG, "NSD service registered: ${info.serviceName} TXT=$txtAttributes")
                 synchronized(nsdLock) { nsdState = NsdState.REGISTERED }
+                stateManager.setNsdRegistrationState(CompanionStateManager.NsdRegistrationState.REGISTERED)
             }
             override fun onRegistrationFailed(info: NsdServiceInfo, errorCode: Int) {
                 Log.e(TAG, "NSD registration failed: error=$errorCode, service=${info.serviceName}")
@@ -359,6 +367,10 @@ class CompanionService : Service() {
                     nsdManager = null
                     nsdState = NsdState.IDLE
                 }
+                stateManager.setNsdRegistrationState(
+                    CompanionStateManager.NsdRegistrationState.FAILED,
+                    errorCode = errorCode,
+                )
             }
             override fun onServiceUnregistered(info: NsdServiceInfo) {
                 Log.i(TAG, "NSD service unregistered: ${info.serviceName}")
@@ -367,6 +379,7 @@ class CompanionService : Service() {
                     nsdManager = null
                     nsdState = NsdState.IDLE
                 }
+                stateManager.setNsdRegistrationState(CompanionStateManager.NsdRegistrationState.IDLE)
             }
             override fun onUnregistrationFailed(info: NsdServiceInfo, errorCode: Int) {
                 Log.e(TAG, "NSD unregistration failed: error=$errorCode, service=${info.serviceName}")
@@ -375,6 +388,10 @@ class CompanionService : Service() {
                     nsdManager = null
                     nsdState = NsdState.IDLE
                 }
+                stateManager.setNsdRegistrationState(
+                    CompanionStateManager.NsdRegistrationState.FAILED,
+                    errorCode = errorCode,
+                )
             }
         }
 
@@ -391,6 +408,7 @@ class CompanionService : Service() {
                 nsdManager = null
                 nsdState = NsdState.IDLE
             }
+            stateManager.setNsdRegistrationState(CompanionStateManager.NsdRegistrationState.FAILED)
         }
     }
 
@@ -402,6 +420,7 @@ class CompanionService : Service() {
             nsdState = NsdState.UNREGISTERING
             nsdManager to nsdRegistrationListener
         }
+        stateManager.setNsdRegistrationState(CompanionStateManager.NsdRegistrationState.UNREGISTERING)
         if (mgr != null && listener != null) {
             runCatching { mgr.unregisterService(listener) }
                 .onFailure {
@@ -411,6 +430,7 @@ class CompanionService : Service() {
                         nsdManager = null
                         nsdState = NsdState.IDLE
                     }
+                    stateManager.setNsdRegistrationState(CompanionStateManager.NsdRegistrationState.IDLE)
                 }
         } else {
             synchronized(nsdLock) {
@@ -418,6 +438,7 @@ class CompanionService : Service() {
                 nsdManager = null
                 nsdState = NsdState.IDLE
             }
+            stateManager.setNsdRegistrationState(CompanionStateManager.NsdRegistrationState.IDLE)
         }
     }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionStateManager.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionStateManager.kt
@@ -15,6 +15,10 @@ import javax.inject.Singleton
 @Singleton
 class CompanionStateManager @Inject constructor() {
 
+    enum class NsdRegistrationState { IDLE, REGISTERING, REGISTERED, UNREGISTERING, FAILED }
+
+    enum class BleAdvertiseState { IDLE, ADVERTISING, FAILED }
+
     private val _lastCapabilityCheck = MutableStateFlow(0L)
     /** Epoch millis of the most recent `/capability` request from a TV. */
     val lastCapabilityCheck: StateFlow<Long> = _lastCapabilityCheck.asStateFlow()
@@ -27,6 +31,34 @@ class CompanionStateManager @Inject constructor() {
     /** Whether the [CompanionService] foreground service is currently active. */
     val isServiceRunning: StateFlow<Boolean> = _isServiceRunning.asStateFlow()
 
+    private val _nsdRegistrationState = MutableStateFlow(NsdRegistrationState.IDLE)
+    /** Mirror of the NSD state machine inside [CompanionService]. */
+    val nsdRegistrationState: StateFlow<NsdRegistrationState> = _nsdRegistrationState.asStateFlow()
+
+    private val _nsdErrorCode = MutableStateFlow<Int?>(null)
+    /** Last NSD registration failure code reported by the system, or null. */
+    val nsdErrorCode: StateFlow<Int?> = _nsdErrorCode.asStateFlow()
+
+    private val _httpServerBinding = MutableStateFlow<String?>(null)
+    /** Bound listen address of [CompanionHttpServer] (e.g. `0.0.0.0:8765`), or null when stopped. */
+    val httpServerBinding: StateFlow<String?> = _httpServerBinding.asStateFlow()
+
+    private val _multicastLockHeld = MutableStateFlow(false)
+    /** Whether [CompanionService] currently holds a Wi-Fi multicast lock. */
+    val multicastLockHeld: StateFlow<Boolean> = _multicastLockHeld.asStateFlow()
+
+    private val _bleAdvertiseState = MutableStateFlow(BleAdvertiseState.IDLE)
+    /** Current state of the BLE fallback advertiser. */
+    val bleAdvertiseState: StateFlow<BleAdvertiseState> = _bleAdvertiseState.asStateFlow()
+
+    private val _bleAdvertiseErrorCode = MutableStateFlow<Int?>(null)
+    /** Last BLE `onStartFailure` error code, or null. */
+    val bleAdvertiseErrorCode: StateFlow<Int?> = _bleAdvertiseErrorCode.asStateFlow()
+
+    private val _wifiIpv4 = MutableStateFlow<String?>(null)
+    /** Latest resolved Wi-Fi IPv4 address seen by [CompanionService], or null off Wi-Fi. */
+    val wifiIpv4: StateFlow<String?> = _wifiIpv4.asStateFlow()
+
     fun onCapabilityChecked() {
         _lastCapabilityCheck.value = System.currentTimeMillis()
     }
@@ -37,5 +69,46 @@ class CompanionStateManager @Inject constructor() {
 
     fun setServiceRunning(running: Boolean) {
         _isServiceRunning.value = running
+        if (!running) {
+            // Reset transient state so the Diagnostics view doesn't report
+            // stale flags once the foreground service is gone.
+            _nsdRegistrationState.value = NsdRegistrationState.IDLE
+            _nsdErrorCode.value = null
+            _httpServerBinding.value = null
+            _multicastLockHeld.value = false
+            _bleAdvertiseState.value = BleAdvertiseState.IDLE
+            _bleAdvertiseErrorCode.value = null
+            _wifiIpv4.value = null
+        }
+    }
+
+    fun setNsdRegistrationState(state: NsdRegistrationState, errorCode: Int? = null) {
+        _nsdRegistrationState.value = state
+        if (state == NsdRegistrationState.FAILED) {
+            _nsdErrorCode.value = errorCode
+        } else if (state == NsdRegistrationState.REGISTERED || state == NsdRegistrationState.IDLE) {
+            _nsdErrorCode.value = null
+        }
+    }
+
+    fun setHttpServerBinding(binding: String?) {
+        _httpServerBinding.value = binding
+    }
+
+    fun setMulticastLockHeld(held: Boolean) {
+        _multicastLockHeld.value = held
+    }
+
+    fun setBleAdvertiseState(state: BleAdvertiseState, errorCode: Int? = null) {
+        _bleAdvertiseState.value = state
+        if (state == BleAdvertiseState.FAILED) {
+            _bleAdvertiseErrorCode.value = errorCode
+        } else if (state == BleAdvertiseState.ADVERTISING || state == BleAdvertiseState.IDLE) {
+            _bleAdvertiseErrorCode.value = null
+        }
+    }
+
+    fun setWifiIpv4(address: String?) {
+        _wifiIpv4.value = address
     }
 }

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -202,4 +202,7 @@
     <string name="diagnostics_value_no">Nein</string>
     <string name="diagnostics_value_stopped">Gestoppt</string>
     <string name="diagnostics_value_none">Keine</string>
+
+    <!-- Version footer -->
+    <string name="settings_version_footer">WatchBuddy v%1$s (Build %2$d)</string>
 </resources>

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -170,4 +170,36 @@
         <item quantity="one">%d Serie</item>
         <item quantity="other">%d Serien</item>
     </plurals>
+
+    <!-- Diagnostics -->
+    <string name="settings_diagnostics">Diagnose</string>
+    <string name="settings_diagnostics_row">Verbindungsdiagnose</string>
+    <string name="diagnostics_title">Diagnose</string>
+    <string name="diagnostics_share_button">Diagnose teilen</string>
+    <string name="diagnostics_section_connectivity">Verbindung</string>
+    <string name="diagnostics_section_nsd">NSD / Companion-Dienst</string>
+    <string name="diagnostics_section_http">HTTP-Server</string>
+    <string name="diagnostics_section_ble">BLE-Advertiser</string>
+    <string name="diagnostics_section_scrobble">Letzter Scrobble</string>
+    <string name="diagnostics_section_build">Build-Infos</string>
+    <string name="diagnostics_row_wifi">WLAN</string>
+    <string name="diagnostics_row_ipv4">IPv4-Adresse</string>
+    <string name="diagnostics_row_multicast_lock">Multicast-Lock</string>
+    <string name="diagnostics_row_service_running">Dienst läuft</string>
+    <string name="diagnostics_row_nsd_state">NSD-Status</string>
+    <string name="diagnostics_row_nsd_error">NSD-Fehlercode</string>
+    <string name="diagnostics_row_http_binding">Bindungsadresse</string>
+    <string name="diagnostics_row_last_capability_poll">Letzter TV-Abruf</string>
+    <string name="diagnostics_row_ble_state">Advertiser-Status</string>
+    <string name="diagnostics_row_ble_error">BLE-Fehlercode</string>
+    <string name="diagnostics_row_scrobble_show">Serie</string>
+    <string name="diagnostics_row_scrobble_progress">Fortschritt</string>
+    <string name="diagnostics_row_scrobble_time">Zeitpunkt</string>
+    <string name="diagnostics_row_version_name">Versionsname</string>
+    <string name="diagnostics_row_version_code">Versionscode</string>
+    <string name="diagnostics_value_unknown">Unbekannt</string>
+    <string name="diagnostics_value_yes">Ja</string>
+    <string name="diagnostics_value_no">Nein</string>
+    <string name="diagnostics_value_stopped">Gestoppt</string>
+    <string name="diagnostics_value_none">Keine</string>
 </resources>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -202,4 +202,7 @@
     <string name="diagnostics_value_no">No</string>
     <string name="diagnostics_value_stopped">Detenido</string>
     <string name="diagnostics_value_none">Ninguno</string>
+
+    <!-- Version footer -->
+    <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>
 </resources>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -170,4 +170,36 @@
         <item quantity="one">%d serie</item>
         <item quantity="other">%d series</item>
     </plurals>
+
+    <!-- Diagnostics -->
+    <string name="settings_diagnostics">Diagnóstico</string>
+    <string name="settings_diagnostics_row">Diagnóstico de conexión</string>
+    <string name="diagnostics_title">Diagnóstico</string>
+    <string name="diagnostics_share_button">Compartir diagnóstico</string>
+    <string name="diagnostics_section_connectivity">Conectividad</string>
+    <string name="diagnostics_section_nsd">NSD / servicio companion</string>
+    <string name="diagnostics_section_http">Servidor HTTP</string>
+    <string name="diagnostics_section_ble">Difusión BLE</string>
+    <string name="diagnostics_section_scrobble">Último scrobble</string>
+    <string name="diagnostics_section_build">Información de build</string>
+    <string name="diagnostics_row_wifi">Wi-Fi</string>
+    <string name="diagnostics_row_ipv4">Dirección IPv4</string>
+    <string name="diagnostics_row_multicast_lock">Bloqueo multicast</string>
+    <string name="diagnostics_row_service_running">Servicio activo</string>
+    <string name="diagnostics_row_nsd_state">Estado NSD</string>
+    <string name="diagnostics_row_nsd_error">Código de error NSD</string>
+    <string name="diagnostics_row_http_binding">Dirección vinculada</string>
+    <string name="diagnostics_row_last_capability_poll">Último sondeo TV</string>
+    <string name="diagnostics_row_ble_state">Estado de difusión</string>
+    <string name="diagnostics_row_ble_error">Código de error BLE</string>
+    <string name="diagnostics_row_scrobble_show">Serie</string>
+    <string name="diagnostics_row_scrobble_progress">Progreso</string>
+    <string name="diagnostics_row_scrobble_time">Hora</string>
+    <string name="diagnostics_row_version_name">Nombre de versión</string>
+    <string name="diagnostics_row_version_code">Código de versión</string>
+    <string name="diagnostics_value_unknown">Desconocido</string>
+    <string name="diagnostics_value_yes">Sí</string>
+    <string name="diagnostics_value_no">No</string>
+    <string name="diagnostics_value_stopped">Detenido</string>
+    <string name="diagnostics_value_none">Ninguno</string>
 </resources>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -202,4 +202,7 @@
     <string name="diagnostics_value_no">Non</string>
     <string name="diagnostics_value_stopped">Arrêté</string>
     <string name="diagnostics_value_none">Aucun</string>
+
+    <!-- Version footer -->
+    <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>
 </resources>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -170,4 +170,36 @@
         <item quantity="one">%d série</item>
         <item quantity="other">%d séries</item>
     </plurals>
+
+    <!-- Diagnostics -->
+    <string name="settings_diagnostics">Diagnostic</string>
+    <string name="settings_diagnostics_row">Diagnostic de connexion</string>
+    <string name="diagnostics_title">Diagnostic</string>
+    <string name="diagnostics_share_button">Partager le diagnostic</string>
+    <string name="diagnostics_section_connectivity">Connectivité</string>
+    <string name="diagnostics_section_nsd">NSD / service compagnon</string>
+    <string name="diagnostics_section_http">Serveur HTTP</string>
+    <string name="diagnostics_section_ble">Diffusion BLE</string>
+    <string name="diagnostics_section_scrobble">Dernier scrobble</string>
+    <string name="diagnostics_section_build">Infos build</string>
+    <string name="diagnostics_row_wifi">Wi-Fi</string>
+    <string name="diagnostics_row_ipv4">Adresse IPv4</string>
+    <string name="diagnostics_row_multicast_lock">Verrou multicast</string>
+    <string name="diagnostics_row_service_running">Service actif</string>
+    <string name="diagnostics_row_nsd_state">État NSD</string>
+    <string name="diagnostics_row_nsd_error">Code erreur NSD</string>
+    <string name="diagnostics_row_http_binding">Adresse liée</string>
+    <string name="diagnostics_row_last_capability_poll">Dernière interrogation TV</string>
+    <string name="diagnostics_row_ble_state">État de diffusion</string>
+    <string name="diagnostics_row_ble_error">Code erreur BLE</string>
+    <string name="diagnostics_row_scrobble_show">Série</string>
+    <string name="diagnostics_row_scrobble_progress">Progression</string>
+    <string name="diagnostics_row_scrobble_time">Heure</string>
+    <string name="diagnostics_row_version_name">Nom de version</string>
+    <string name="diagnostics_row_version_code">Code de version</string>
+    <string name="diagnostics_value_unknown">Inconnu</string>
+    <string name="diagnostics_value_yes">Oui</string>
+    <string name="diagnostics_value_no">Non</string>
+    <string name="diagnostics_value_stopped">Arrêté</string>
+    <string name="diagnostics_value_none">Aucun</string>
 </resources>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -178,4 +178,36 @@
         <item quantity="one">%d show</item>
         <item quantity="other">%d shows</item>
     </plurals>
+
+    <!-- Diagnostics -->
+    <string name="settings_diagnostics">Diagnostics</string>
+    <string name="settings_diagnostics_row">Connection diagnostics</string>
+    <string name="diagnostics_title">Diagnostics</string>
+    <string name="diagnostics_share_button">Share diagnostics</string>
+    <string name="diagnostics_section_connectivity">Connectivity</string>
+    <string name="diagnostics_section_nsd">NSD / companion service</string>
+    <string name="diagnostics_section_http">HTTP server</string>
+    <string name="diagnostics_section_ble">BLE advertiser</string>
+    <string name="diagnostics_section_scrobble">Last scrobble</string>
+    <string name="diagnostics_section_build">Build info</string>
+    <string name="diagnostics_row_wifi">Wi-Fi</string>
+    <string name="diagnostics_row_ipv4">IPv4 address</string>
+    <string name="diagnostics_row_multicast_lock">Multicast lock</string>
+    <string name="diagnostics_row_service_running">Service running</string>
+    <string name="diagnostics_row_nsd_state">NSD state</string>
+    <string name="diagnostics_row_nsd_error">NSD error code</string>
+    <string name="diagnostics_row_http_binding">Bound address</string>
+    <string name="diagnostics_row_last_capability_poll">Last TV poll</string>
+    <string name="diagnostics_row_ble_state">Advertiser state</string>
+    <string name="diagnostics_row_ble_error">BLE error code</string>
+    <string name="diagnostics_row_scrobble_show">Show</string>
+    <string name="diagnostics_row_scrobble_progress">Progress</string>
+    <string name="diagnostics_row_scrobble_time">Time</string>
+    <string name="diagnostics_row_version_name">Version name</string>
+    <string name="diagnostics_row_version_code">Version code</string>
+    <string name="diagnostics_value_unknown">Unknown</string>
+    <string name="diagnostics_value_yes">Yes</string>
+    <string name="diagnostics_value_no">No</string>
+    <string name="diagnostics_value_stopped">Stopped</string>
+    <string name="diagnostics_value_none">None</string>
 </resources>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -210,4 +210,7 @@
     <string name="diagnostics_value_no">No</string>
     <string name="diagnostics_value_stopped">Stopped</string>
     <string name="diagnostics_value_none">None</string>
+
+    <!-- Version footer -->
+    <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>
 </resources>

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/service/CompanionStateManagerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/service/CompanionStateManagerTest.kt
@@ -1,0 +1,76 @@
+package com.justb81.watchbuddy.phone.service
+
+import com.justb81.watchbuddy.service.CompanionStateManager
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("CompanionStateManager")
+class CompanionStateManagerTest {
+
+    @Test
+    fun `nsd state transitions emit and error code is carried`() {
+        val mgr = CompanionStateManager()
+        assertEquals(CompanionStateManager.NsdRegistrationState.IDLE, mgr.nsdRegistrationState.value)
+        assertNull(mgr.nsdErrorCode.value)
+
+        mgr.setNsdRegistrationState(CompanionStateManager.NsdRegistrationState.REGISTERING)
+        assertEquals(CompanionStateManager.NsdRegistrationState.REGISTERING, mgr.nsdRegistrationState.value)
+
+        mgr.setNsdRegistrationState(CompanionStateManager.NsdRegistrationState.REGISTERED)
+        assertEquals(CompanionStateManager.NsdRegistrationState.REGISTERED, mgr.nsdRegistrationState.value)
+        assertNull(mgr.nsdErrorCode.value)
+
+        mgr.setNsdRegistrationState(CompanionStateManager.NsdRegistrationState.FAILED, errorCode = 3)
+        assertEquals(CompanionStateManager.NsdRegistrationState.FAILED, mgr.nsdRegistrationState.value)
+        assertEquals(3, mgr.nsdErrorCode.value)
+
+        // Clearing to IDLE resets the error code.
+        mgr.setNsdRegistrationState(CompanionStateManager.NsdRegistrationState.IDLE)
+        assertNull(mgr.nsdErrorCode.value)
+    }
+
+    @Test
+    fun `ble advertise state transitions emit and error code is carried`() {
+        val mgr = CompanionStateManager()
+        assertEquals(CompanionStateManager.BleAdvertiseState.IDLE, mgr.bleAdvertiseState.value)
+
+        mgr.setBleAdvertiseState(CompanionStateManager.BleAdvertiseState.ADVERTISING)
+        assertEquals(CompanionStateManager.BleAdvertiseState.ADVERTISING, mgr.bleAdvertiseState.value)
+        assertNull(mgr.bleAdvertiseErrorCode.value)
+
+        mgr.setBleAdvertiseState(CompanionStateManager.BleAdvertiseState.FAILED, errorCode = 2)
+        assertEquals(CompanionStateManager.BleAdvertiseState.FAILED, mgr.bleAdvertiseState.value)
+        assertEquals(2, mgr.bleAdvertiseErrorCode.value)
+
+        mgr.setBleAdvertiseState(CompanionStateManager.BleAdvertiseState.IDLE)
+        assertNull(mgr.bleAdvertiseErrorCode.value)
+    }
+
+    @Test
+    fun `setServiceRunning false resets transient state`() {
+        val mgr = CompanionStateManager()
+        mgr.setNsdRegistrationState(CompanionStateManager.NsdRegistrationState.REGISTERED)
+        mgr.setHttpServerBinding("0.0.0.0:8765")
+        mgr.setMulticastLockHeld(true)
+        mgr.setBleAdvertiseState(CompanionStateManager.BleAdvertiseState.ADVERTISING)
+        mgr.setWifiIpv4("192.168.1.2")
+        mgr.setServiceRunning(true)
+
+        assertTrue(mgr.isServiceRunning.value)
+        assertEquals("0.0.0.0:8765", mgr.httpServerBinding.value)
+        assertTrue(mgr.multicastLockHeld.value)
+
+        mgr.setServiceRunning(false)
+
+        assertFalse(mgr.isServiceRunning.value)
+        assertNull(mgr.httpServerBinding.value)
+        assertFalse(mgr.multicastLockHeld.value)
+        assertEquals(CompanionStateManager.NsdRegistrationState.IDLE, mgr.nsdRegistrationState.value)
+        assertEquals(CompanionStateManager.BleAdvertiseState.IDLE, mgr.bleAdvertiseState.value)
+        assertNull(mgr.wifiIpv4.value)
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneBleScanner.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneBleScanner.kt
@@ -52,7 +52,10 @@ class PhoneBleScanner @Inject constructor(
     private var scanner: BluetoothLeScanner? = null
     private var activeCallback: ScanCallback? = null
 
-    fun start(listener: Listener): Boolean {
+    fun start(
+        listener: Listener,
+        onFailure: (Int) -> Unit = {},
+    ): Boolean {
         if (!hasScanPermission()) {
             Log.i(TAG, "start skipped: BLUETOOTH_SCAN permission not granted")
             return false
@@ -103,6 +106,7 @@ class PhoneBleScanner @Inject constructor(
                         scanner = null
                     }
                 }
+                onFailure(errorCode)
             }
         }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -55,8 +55,30 @@ class PhoneDiscoveryManager @Inject constructor(
         private const val RESTART_BACKOFF_MS = 500L
     }
 
+    enum class BleScanState { IDLE, SCANNING, FAILED }
+
     private val _discoveredPhones = MutableStateFlow<List<DiscoveredPhone>>(emptyList())
     val discoveredPhones: StateFlow<List<DiscoveredPhone>> = _discoveredPhones
+
+    private val _discoveryActive = MutableStateFlow(false)
+    /** True between [startDiscovery] and [stopDiscovery]. */
+    val discoveryActive: StateFlow<Boolean> = _discoveryActive
+
+    private val _multicastLockHeld = MutableStateFlow(false)
+    /** Whether this manager currently holds a Wi-Fi multicast lock. */
+    val multicastLockHeld: StateFlow<Boolean> = _multicastLockHeld
+
+    private val _bleScanState = MutableStateFlow(BleScanState.IDLE)
+    /** Current state of the BLE fallback scanner. */
+    val bleScanState: StateFlow<BleScanState> = _bleScanState
+
+    private val _bleScanErrorCode = MutableStateFlow<Int?>(null)
+    /** Last `onScanFailed` error code reported by the BLE scanner, or null. */
+    val bleScanErrorCode: StateFlow<Int?> = _bleScanErrorCode
+
+    private val _lastHeartbeatTick = MutableStateFlow(0L)
+    /** Epoch millis of the last heartbeat loop pass, or 0 before the first tick. */
+    val lastHeartbeatTick: StateFlow<Long> = _lastHeartbeatTick
 
     // Nullable + runCatching so that a missing NSD system service on unusual
     // TV ROMs cannot throw during Hilt singleton construction, which would
@@ -163,6 +185,7 @@ class PhoneDiscoveryManager @Inject constructor(
     fun startDiscovery() {
         Log.i(TAG, "startDiscovery: type=$SERVICE_TYPE")
         isDiscovering = true
+        _discoveryActive.value = true
         acquireMulticastLock()
         val mgr = nsdManager
         if (mgr != null) {
@@ -180,6 +203,7 @@ class PhoneDiscoveryManager @Inject constructor(
     fun stopDiscovery() {
         Log.i(TAG, "stopDiscovery")
         isDiscovering = false
+        _discoveryActive.value = false
         heartbeatJob?.cancel()
         unregisterNetworkCallback()
         val mgr = nsdManager
@@ -187,6 +211,8 @@ class PhoneDiscoveryManager @Inject constructor(
             runCatching { mgr.stopServiceDiscovery(discoveryListener) }
         }
         bleScanner.stop()
+        _bleScanState.value = BleScanState.IDLE
+        _bleScanErrorCode.value = null
         releaseMulticastLock()
     }
 
@@ -271,6 +297,7 @@ class PhoneDiscoveryManager @Inject constructor(
                 acquire()
             }
             multicastLock = lock
+            _multicastLockHeld.value = lock.isHeld
             Log.i(TAG, "multicast lock acquired (held=${lock.isHeld})")
         }.onFailure { Log.e(TAG, "multicast lock acquire failed", it) }
     }
@@ -278,6 +305,7 @@ class PhoneDiscoveryManager @Inject constructor(
     private fun releaseMulticastLock() {
         val lock = multicastLock ?: run {
             Log.i(TAG, "multicast lock release skipped: no lock held")
+            _multicastLockHeld.value = false
             return
         }
         runCatching {
@@ -289,6 +317,7 @@ class PhoneDiscoveryManager @Inject constructor(
             }
         }.onFailure { Log.w(TAG, "multicast lock release failed", it) }
         multicastLock = null
+        _multicastLockHeld.value = false
     }
 
     private fun nsdErrorName(errorCode: Int): String = when (errorCode) {
@@ -302,6 +331,7 @@ class PhoneDiscoveryManager @Inject constructor(
         heartbeatJob = heartbeatScope.launch {
             while (true) {
                 delay(DiscoveryConstants.HEARTBEAT_INTERVAL_MS)
+                _lastHeartbeatTick.value = System.currentTimeMillis()
                 checkAllPhones()
             }
         }
@@ -522,8 +552,21 @@ class PhoneDiscoveryManager @Inject constructor(
     }
 
     private fun startBleScan() {
-        bleScanner.start { ipv4, port, quality, backend ->
-            onBleAdvertisement(ipv4, port, quality, backend)
+        val started = bleScanner.start(
+            listener = { ipv4, port, quality, backend ->
+                onBleAdvertisement(ipv4, port, quality, backend)
+            },
+            onFailure = { errorCode ->
+                _bleScanState.value = BleScanState.FAILED
+                _bleScanErrorCode.value = errorCode
+            },
+        )
+        if (started) {
+            _bleScanState.value = BleScanState.SCANNING
+            _bleScanErrorCode.value = null
+        } else if (_bleScanState.value != BleScanState.FAILED) {
+            // Permission denied, BLE off, or unsupported hardware — all soft failures.
+            _bleScanState.value = BleScanState.IDLE
         }
     }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -1,0 +1,313 @@
+package com.justb81.watchbuddy.tv.ui.diagnostics
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.tv.material3.*
+import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.logging.DiagnosticShare
+import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun TvDiagnosticsScreen(
+    onBack: () -> Unit,
+    viewModel: TvDiagnosticsViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 48.dp, vertical = 32.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item {
+                Text(
+                    text = stringResource(R.string.tv_diagnostics_title),
+                    fontSize = 32.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White,
+                )
+                Spacer(Modifier.height(16.dp))
+            }
+
+            item {
+                DiagnosticsSection(
+                    title = stringResource(R.string.tv_diagnostics_section_connectivity),
+                    rows = listOf(
+                        DiagRow(
+                            stringResource(R.string.tv_diagnostics_row_multicast_lock),
+                            yesNoStr(uiState.multicastLockHeld),
+                            if (uiState.multicastLockHeld) Status.OK
+                            else if (uiState.discoveryActive) Status.FAIL else Status.NEUTRAL,
+                        ),
+                    ),
+                )
+            }
+
+            item {
+                DiagnosticsSection(
+                    title = stringResource(R.string.tv_diagnostics_section_nsd),
+                    rows = listOfNotNull(
+                        DiagRow(
+                            stringResource(R.string.tv_diagnostics_row_discovery_active),
+                            yesNoStr(uiState.discoveryActive),
+                            if (uiState.discoveryActive) Status.OK else Status.NEUTRAL,
+                        ),
+                        DiagRow(
+                            stringResource(R.string.tv_diagnostics_row_last_heartbeat),
+                            formatAge(uiState.lastHeartbeatMs),
+                            heartbeatStatus(uiState.lastHeartbeatMs, uiState.discoveryActive),
+                        ),
+                    ),
+                )
+            }
+
+            item {
+                DiagnosticsSection(
+                    title = stringResource(R.string.tv_diagnostics_section_ble),
+                    rows = listOfNotNull(
+                        DiagRow(
+                            stringResource(R.string.tv_diagnostics_row_ble_state),
+                            uiState.bleScanState.name,
+                            when (uiState.bleScanState) {
+                                PhoneDiscoveryManager.BleScanState.SCANNING -> Status.OK
+                                PhoneDiscoveryManager.BleScanState.FAILED -> Status.FAIL
+                                PhoneDiscoveryManager.BleScanState.IDLE -> Status.NEUTRAL
+                            },
+                        ),
+                        uiState.bleScanErrorCode?.let {
+                            DiagRow(
+                                stringResource(R.string.tv_diagnostics_row_ble_error),
+                                it.toString(),
+                                Status.FAIL,
+                            )
+                        },
+                    ),
+                )
+            }
+
+            item {
+                Text(
+                    text = stringResource(R.string.tv_diagnostics_section_phones).uppercase(),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White.copy(alpha = 0.7f),
+                    modifier = Modifier.padding(top = 8.dp, bottom = 4.dp, start = 4.dp),
+                )
+            }
+
+            if (uiState.phones.isEmpty()) {
+                item {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+                        onClick = {},
+                    ) {
+                        Text(
+                            text = stringResource(R.string.tv_diagnostics_value_no_phones),
+                            color = Color.White.copy(alpha = 0.5f),
+                            modifier = Modifier.padding(16.dp),
+                        )
+                    }
+                }
+            } else {
+                items(uiState.phones, key = { it.baseUrl }) { phone ->
+                    PhoneDiagnosticsCard(phone)
+                }
+            }
+
+            item {
+                DiagnosticsSection(
+                    title = stringResource(R.string.tv_diagnostics_section_build),
+                    rows = listOf(
+                        DiagRow(
+                            stringResource(R.string.tv_diagnostics_row_version_name),
+                            uiState.versionName,
+                            Status.NEUTRAL,
+                        ),
+                        DiagRow(
+                            stringResource(R.string.tv_diagnostics_row_version_code),
+                            uiState.versionCode.toString(),
+                            Status.NEUTRAL,
+                        ),
+                    ),
+                )
+            }
+
+            item {
+                Spacer(Modifier.height(16.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                    OutlinedButton(onClick = { DiagnosticShare.launchShare(context) }) {
+                        Text(stringResource(R.string.tv_diagnostics_share_button))
+                    }
+                    OutlinedButton(onClick = onBack) {
+                        Text(stringResource(R.string.tv_back))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun PhoneDiagnosticsCard(phone: PhoneDiscoveryManager.DiscoveredPhone) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+        onClick = {},
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = phone.capability?.userName
+                    ?: phone.serviceInfo.serviceName
+                    ?: phone.baseUrl,
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Medium,
+                color = Color.White,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = phone.baseUrl,
+                fontSize = 12.sp,
+                color = Color.White.copy(alpha = 0.5f),
+            )
+            Spacer(Modifier.height(8.dp))
+            PhoneRow(stringResource(R.string.tv_diagnostics_row_phone_score), phone.score.toString())
+            phone.txtRecord?.let { txt ->
+                PhoneRow(
+                    stringResource(R.string.tv_diagnostics_row_phone_quality),
+                    txt.modelQuality.toString(),
+                )
+                PhoneRow(
+                    stringResource(R.string.tv_diagnostics_row_phone_backend),
+                    txt.llmBackend.name,
+                )
+            }
+            PhoneRow(
+                stringResource(R.string.tv_diagnostics_row_phone_fail_count),
+                phone.failCount.toString(),
+            )
+            PhoneRow(
+                stringResource(R.string.tv_diagnostics_row_phone_last_success),
+                formatAge(phone.lastSuccessfulCheck),
+            )
+        }
+    }
+}
+
+@Composable
+private fun PhoneRow(label: String, value: String) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 2.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label, fontSize = 12.sp, color = Color.White.copy(alpha = 0.7f))
+        Text(value, fontSize = 12.sp, color = Color.White)
+    }
+}
+
+private data class DiagRow(val label: String, val value: String, val status: Status)
+
+private enum class Status { OK, WARN, FAIL, NEUTRAL }
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun DiagnosticsSection(title: String, rows: List<DiagRow>) {
+    Text(
+        text = title.uppercase(),
+        fontSize = 14.sp,
+        fontWeight = FontWeight.Bold,
+        color = Color.White.copy(alpha = 0.7f),
+        modifier = Modifier.padding(top = 8.dp, bottom = 4.dp, start = 4.dp),
+    )
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+        onClick = {},
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            rows.forEach { row ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Box(
+                            modifier = Modifier
+                                .size(10.dp)
+                                .background(statusColor(row.status), RoundedCornerShape(2.dp)),
+                        )
+                        Spacer(Modifier.width(12.dp))
+                        Text(row.label, fontSize = 14.sp, color = Color.White)
+                    }
+                    Text(
+                        row.value,
+                        fontSize = 13.sp,
+                        color = Color.White.copy(alpha = 0.7f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun statusColor(status: Status): Color = when (status) {
+    Status.OK -> Color(0xFF2E7D32)
+    Status.WARN -> Color(0xFFF9A825)
+    Status.FAIL -> Color(0xFFC62828)
+    Status.NEUTRAL -> Color.White.copy(alpha = 0.3f)
+}
+
+@Composable
+private fun yesNoStr(value: Boolean): String =
+    if (value) stringResource(R.string.tv_diagnostics_value_yes)
+    else stringResource(R.string.tv_diagnostics_value_no)
+
+private fun heartbeatStatus(tickMs: Long, discoveryActive: Boolean): Status {
+    if (!discoveryActive) return Status.NEUTRAL
+    if (tickMs == 0L) return Status.WARN
+    val ageMs = System.currentTimeMillis() - tickMs
+    return when {
+        ageMs < 2 * 60_000 -> Status.OK
+        ageMs < 5 * 60_000 -> Status.WARN
+        else -> Status.FAIL
+    }
+}
+
+private fun formatAge(timestampMs: Long): String {
+    if (timestampMs == 0L) return "—"
+    val seconds = (System.currentTimeMillis() - timestampMs) / 1000
+    return when {
+        seconds < 0 -> "—"
+        seconds < 60 -> "${seconds}s ago"
+        seconds < 3_600 -> "${seconds / 60}m ago"
+        else -> "${seconds / 3_600}h ago"
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
@@ -1,0 +1,64 @@
+package com.justb81.watchbuddy.tv.ui.diagnostics
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.justb81.watchbuddy.BuildConfig
+import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class TvDiagnosticsUiState(
+    val discoveryActive: Boolean = false,
+    val multicastLockHeld: Boolean = false,
+    val bleScanState: PhoneDiscoveryManager.BleScanState = PhoneDiscoveryManager.BleScanState.IDLE,
+    val bleScanErrorCode: Int? = null,
+    val lastHeartbeatMs: Long = 0L,
+    val phones: List<PhoneDiscoveryManager.DiscoveredPhone> = emptyList(),
+    val versionName: String = BuildConfig.VERSION_NAME,
+    val versionCode: Int = BuildConfig.VERSION_CODE,
+)
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class TvDiagnosticsViewModel @Inject constructor(
+    phoneDiscovery: PhoneDiscoveryManager,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(TvDiagnosticsUiState())
+    val uiState: StateFlow<TvDiagnosticsUiState> = _uiState.asStateFlow()
+
+    init {
+        val partA = combine(
+            phoneDiscovery.discoveryActive,
+            phoneDiscovery.multicastLockHeld,
+            phoneDiscovery.bleScanState,
+        ) { active, lock, ble ->
+            Triple(active, lock, ble)
+        }
+        val partB = combine(
+            phoneDiscovery.bleScanErrorCode,
+            phoneDiscovery.lastHeartbeatTick,
+            phoneDiscovery.discoveredPhones,
+        ) { bleErr, tick, phones ->
+            Triple(bleErr, tick, phones)
+        }
+        viewModelScope.launch {
+            combine(partA, partB) { a, b ->
+                TvDiagnosticsUiState(
+                    discoveryActive = a.first,
+                    multicastLockHeld = a.second,
+                    bleScanState = a.third,
+                    bleScanErrorCode = b.first,
+                    lastHeartbeatMs = b.second,
+                    phones = b.third,
+                )
+            }.collect { _uiState.value = it }
+        }
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.tv.ui.diagnostics.TvDiagnosticsScreen
 import com.justb81.watchbuddy.tv.ui.home.TvHomeScreen
 import com.justb81.watchbuddy.tv.ui.recap.RecapScreen
 import com.justb81.watchbuddy.tv.ui.scrobble.ScrobbleOverlay
@@ -22,6 +23,7 @@ sealed class TvRoute(val route: String) {
     object ShowDetail : TvRoute("tv_show_detail")
     object Recap              : TvRoute("tv_recap")
     object StreamingSettings  : TvRoute("tv_streaming_settings")
+    object Diagnostics        : TvRoute("tv_diagnostics")
 }
 
 @Composable
@@ -86,8 +88,13 @@ fun TvNavGraph() {
 
         composable(TvRoute.StreamingSettings.route) {
             StreamingSettingsScreen(
-                onBack = { navController.popBackStack() }
+                onBack = { navController.popBackStack() },
+                onDiagnosticsClick = { navController.navigate(TvRoute.Diagnostics.route) }
             )
+        }
+
+        composable(TvRoute.Diagnostics.route) {
+            TvDiagnosticsScreen(onBack = { navController.popBackStack() })
         }
     }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsScreen.kt
@@ -26,6 +26,7 @@ import com.justb81.watchbuddy.tv.ui.theme.extendedColors
 @Composable
 fun StreamingSettingsScreen(
     onBack: () -> Unit,
+    onDiagnosticsClick: () -> Unit = {},
     viewModel: StreamingSettingsViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -85,9 +86,14 @@ fun StreamingSettingsScreen(
 
             Spacer(Modifier.height(16.dp))
 
-            // Back button
-            OutlinedButton(onClick = onBack) {
-                Text(stringResource(R.string.tv_back))
+            // Footer actions
+            Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                OutlinedButton(onClick = onBack) {
+                    Text(stringResource(R.string.tv_back))
+                }
+                OutlinedButton(onClick = onDiagnosticsClick) {
+                    Text(stringResource(R.string.tv_diagnostics_title))
+                }
             }
         }
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/StreamingSettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.tv.material3.*
+import com.justb81.watchbuddy.BuildConfig
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.model.StreamingService
 import com.justb81.watchbuddy.tv.ui.theme.extendedColors
@@ -85,6 +86,17 @@ fun StreamingSettingsScreen(
             }
 
             Spacer(Modifier.height(16.dp))
+
+            Text(
+                text = stringResource(
+                    R.string.settings_version_footer,
+                    BuildConfig.VERSION_NAME,
+                    BuildConfig.VERSION_CODE,
+                ),
+                fontSize = 12.sp,
+                color = Color.White.copy(alpha = 0.5f),
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
 
             // Footer actions
             Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -93,4 +93,27 @@
     <string name="cd_service_move_up">%1$s in der Priorität nach oben verschieben</string>
     <string name="cd_service_move_down">%1$s in der Priorität nach unten verschieben</string>
 
+    <!-- Diagnostics -->
+    <string name="tv_diagnostics_title">Diagnose</string>
+    <string name="tv_diagnostics_share_button">Diagnose teilen</string>
+    <string name="tv_diagnostics_section_connectivity">Verbindung</string>
+    <string name="tv_diagnostics_section_nsd">Erkennung (NSD)</string>
+    <string name="tv_diagnostics_section_ble">BLE-Scanner</string>
+    <string name="tv_diagnostics_section_phones">Gefundene Telefone</string>
+    <string name="tv_diagnostics_section_build">Build-Infos</string>
+    <string name="tv_diagnostics_row_multicast_lock">Multicast-Lock</string>
+    <string name="tv_diagnostics_row_discovery_active">Erkennung aktiv</string>
+    <string name="tv_diagnostics_row_last_heartbeat">Letzter Heartbeat</string>
+    <string name="tv_diagnostics_row_ble_state">Scanner-Status</string>
+    <string name="tv_diagnostics_row_ble_error">BLE-Fehlercode</string>
+    <string name="tv_diagnostics_row_phone_score">Punkte</string>
+    <string name="tv_diagnostics_row_phone_quality">Modellqualität</string>
+    <string name="tv_diagnostics_row_phone_backend">LLM-Backend</string>
+    <string name="tv_diagnostics_row_phone_fail_count">Aufeinanderfolgende Fehler</string>
+    <string name="tv_diagnostics_row_phone_last_success">Letzter Erfolg</string>
+    <string name="tv_diagnostics_row_version_name">Versionsname</string>
+    <string name="tv_diagnostics_row_version_code">Versionscode</string>
+    <string name="tv_diagnostics_value_yes">Ja</string>
+    <string name="tv_diagnostics_value_no">Nein</string>
+    <string name="tv_diagnostics_value_no_phones">Noch keine Telefone gefunden.</string>
 </resources>

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -116,4 +116,7 @@
     <string name="tv_diagnostics_value_yes">Ja</string>
     <string name="tv_diagnostics_value_no">Nein</string>
     <string name="tv_diagnostics_value_no_phones">Noch keine Telefone gefunden.</string>
+
+    <!-- Version footer -->
+    <string name="settings_version_footer">WatchBuddy v%1$s (Build %2$d)</string>
 </resources>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -93,4 +93,27 @@
     <string name="cd_service_move_up">Subir %1$s en la prioridad</string>
     <string name="cd_service_move_down">Bajar %1$s en la prioridad</string>
 
+    <!-- Diagnostics -->
+    <string name="tv_diagnostics_title">Diagnóstico</string>
+    <string name="tv_diagnostics_share_button">Compartir diagnóstico</string>
+    <string name="tv_diagnostics_section_connectivity">Conectividad</string>
+    <string name="tv_diagnostics_section_nsd">Descubrimiento (NSD)</string>
+    <string name="tv_diagnostics_section_ble">Escáner BLE</string>
+    <string name="tv_diagnostics_section_phones">Teléfonos encontrados</string>
+    <string name="tv_diagnostics_section_build">Información de build</string>
+    <string name="tv_diagnostics_row_multicast_lock">Bloqueo multicast</string>
+    <string name="tv_diagnostics_row_discovery_active">Descubrimiento activo</string>
+    <string name="tv_diagnostics_row_last_heartbeat">Último heartbeat</string>
+    <string name="tv_diagnostics_row_ble_state">Estado del escáner</string>
+    <string name="tv_diagnostics_row_ble_error">Código de error BLE</string>
+    <string name="tv_diagnostics_row_phone_score">Puntuación</string>
+    <string name="tv_diagnostics_row_phone_quality">Calidad del modelo</string>
+    <string name="tv_diagnostics_row_phone_backend">Backend LLM</string>
+    <string name="tv_diagnostics_row_phone_fail_count">Fallos consecutivos</string>
+    <string name="tv_diagnostics_row_phone_last_success">Último éxito</string>
+    <string name="tv_diagnostics_row_version_name">Nombre de versión</string>
+    <string name="tv_diagnostics_row_version_code">Código de versión</string>
+    <string name="tv_diagnostics_value_yes">Sí</string>
+    <string name="tv_diagnostics_value_no">No</string>
+    <string name="tv_diagnostics_value_no_phones">No se han encontrado teléfonos.</string>
 </resources>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -116,4 +116,7 @@
     <string name="tv_diagnostics_value_yes">Sí</string>
     <string name="tv_diagnostics_value_no">No</string>
     <string name="tv_diagnostics_value_no_phones">No se han encontrado teléfonos.</string>
+
+    <!-- Version footer -->
+    <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>
 </resources>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -93,4 +93,27 @@
     <string name="cd_service_move_up">Monter %1$s dans la priorité</string>
     <string name="cd_service_move_down">Descendre %1$s dans la priorité</string>
 
+    <!-- Diagnostics -->
+    <string name="tv_diagnostics_title">Diagnostic</string>
+    <string name="tv_diagnostics_share_button">Partager le diagnostic</string>
+    <string name="tv_diagnostics_section_connectivity">Connectivité</string>
+    <string name="tv_diagnostics_section_nsd">Découverte (NSD)</string>
+    <string name="tv_diagnostics_section_ble">Scanner BLE</string>
+    <string name="tv_diagnostics_section_phones">Téléphones détectés</string>
+    <string name="tv_diagnostics_section_build">Infos build</string>
+    <string name="tv_diagnostics_row_multicast_lock">Verrou multicast</string>
+    <string name="tv_diagnostics_row_discovery_active">Découverte active</string>
+    <string name="tv_diagnostics_row_last_heartbeat">Dernier heartbeat</string>
+    <string name="tv_diagnostics_row_ble_state">État du scanner</string>
+    <string name="tv_diagnostics_row_ble_error">Code erreur BLE</string>
+    <string name="tv_diagnostics_row_phone_score">Score</string>
+    <string name="tv_diagnostics_row_phone_quality">Qualité du modèle</string>
+    <string name="tv_diagnostics_row_phone_backend">Backend LLM</string>
+    <string name="tv_diagnostics_row_phone_fail_count">Échecs consécutifs</string>
+    <string name="tv_diagnostics_row_phone_last_success">Dernier succès</string>
+    <string name="tv_diagnostics_row_version_name">Nom de version</string>
+    <string name="tv_diagnostics_row_version_code">Code de version</string>
+    <string name="tv_diagnostics_value_yes">Oui</string>
+    <string name="tv_diagnostics_value_no">Non</string>
+    <string name="tv_diagnostics_value_no_phones">Aucun téléphone détecté.</string>
 </resources>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -116,4 +116,7 @@
     <string name="tv_diagnostics_value_yes">Oui</string>
     <string name="tv_diagnostics_value_no">Non</string>
     <string name="tv_diagnostics_value_no_phones">Aucun téléphone détecté.</string>
+
+    <!-- Version footer -->
+    <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>
 </resources>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -116,4 +116,7 @@
     <string name="tv_diagnostics_value_yes">Yes</string>
     <string name="tv_diagnostics_value_no">No</string>
     <string name="tv_diagnostics_value_no_phones">No phones discovered yet.</string>
+
+    <!-- Version footer -->
+    <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>
 </resources>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -92,4 +92,28 @@
     <string name="cd_scrobble_countdown">Auto-confirm in %1$d seconds</string>
     <string name="cd_service_move_up">Move %1$s up in priority</string>
     <string name="cd_service_move_down">Move %1$s down in priority</string>
+
+    <!-- Diagnostics -->
+    <string name="tv_diagnostics_title">Diagnostics</string>
+    <string name="tv_diagnostics_share_button">Share diagnostics</string>
+    <string name="tv_diagnostics_section_connectivity">Connectivity</string>
+    <string name="tv_diagnostics_section_nsd">Discovery (NSD)</string>
+    <string name="tv_diagnostics_section_ble">BLE scanner</string>
+    <string name="tv_diagnostics_section_phones">Discovered phones</string>
+    <string name="tv_diagnostics_section_build">Build info</string>
+    <string name="tv_diagnostics_row_multicast_lock">Multicast lock</string>
+    <string name="tv_diagnostics_row_discovery_active">Discovery active</string>
+    <string name="tv_diagnostics_row_last_heartbeat">Last heartbeat</string>
+    <string name="tv_diagnostics_row_ble_state">Scanner state</string>
+    <string name="tv_diagnostics_row_ble_error">BLE error code</string>
+    <string name="tv_diagnostics_row_phone_score">Score</string>
+    <string name="tv_diagnostics_row_phone_quality">Model quality</string>
+    <string name="tv_diagnostics_row_phone_backend">LLM backend</string>
+    <string name="tv_diagnostics_row_phone_fail_count">Consecutive failures</string>
+    <string name="tv_diagnostics_row_phone_last_success">Last success</string>
+    <string name="tv_diagnostics_row_version_name">Version name</string>
+    <string name="tv_diagnostics_row_version_code">Version code</string>
+    <string name="tv_diagnostics_value_yes">Yes</string>
+    <string name="tv_diagnostics_value_no">No</string>
+    <string name="tv_diagnostics_value_no_phones">No phones discovered yet.</string>
 </resources>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -251,6 +251,28 @@ network callback restarts discovery when Wi-Fi returns, and an empty phone list 
 60 s heartbeat tick cycles discovery so the TV recovers from silent NSD failures without
 requiring an app relaunch.
 
+## Diagnostics View
+
+Both apps expose a **Diagnostics** screen under Settings → Diagnostics. It renders the
+live connection state from the shared singletons — `CompanionStateManager` on the phone,
+`PhoneDiscoveryManager` on the TV — so end users (and agents triaging bug reports) can
+distinguish the common causes of "TV can't see the phone":
+
+- **Phone** — Wi-Fi on/off + IPv4, multicast lock, NSD registration state (IDLE /
+  REGISTERING / REGISTERED / UNREGISTERING / FAILED + error code), HTTP listen address,
+  age of the most recent TV `/capability` poll, BLE advertiser state + error code, last
+  scrobble event, build info.
+- **TV** — multicast lock held, discovery active, heartbeat age, BLE scanner state +
+  error code, one card per discovered phone (name, `baseUrl`, score, `modelQuality`,
+  `llmBackend`, `failCount`, age of `lastSuccessfulCheck`), build info.
+
+Each row is colour-coded green / yellow / red so users can tell "AP isolation" (no phones
+at all, BLE scanning, multicast lock held) apart from "`/capability` 500" (phone
+discovered, non-zero `failCount`). A "Share diagnostics" button delegates to
+`DiagnosticShare.launchShare()`, which bundles the current `DiagnosticLog` snapshot and
+any pending crash reports through the system share sheet. The view is available in
+release builds; no new build variant was introduced (#331).
+
 ## Scrobble Event Display (Phone)
 
 When the phone's HTTP server receives a scrobble event (`/scrobble/start|pause|stop`), it


### PR DESCRIPTION
Implements the plans from #331 **and** #330.

## Summary

1. **In-app diagnostics view (#331)** — a Settings → Diagnostics screen on both apps that renders the live phone↔TV connection state from the existing shared singletons (`CompanionStateManager` on phone, `PhoneDiscoveryManager` on TV). End users can now distinguish common "TV can't see the phone" root causes — AP/client isolation, multicast filtering, `/capability` 500, BLE permission denied — without needing `adb logcat`, and can export the `DiagnosticLog` snapshot through the existing `DiagnosticShare` share-sheet pipeline.
2. **Settings version footer (#330)** — a `WatchBuddy v<name> (build <code>)` footer at the bottom of each Settings screen, sourced from `BuildConfig`, so bug-report filers can tell at a glance which build they're on.

## Phone

- **`CompanionStateManager`** gains `nsdRegistrationState` (+`nsdErrorCode`), `httpServerBinding`, `multicastLockHeld`, `bleAdvertiseState` (+`bleAdvertiseErrorCode`), `wifiIpv4` StateFlows. `setServiceRunning(false)` resets the transient set so stale flags don't linger after the foreground service stops.
- **`CompanionService`** pushes every NSD transition, multicast-lock acquire/release, HTTP binding, and Wi-Fi IPv4 snapshot into the manager — instrumentation only, no behavior change.
- **`CompanionBleAdvertiser`** reports `onStartSuccess` / `onStartFailure(code)` / `stop` transitions through the manager; injected as a new dependency.
- **`phone/ui/diagnostics/`** (new) — `DiagnosticsScreen` + `DiagnosticsViewModel`. Scrollable layout, `key: value` rows with green/yellow/red status dots. Footer is a `Share diagnostics` button wired to `DiagnosticShare.launchShare(context)`.
- **`SettingsScreen`** gets a new top-of-list Diagnostics row and a centered version footer at the bottom of the scrollable column; `PhoneNavGraph` gets a `Diagnostics` route.

## TV

- **`PhoneDiscoveryManager`** gains `discoveryActive`, `multicastLockHeld`, `bleScanState` (+`bleScanErrorCode`), `lastHeartbeatTick` StateFlows.
- **`PhoneBleScanner.start(...)`** takes an optional `onFailure(errorCode)` callback (defaulted, so existing call sites are unchanged at source level). `PhoneDiscoveryManager` uses it to flip `bleScanState` to `FAILED` when the scanner reports a hardware error.
- **`tv/ui/diagnostics/`** (new) — `TvDiagnosticsScreen` + `TvDiagnosticsViewModel`. Compose-for-TV layout with one `Card` per discovered phone (`baseUrl`, score, `modelQuality`, `llmBackend`, `failCount`, age of `lastSuccessfulCheck`). `StreamingSettingsScreen` footer gets a Diagnostics button, a version footer line, and `TvNavGraph` gets a `Diagnostics` route.

## Localisation

30+ new keys across phone and TV, EN / DE / FR / ES, plus the localised `settings_version_footer` key on both apps.

## Tests

- New `CompanionStateManagerTest` — pins NSD / BLE state transitions, error-code carry-through, and the `setServiceRunning(false)` reset.

## Docs

- `CLAUDE.md` — `diagnostics/` added to both app trees; new "Diagnostics view" bullet under Important Patterns.
- `docs/architecture.md` — new **Diagnostics View** section under Communication Protocol.
- `README.md` — in-app diagnostics added to Key Features.

## Non-goals

- No new build variant — the view ships in release builds.
- No telemetry — all data stays on-device and is only exported via the existing share-sheet.
- No TMDB/Trakt credentials exposed (only presence/absence).
- No change to the NSD/BLE wire protocol.

## Test plan

- [ ] CI `build-android.yml` (green gate).
- [ ] Manual (phone): toggle "I am watching TV"; Settings → Diagnostics shows green status for Wi-Fi, multicast lock, NSD registered, HTTP bound, BLE advertising (if `BLUETOOTH_ADVERTISE` granted); version footer visible at bottom of Settings.
- [ ] Manual (TV): with phone discovered, Settings → Diagnostics shows discovery active, BLE scanning, one phone card with non-zero score and `failCount=0`; version footer visible above the Back / Diagnostics buttons.
- [ ] Manual (TV): with phone off or isolated, card list is empty; BLE scanner still active; multicast lock held.
- [ ] Manual: "Share diagnostics" on either screen opens the share sheet with a `.txt` snapshot.

Closes #331.
Closes #330.

https://claude.ai/code/session_01DqBRbJMWcPA6hC7hborm4G