### PR TITLE
feat(phone): add pull-to-refresh to Home and Show Detail screens

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
@@ -56,6 +56,10 @@ class ShowRepository @Inject constructor(
         ShowProgressCalculator.latestWatchedInstant(it.entry)
     }.thenBy { it.entry.show.title.lowercase() }
 
+    fun invalidateCache() {
+        lastFetch = 0L
+    }
+
     suspend fun getShows(): List<EnrichedShowEntry> {
         val now = System.currentTimeMillis()
         val cached = _shows.value

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
@@ -250,6 +250,7 @@ fun HomeScreen(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun HomeContent(
     state: HomeUiState,

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.*
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
@@ -238,7 +239,9 @@ fun HomeScreen(
                         HomeContent(
                             state = uiState,
                             onShowClick = onShowClick,
-                            onToggleWatchingTv = handleToggleWatchingTv
+                            onToggleWatchingTv = handleToggleWatchingTv,
+                            isRefreshing = uiState.isSyncing,
+                            onRefresh = { viewModel.sync() }
                         )
                     }
                 }
@@ -251,7 +254,9 @@ fun HomeScreen(
 private fun HomeContent(
     state: HomeUiState,
     onShowClick: (Int) -> Unit,
-    onToggleWatchingTv: (Boolean) -> Unit
+    onToggleWatchingTv: (Boolean) -> Unit,
+    isRefreshing: Boolean,
+    onRefresh: () -> Unit
 ) {
     val orientation = LocalConfiguration.current.orientation
     val isLandscape = orientation == Configuration.ORIENTATION_LANDSCAPE
@@ -265,6 +270,11 @@ private fun HomeContent(
     }
     var allShowsExpanded by rememberSaveable { mutableStateOf(false) }
 
+    PullToRefreshBox(
+        isRefreshing = isRefreshing,
+        onRefresh = onRefresh,
+        modifier = Modifier.fillMaxSize()
+    ) {
     LazyColumn(
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
@@ -345,6 +355,7 @@ private fun HomeContent(
                 )
             }
         }
+    }
     }
 }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
@@ -169,35 +169,41 @@ class HomeViewModel @Inject constructor(
     }
 
     fun loadShows() {
-        viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, error = null) }
-            try {
-                val token = tokenRepository.getAccessToken()
-                    ?: throw IllegalStateException("No access token available")
-                showRepository.getShows() // Result flows into observeShows() via StateFlow.
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        lastSyncTime = getApplication<Application>().getString(R.string.home_just_now)
-                    )
-                }
-            } catch (e: Exception) {
-                val httpCode = (e as? retrofit2.HttpException)?.code()
-                val errorMsg = if (httpCode == 401 || httpCode == 403) {
-                    getApplication<Application>().getString(R.string.home_sync_failed_auth)
-                } else {
-                    getApplication<Application>().getString(R.string.home_sync_failed, e.message)
-                }
-                _uiState.update { it.copy(isLoading = false, error = errorMsg) }
-            }
-        }
+        viewModelScope.launch { fetchShows() }
     }
 
     fun sync() {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isSyncing = true)
-            loadShows()
-            _uiState.value = _uiState.value.copy(isSyncing = false)
+            _uiState.update { it.copy(isSyncing = true) }
+            showRepository.invalidateCache()
+            try {
+                fetchShows()
+            } finally {
+                _uiState.update { it.copy(isSyncing = false) }
+            }
+        }
+    }
+
+    private suspend fun fetchShows() {
+        _uiState.update { it.copy(isLoading = true, error = null) }
+        try {
+            val token = tokenRepository.getAccessToken()
+                ?: throw IllegalStateException("No access token available")
+            showRepository.getShows() // Result flows into observeShows() via StateFlow.
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    lastSyncTime = getApplication<Application>().getString(R.string.home_just_now)
+                )
+            }
+        } catch (e: Exception) {
+            val httpCode = (e as? retrofit2.HttpException)?.code()
+            val errorMsg = if (httpCode == 401 || httpCode == 403) {
+                getApplication<Application>().getString(R.string.home_sync_failed_auth)
+            } else {
+                getApplication<Application>().getString(R.string.home_sync_failed, e.message)
+            }
+            _uiState.update { it.copy(isLoading = false, error = errorMsg) }
         }
     }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material3.*
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -101,6 +102,11 @@ fun ShowDetailScreen(
                 }
 
                 else -> {
+                    PullToRefreshBox(
+                        isRefreshing = uiState.isRefreshing,
+                        onRefresh = { viewModel.loadShowDetail(isRefresh = true) },
+                        modifier = Modifier.fillMaxSize()
+                    ) {
                     LazyColumn(
                         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp)
@@ -139,6 +145,7 @@ fun ShowDetailScreen(
                                 )
                             }
                         }
+                    }
                     }
                 }
             }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModel.kt
