### PR TITLE
docs: require concurrency check before starting agent work

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,12 +128,17 @@ The only exceptions are **localization string resources** (`values-de/`, `values
 
 **The complete agent workflow:**
 
-1. Create a feature branch from `main`
-2. Make changes and commit using Conventional Commits (see below)
-3. Push the branch and open a PR against `main`
-4. **Wait for a green CI build** (`build-android.yml`) — do not continue if the build is red; fix the issue first
-5. **Auto-merge when green.** Once every required build step on the PR has completed successfully, the agent may merge the PR into `main` automatically (e.g. via `enable_pr_auto_merge` or by merging directly after CI passes). Use a squash merge and delete the branch after merge.
-6. If CI fails or a required check is still pending, do NOT merge — fix the failure or wait.
+1. **Check for concurrent agent work — MANDATORY first step.** Before doing anything else, verify that no other Claude Code session is already working on the same issue:
+   - Identify the target issue number from the triggering context (initial prompt, linked issue, or branch-name hint).
+   - Call `mcp__github__list_pull_requests` with `state: "open"` on `justb81/watchbuddy` and scan each PR's title **and** body for a closing keyword referencing the target issue: `Closes #N`, `Fixes #N`, `Resolves #N`, `Closes GH-N`, `Fixes GH-N`, `Resolves GH-N` (case-insensitive).
+   - If any open PR matches, post a single comment on the issue via `mcp__github__add_issue_comment` — e.g. *"Another Claude Code session is already working on this issue — see #\<PR-number\>. Aborting this session to avoid parallel work."* — and stop immediately. Do not create a branch, do not edit files, do not commit.
+   - Exception: skip this check when the session is explicitly invoked to continue work on a specific existing PR (e.g. responding to review comments on that PR).
+2. Create a feature branch from `main`
+3. Make changes and commit using Conventional Commits (see below)
+4. Push the branch and open a PR against `main`
+5. **Wait for a green CI build** (`build-android.yml`) — do not continue if the build is red; fix the issue first
+6. **Auto-merge when green.** Once every required build step on the PR has completed successfully, the agent may merge the PR into `main` automatically (e.g. via `enable_pr_auto_merge` or by merging directly after CI passes). Use a squash merge and delete the branch after merge.
+7. If CI fails or a required check is still pending, do NOT merge — fix the failure or wait.
 
 > One PR per task. Never merge with red or missing required checks. If a reviewer has requested changes, wait for their approval before merging even if CI is green.
 


### PR DESCRIPTION
## Summary

Adds a mandatory first step to the agent workflow in `CLAUDE.md`: before creating a branch, every agent session must list open PRs on `justb81/watchbuddy` and check whether any of them already references the target issue via a closing keyword (`Closes #N`, `Fixes #N`, `Resolves #N`, incl. `GH-N` variants, case-insensitive). If a match is found, the agent posts a single comment on the issue and aborts — no branch, no edits, no commit.

Prevents the recurring problem of multiple Claude Code sessions spawning parallel branches and PRs for the same issue.

## Why CLAUDE.md only

- `CLAUDE.md` is injected into every session's context at startup, so the rule is seen by every agent with zero infrastructure.
- Claude Code sessions here are spawned from the GitHub App / web UI, not from `.github/workflows/*`, so a workflow `concurrency:` block cannot gate them.
- Scope was intentionally kept to "explicit issue reference in PR body/title" — branch-name heuristics and assignee checks are out of scope to avoid false positives.

## Exception

Sessions that are explicitly invoked to continue work on an existing PR (e.g. addressing review feedback) skip the check.

## Test plan

- [ ] Positive case: open a dummy issue `N`; let a first session create PR #A with `Closes #N`; trigger a second session on issue `N`; expect the abort comment and no second branch.
- [ ] Negative case: close PR #A; trigger a new session on issue `N`; expect normal workflow.
- [ ] Exception case: trigger a session via review comment on an existing PR; expect normal workflow (no abort).
- [ ] Render `CLAUDE.md` on GitHub to verify the renumbered list reads correctly.

https://claude.ai/code/session_01DErtNPyGnCdhErJH1hn3p3