@@ -24,6 +24,7 @@ import javax.inject.Inject
 
 data class ShowDetailUiState(
     val isLoading: Boolean = true,
+    val isRefreshing: Boolean = false,
     val show: TraktShow? = null,
     val posterUrl: String? = null,
     val overview: String? = null,
@@ -69,26 +70,37 @@ class ShowDetailViewModel @Inject constructor(
         loadShowDetail()
     }
 
-    fun loadShowDetail() {
+    fun loadShowDetail(isRefresh: Boolean = false) {
         viewModelScope.launch {
-            _uiState.value = ShowDetailUiState(isLoading = true)
+            if (isRefresh) {
+                _uiState.update { it.copy(isRefreshing = true, error = null) }
+            } else {
+                _uiState.value = ShowDetailUiState(isLoading = true)
+            }
             try {
                 val watchedEntry = findWatchedEntry()
                 val seasons = episodeRepository.getSeasonsWithEpisodes(traktShowId.toString())
                 val seasonUis = buildSeasonUis(seasons, watchedEntry)
 
-                _uiState.value = ShowDetailUiState(
-                    isLoading = false,
-                    show = watchedEntry.show,
-                    seasons = seasonUis
-                )
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        isRefreshing = false,
+                        show = watchedEntry.show,
+                        seasons = seasonUis,
+                        error = null
+                    )
+                }
 
                 watchedEntry.show.ids.tmdb?.let { tmdbId -> loadTmdbDetails(tmdbId) }
             } catch (e: Exception) {
-                _uiState.value = ShowDetailUiState(
-                    isLoading = false,
-                    error = getApplication<Application>().getString(R.string.error_generic)
-                )
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        isRefreshing = false,
+                        error = getApplication<Application>().getString(R.string.error_generic)
+                    )
+                }
             }
         }
     }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
@@ -120,6 +120,20 @@ class ShowRepositoryTest {
     }
 
     @Test
+    fun `invalidateCache causes getShows to hit network even within TTL`() = runTest {
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+        coEvery { traktApi.getWatchedShows(any()) } returns testShows
+
+        repository.getShows()
+        coVerify(exactly = 1) { traktApi.getWatchedShows(any()) }
+
+        repository.invalidateCache()
+        repository.getShows()
+
+        coVerify(exactly = 2) { traktApi.getWatchedShows(any()) }
+    }
+
+    @Test
     fun `getShows enriches entries with TMDB poster path when API key is set`() = runTest {
         every { settingsRepository.getTmdbApiKey() } returns flowOf("api-key")
         coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModelTest.kt
@@ -240,6 +240,48 @@ class HomeViewModelTest {
 
             assertNull(vm.uiState.value.error)
         }
+
+        @Test
+        fun `sync resets isSyncing to false after successful load`() = runTest {
+            every { tokenRepository.getAccessToken() } returns "valid-token"
+            stubShows(emptyList())
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.sync()
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.isSyncing)
+        }
+
+        @Test
+        fun `sync resets isSyncing to false after failed load`() = runTest {
+            every { tokenRepository.getAccessToken() } returns "valid-token"
+            stubShowsThrows(RuntimeException("network error"))
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.sync()
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.isSyncing)
+        }
+
+        @Test
+        fun `sync calls invalidateCache to bypass TTL`() = runTest {
+            every { tokenRepository.getAccessToken() } returns "valid-token"
+            stubShows(emptyList())
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            vm.sync()
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { showRepository.invalidateCache() }
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary

Implements issue #328 — pull-to-refresh gesture on both phone screens using `PullToRefreshBox` from the already-pinned `compose-bom = 2025.04.01`. No new dependencies required.

- **HomeScreen**: wraps `LazyColumn` in `HomeContent` with `PullToRefreshBox`; pull calls `sync()` which bypasses the `ShowRepository` 5-min TTL via `invalidateCache()` so the network is always hit on a manual refresh. The top-bar sync button is preserved as an additive alternative.
- **ShowDetailScreen**: wraps `LazyColumn` in the `else` branch with `PullToRefreshBox`; pull calls `loadShowDetail(isRefresh=true)`, which keeps existing content visible (spinner-only, no full-screen loading takeover) while data reloads.
- **`ShowRepository.invalidateCache()`**: resets `lastFetch` to `0L` so the next `getShows()` call skips the TTL and goes to the network.
- **`HomeViewModel.sync()`**: extracted private suspend `fetchShows()` so `isSyncing` is correctly reset in a `finally` block on both success and failure paths (previously it was reset immediately after launching the inner coroutine, before it finished).

## Test plan

- [x] `HomeViewModelTest`: `isSyncing` resets to `false` on success and failure; `sync()` calls `invalidateCache()`
- [x] `ShowRepositoryTest`: `invalidateCache()` causes network hit even within TTL
- [ ] Manual: Home screen — swipe down → indicator spins → list updates; airplane mode → spinner stops, existing error message shown
- [ ] Manual: Show Detail — swipe down → episodes reload without full-screen loading takeover; Retry button on error state still functional

https://claude.ai/code/session_01H2Vov161BXjYqteH9WV1Wc