### PR TITLE
feat(tv): Settings screen, phone-discovery toggle, boot autostart (#344)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,10 @@ watchbuddy/
 │       └── (service/)  CompanionService, CompanionStateManager (foreground NSD server + shared state)
 ├── app-tv/             Google TV app (Kotlin, Compose for TV)
 │   └── src/main/java/com/justb81/watchbuddy/tv/
+│       ├── boot/       BootReceiver (starts TvDiscoveryService on BOOT_COMPLETED when autostart pref is true)
 │       ├── data/       StreamingPreferencesRepository, UserSessionRepository, TvShowCache
 │       ├── di/         AppModule (Hilt dependency injection)
-│       ├── discovery/  PhoneDiscoveryManager, PhoneApiService, PhoneApiClientFactory
+│       ├── discovery/  PhoneDiscoveryManager, PhoneApiService, PhoneApiClientFactory, TvDiscoveryService (foreground service; keeps discovery alive after boot)
 │       ├── scrobbler/  TvScrobbleDispatcher, TvWatchedShowSource
 │       ├── ui/         TvMainActivity, TvNavGraph
 │       │   ├── home/       TvHomeScreen, TvHomeViewModel
@@ -38,7 +39,7 @@ watchbuddy/
 │       │   ├── recap/      RecapScreen, RecapViewModel
 │       │   ├── diagnostics/ TvDiagnosticsScreen, TvDiagnosticsViewModel (discovery / BLE / discovered-phones health — view-only, no Share)
 │       │   ├── scrobble/   ScrobbleOverlay, ScrobbleViewModel
-│       │   ├── settings/   StreamingSettingsScreen, StreamingSettingsViewModel
+│       │   ├── settings/   TvSettingsScreen, TvSettingsViewModel (phone-discovery toggle + boot-autostart toggle + nav to StreamingSettings/Diagnostics), StreamingSettingsScreen, StreamingSettingsViewModel
 │       │   ├── showdetail/ ShowDetailScreen, ShowDetailViewModel
 │       │   ├── theme/      TV Material theme
 │       │   └── userselect/ UserSelectScreen, UserSelectViewModel
@@ -206,6 +207,7 @@ For the authoritative HTTP API table, NSD TXT-record contract (`version`, `model
 - **Multi-user:** Multiple phones can connect to one TV simultaneously; scrobbling records the episode for each connected user independently; shared watch mode avoids recap spoilers.
 - **Manual episode marking (phone):** Tapping a show on HomeScreen opens `ShowDetailScreen`, which fetches the full season/episode structure via `EpisodeRepository.getSeasonsWithEpisodes` (Trakt `shows/:id/seasons?extended=episodes`, 10-min per-show cache). Each episode has a checkbox; toggling calls `sync/history` add or remove through `EpisodeRepository`, optimistically flips the UI, and on success calls `ShowRepository.updateLocalWatched(...)`. That mutates the in-memory `shows` `StateFlow` so `HomeViewModel` counters update without a round-trip (#216). The layout pulls the season the user is currently mid-watching to the top, expanded; all other seasons appear below, collapsed.
 - **Diagnostics view:** Settings → Diagnostics on both apps renders live phone↔TV connection health from the existing shared singletons (`CompanionStateManager` on phone, `PhoneDiscoveryManager` on TV) — Wi-Fi / multicast lock / NSD state / HTTP bind / BLE state on the phone; discovery active / heartbeat age / BLE scan state / per-phone score + failCount on the TV (#331). Status dots are color-coded (green/yellow/red) so users can tell "AP isolation" (no phones at all) apart from "`/capability` 500" (discovered but broken). On the **phone only**, a "Share diagnostics" button funnels through `DiagnosticShare.launchShare()` so the `DiagnosticLog` breadcrumb snapshot + any pending crash reports can be exported via the system share sheet (#338). The TV screen is view-only — TV share was removed because the Android TV system share sheet is effectively unusable with a D-pad. For the snapshot to be actionable, connectivity subsystems on the phone (`CompanionService`, NSD state machine, `CompanionHttpServer` request log, `CompanionBleAdvertiser`, `WifiStateProvider`, `HomeViewModel` toggle) emit `DiagnosticLog.event(...)` breadcrumbs — without those the ring only carries auth/settings/app-lifecycle traces. Available in release builds; no new build variant.
+- **TV phone-discovery toggle and boot autostart (#344):** `TvSettingsScreen` (reached via the Settings button on the TV home screen) exposes two toggles stored in `StreamingPreferencesRepository`: `isPhoneDiscoveryEnabled` (default true) and `isAutostartEnabled` (default false). Disabling `isPhoneDiscoveryEnabled` stops `PhoneDiscoveryManager` and clears the discovered-phone list; re-enabling restarts it. Enabling `isAutostartEnabled` causes `BootReceiver` to start `TvDiscoveryService` at TV boot. `TvDiscoveryService` (foreground, `connectedDevice`) self-stops when both prefs become false. `TvHomeViewModel.onCleared` skips `stopDiscovery()` while `TvDiscoveryService.isRunning` is true so the service lifetime is independent of the UI.
 
 ## Documentation Maintenance
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ watchbuddy/
 - **RAM-adaptive LLM** — AICore (Gemini Nano) if available, otherwise LiteRT-LM with auto-selected Gemma model based on free RAM
 - **Resilient pairing** — NSD/mDNS with a parallel BLE fallback so phone ↔ TV discovery keeps working on guest Wi-Fi, mesh routers, and other networks where multicast is blocked
 - **In-app diagnostics** — Settings → Diagnostics on both apps shows live connection health (Wi-Fi / NSD / HTTP / BLE on the phone; discovery / heartbeat / discovered phones on the TV) with a one-tap "Share diagnostics" button that exports the `DiagnosticLog` and any pending crash reports for bug reports
+- **Toggleable phone discovery** — Settings → Phone Discovery on the TV app lets users disable background phone scanning; discovery resumes automatically when re-enabled
+- **TV autostart** — Settings → Start at Boot on the TV app keeps discovery running after the TV powers on via a foreground service started by the boot receiver
 
 ## Module Structure
 

--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -4,6 +4,10 @@
 
     <!-- Network -->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- Required for foreground services of type connectedDevice on Android 14+ -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
@@ -69,6 +73,25 @@
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- Boot receiver: starts TvDiscoveryService when the TV powers on,
+             if the user has enabled autostart in Settings. Exported=false because
+             it only needs to receive the system BOOT_COMPLETED broadcast. -->
+        <receiver
+            android:name=".tv.boot.BootReceiver"
+            android:exported="false"
+            android:directBootAware="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
+        <!-- Background discovery service: keeps PhoneDiscoveryManager alive after boot.
+             Started by BootReceiver; binds to TvMainActivity when the user opens the app. -->
+        <service
+            android:name=".tv.discovery.TvDiscoveryService"
+            android:exported="false"
+            android:foregroundServiceType="connectedDevice" />
 
         <!-- TV app does not use WorkManager; disable its auto-init so the
              startup path does not build a Room-backed WorkDatabase for

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/boot/BootReceiver.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/boot/BootReceiver.kt
@@ -20,30 +20,43 @@ class BootReceiver : BroadcastReceiver() {
     lateinit var preferencesRepository: StreamingPreferencesRepository
 
     override fun onReceive(context: Context, intent: Intent) {
-        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
-
-        val autostartEnabled = runBlocking { preferencesRepository.isAutostartEnabled.first() }
-        if (!autostartEnabled) {
-            Log.i(TAG, "autostart disabled; skipping boot-triggered discovery")
-            return
-        }
-
-        Log.i(TAG, "boot completed; starting TvDiscoveryService")
-        try {
-            ContextCompat.startForegroundService(
-                context,
-                Intent(context, TvDiscoveryService::class.java)
-            )
-        } catch (e: Exception) {
-            DiagnosticLog.event(
-                "tv.boot.autostart.failed",
-                "foreground service start failed: ${e.message}"
-            )
-            Log.e(TAG, "failed to start TvDiscoveryService on boot", e)
-        }
+        handleBootIntent(context, intent, preferencesRepository)
     }
 
     companion object {
         private const val TAG = "BootReceiver"
+
+        /**
+         * Core boot-intent handler, extracted for testability.
+         * Called from [onReceive] with the Hilt-injected repository in production,
+         * and directly (with a mock repository) in unit tests.
+         */
+        internal fun handleBootIntent(
+            context: Context,
+            intent: Intent,
+            repository: StreamingPreferencesRepository,
+        ) {
+            if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+
+            val autostartEnabled = runBlocking { repository.isAutostartEnabled.first() }
+            if (!autostartEnabled) {
+                Log.i(TAG, "autostart disabled; skipping boot-triggered discovery")
+                return
+            }
+
+            Log.i(TAG, "boot completed; starting TvDiscoveryService")
+            try {
+                ContextCompat.startForegroundService(
+                    context,
+                    Intent(context, TvDiscoveryService::class.java)
+                )
+            } catch (e: Exception) {
+                DiagnosticLog.event(
+                    "tv.boot.autostart.failed",
+                    "foreground service start failed: ${e.message}"
+                )
+                Log.e(TAG, "failed to start TvDiscoveryService on boot", e)
+            }
+        }
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/boot/BootReceiver.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/boot/BootReceiver.kt
@@ -1,0 +1,49 @@
+package com.justb81.watchbuddy.tv.boot
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import androidx.core.content.ContextCompat
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
+import com.justb81.watchbuddy.tv.discovery.TvDiscoveryService
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class BootReceiver : BroadcastReceiver() {
+
+    @Inject
+    lateinit var preferencesRepository: StreamingPreferencesRepository
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED) return
+
+        val autostartEnabled = runBlocking { preferencesRepository.isAutostartEnabled.first() }
+        if (!autostartEnabled) {
+            Log.i(TAG, "autostart disabled; skipping boot-triggered discovery")
+            return
+        }
+
+        Log.i(TAG, "boot completed; starting TvDiscoveryService")
+        try {
+            ContextCompat.startForegroundService(
+                context,
+                Intent(context, TvDiscoveryService::class.java)
+            )
+        } catch (e: Exception) {
+            DiagnosticLog.event(
+                "tv.boot.autostart.failed",
+                "foreground service start failed: ${e.message}"
+            )
+            Log.e(TAG, "failed to start TvDiscoveryService on boot", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "BootReceiver"
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepository.kt
@@ -3,7 +3,9 @@ package com.justb81.watchbuddy.tv.data
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -18,23 +20,28 @@ private val Context.streamingDataStore: DataStore<Preferences> by preferencesDat
     name = "streaming_preferences"
 )
 
+/** Hilt-accessible accessor used by [AppModule] to provide the singleton DataStore. */
+internal fun Context.getStreamingDataStore(): DataStore<Preferences> = streamingDataStore
+
 @Singleton
 class StreamingPreferencesRepository @Inject constructor(
-    @param:ApplicationContext private val context: Context
+    @param:ApplicationContext private val context: Context,
+    private val dataStore: DataStore<Preferences>,
 ) {
     private val subscribedKey = stringSetPreferencesKey("subscribed_service_ids")
     private val orderKey = stringPreferencesKey("service_order")
+    private val phoneDiscoveryEnabledKey = booleanPreferencesKey("phone_discovery_enabled")
+    private val autostartEnabledKey = booleanPreferencesKey("autostart_enabled")
 
     /**
      * Emits the ordered list of subscribed service IDs.
      * Empty list means no preference has been set (show all as fallback).
      */
-    val subscribedServiceIds: Flow<List<String>> = context.streamingDataStore.data
-        .catch { emit(androidx.datastore.preferences.core.emptyPreferences()) }
+    val subscribedServiceIds: Flow<List<String>> = dataStore.data
+        .catch { emit(emptyPreferences()) }
         .map { prefs ->
             val ids = prefs[subscribedKey] ?: emptySet()
             val order = prefs[orderKey]?.split(",") ?: emptyList()
-            // Return IDs sorted by the stored priority order
             if (order.isNotEmpty()) {
                 ids.sortedBy { id -> order.indexOf(id).let { if (it == -1) Int.MAX_VALUE else it } }
             } else {
@@ -43,9 +50,27 @@ class StreamingPreferencesRepository @Inject constructor(
         }
 
     suspend fun setSubscribedServices(orderedIds: List<String>) {
-        context.streamingDataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             prefs[subscribedKey] = orderedIds.toSet()
             prefs[orderKey] = orderedIds.joinToString(",")
         }
+    }
+
+    /** Emits whether phone discovery is active. Defaults to true. */
+    val isPhoneDiscoveryEnabled: Flow<Boolean> = dataStore.data
+        .catch { emit(emptyPreferences()) }
+        .map { prefs -> prefs[phoneDiscoveryEnabledKey] ?: true }
+
+    suspend fun setPhoneDiscoveryEnabled(enabled: Boolean) {
+        dataStore.edit { prefs -> prefs[phoneDiscoveryEnabledKey] = enabled }
+    }
+
+    /** Emits whether discovery should start automatically at TV boot. Defaults to false. */
+    val isAutostartEnabled: Flow<Boolean> = dataStore.data
+        .catch { emit(emptyPreferences()) }
+        .map { prefs -> prefs[autostartEnabledKey] ?: false }
+
+    suspend fun setAutostartEnabled(enabled: Boolean) {
+        dataStore.edit { prefs -> prefs[autostartEnabledKey] = enabled }
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
@@ -1,13 +1,18 @@
 package com.justb81.watchbuddy.tv.di
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher
 import com.justb81.watchbuddy.core.scrobbler.WatchedShowSource
+import com.justb81.watchbuddy.tv.data.getStreamingDataStore
 import com.justb81.watchbuddy.tv.scrobbler.TvScrobbleDispatcher
 import com.justb81.watchbuddy.tv.scrobbler.TvWatchedShowSource
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Named
 import javax.inject.Singleton
@@ -23,6 +28,11 @@ abstract class AppModule {
     abstract fun bindScrobbleDispatcher(impl: TvScrobbleDispatcher): ScrobbleDispatcher
 
     companion object {
+
+        @Provides
+        @Singleton
+        fun provideStreamingDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+            context.getStreamingDataStore()
 
         /**
          * Token proxy backend URL — the TV app uses no token proxy, so this is blank.

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -292,9 +292,14 @@ class PhoneDiscoveryManager @Inject constructor(
         val cm = runCatching {
             context.applicationContext.getSystemService(ConnectivityManager::class.java)
         }.getOrNull() ?: return
-        val request = NetworkRequest.Builder()
-            .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
-            .build()
+        val request = runCatching {
+            NetworkRequest.Builder()
+                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                .build()
+        }.getOrElse {
+            Log.w(TAG, "failed to build NetworkRequest; Wi-Fi reconnect recovery disabled", it)
+            return
+        }
         val callback = object : ConnectivityManager.NetworkCallback() {
             override fun onAvailable(network: Network) {
                 Log.i(TAG, "Wi-Fi available — cycling discovery (NSD + BLE)")

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -201,6 +201,24 @@ class PhoneDiscoveryManager @Inject constructor(
         }
     }
 
+    /**
+     * Idempotent enable/disable toggle for phone discovery.
+     *
+     * Calling `setEnabled(true)` when already discovering is a no-op.
+     * Calling `setEnabled(false)` stops all discovery channels and clears the
+     * discovered phone list so the TV home screen reflects the change immediately.
+     */
+    fun setEnabled(enabled: Boolean) {
+        if (enabled) {
+            if (!isDiscovering) startDiscovery()
+        } else {
+            if (isDiscovering) {
+                stopDiscovery()
+                _discoveredPhones.value = emptyList()
+            }
+        }
+    }
+
     fun startDiscovery() {
         Log.i(TAG, "startDiscovery: type=$SERVICE_TYPE")
         isDiscovering = true

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/TvDiscoveryService.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/TvDiscoveryService.kt
@@ -1,0 +1,116 @@
+package com.justb81.watchbuddy.tv.discovery
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Foreground service that keeps phone discovery running after TV boot when autostart is enabled.
+ *
+ * Lifecycle:
+ * - Started by [com.justb81.watchbuddy.tv.boot.BootReceiver] when BOOT_COMPLETED fires and
+ *   the autostart preference is true.
+ * - Starts [PhoneDiscoveryManager] on [onStartCommand] (idempotent via [PhoneDiscoveryManager.setEnabled]).
+ * - Self-stops when both [isPhoneDiscoveryEnabled] and [isAutostartEnabled] become false so the
+ *   user can suppress background discovery entirely from the Settings screen.
+ * - [TvHomeViewModel] skips [PhoneDiscoveryManager.stopDiscovery] on clear when this service is
+ *   running so the discovery lifetime outlives the UI.
+ */
+@AndroidEntryPoint
+class TvDiscoveryService : Service() {
+
+    @Inject
+    lateinit var phoneDiscoveryManager: PhoneDiscoveryManager
+
+    @Inject
+    lateinit var preferencesRepository: StreamingPreferencesRepository
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    companion object {
+        private const val TAG = "TvDiscoveryService"
+        private const val NOTIFICATION_ID = 1001
+        private const val CHANNEL_ID = "watchbuddy_tv_discovery"
+
+        @Volatile
+        var isRunning: Boolean = false
+            private set
+
+        @androidx.annotation.VisibleForTesting
+        fun setRunningForTest(value: Boolean) {
+            isRunning = value
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        isRunning = true
+        createNotificationChannel()
+        startForeground(NOTIFICATION_ID, buildNotification())
+        Log.i(TAG, "service created; starting phone discovery")
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        phoneDiscoveryManager.setEnabled(true)
+        observePreferencesToSelfStop()
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        isRunning = false
+        serviceScope.cancel()
+        super.onDestroy()
+        Log.i(TAG, "service destroyed")
+        // Discovery continues if enabled; TvHomeViewModel takes over when the activity starts.
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun observePreferencesToSelfStop() {
+        serviceScope.launch {
+            combine(
+                preferencesRepository.isPhoneDiscoveryEnabled,
+                preferencesRepository.isAutostartEnabled,
+            ) { discoveryEnabled, autostartEnabled ->
+                discoveryEnabled to autostartEnabled
+            }.collect { (discoveryEnabled, autostartEnabled) ->
+                phoneDiscoveryManager.setEnabled(discoveryEnabled)
+                if (!discoveryEnabled && !autostartEnabled) {
+                    Log.i(TAG, "both discovery and autostart disabled; stopping service")
+                    stopSelf()
+                }
+            }
+        }
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.tv_discovery_notification_channel_name),
+            NotificationManager.IMPORTANCE_LOW
+        )
+        getSystemService(NotificationManager::class.java)?.createNotificationChannel(channel)
+    }
+
+    private fun buildNotification() = NotificationCompat.Builder(this, CHANNEL_ID)
+        .setContentTitle(getString(R.string.app_name))
+        .setContentText(getString(R.string.tv_discovery_notification_text))
+        .setSmallIcon(R.mipmap.ic_launcher)
+        .setPriority(NotificationCompat.PRIORITY_LOW)
+        .setOngoing(true)
+        .build()
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -48,7 +48,7 @@ import java.time.ZoneId
 fun TvHomeScreen(
     onShowClick: (TraktWatchedEntry) -> Unit,
     onUserSelectClick: () -> Unit,
-    onStreamingSettingsClick: () -> Unit = {},
+    onSettingsClick: () -> Unit = {},
     viewModel: TvHomeViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -89,9 +89,9 @@ fun TvHomeScreen(
                     }
 
                     OutlinedButton(
-                        onClick = onStreamingSettingsClick,
+                        onClick = onSettingsClick,
                         scale = ButtonDefaults.scale(scale = 1f)
-                    ) { Text(stringResource(R.string.tv_streaming_settings_button)) }
+                    ) { Text(stringResource(R.string.tv_settings_button)) }
 
                     Button(
                         onClick = onUserSelectClick,

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.progress.ShowProgress
 import com.justb81.watchbuddy.core.progress.ShowProgressCalculator
+import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
 import com.justb81.watchbuddy.tv.data.TvShowCache
 import com.justb81.watchbuddy.tv.data.UserSessionRepository
+import com.justb81.watchbuddy.tv.discovery.TvDiscoveryService
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneApiService
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
@@ -44,7 +46,8 @@ class TvHomeViewModel @Inject constructor(
     private val phoneDiscovery: PhoneDiscoveryManager,
     private val phoneApiClientFactory: PhoneApiClientFactory,
     private val userSessionRepository: UserSessionRepository,
-    private val tvShowCache: TvShowCache
+    private val tvShowCache: TvShowCache,
+    private val streamingPreferencesRepository: StreamingPreferencesRepository,
 ) : ViewModel() {
 
     companion object {
@@ -61,9 +64,17 @@ class TvHomeViewModel @Inject constructor(
     private var loadedOffset: Int = 0
 
     init {
-        runCatching { phoneDiscovery.startDiscovery() }
+        observeDiscoveryEnabled()
         observePhones()
         observeSelectedUsers()
+    }
+
+    private fun observeDiscoveryEnabled() {
+        viewModelScope.launch {
+            streamingPreferencesRepository.isPhoneDiscoveryEnabled.collect { enabled ->
+                runCatching { phoneDiscovery.setEnabled(enabled) }
+            }
+        }
     }
 
     private fun observePhones() {
@@ -215,7 +226,10 @@ class TvHomeViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        phoneDiscovery.stopDiscovery()
+        // Leave discovery running when the background service owns the lifecycle.
+        if (!TvDiscoveryService.isRunning) {
+            phoneDiscovery.stopDiscovery()
+        }
     }
 }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
@@ -14,16 +14,18 @@ import com.justb81.watchbuddy.tv.ui.recap.RecapScreen
 import com.justb81.watchbuddy.tv.ui.scrobble.ScrobbleOverlay
 import com.justb81.watchbuddy.tv.ui.scrobble.ScrobbleViewModel
 import com.justb81.watchbuddy.tv.ui.settings.StreamingSettingsScreen
+import com.justb81.watchbuddy.tv.ui.settings.TvSettingsScreen
 import com.justb81.watchbuddy.tv.ui.showdetail.ShowDetailScreen
 import com.justb81.watchbuddy.tv.ui.userselect.UserSelectScreen
 
 sealed class TvRoute(val route: String) {
-    object Home       : TvRoute("tv_home")
-    object UserSelect : TvRoute("tv_user_select")
-    object ShowDetail : TvRoute("tv_show_detail")
-    object Recap              : TvRoute("tv_recap")
-    object StreamingSettings  : TvRoute("tv_streaming_settings")
-    object Diagnostics        : TvRoute("tv_diagnostics")
+    object Home              : TvRoute("tv_home")
+    object UserSelect        : TvRoute("tv_user_select")
+    object ShowDetail        : TvRoute("tv_show_detail")
+    object Recap             : TvRoute("tv_recap")
+    object Settings          : TvRoute("tv_settings")
+    object StreamingSettings : TvRoute("tv_streaming_settings")
+    object Diagnostics       : TvRoute("tv_diagnostics")
 }
 
 @Composable
@@ -46,8 +48,8 @@ fun TvNavGraph() {
                 onUserSelectClick = {
                     navController.navigate(TvRoute.UserSelect.route)
                 },
-                onStreamingSettingsClick = {
-                    navController.navigate(TvRoute.StreamingSettings.route)
+                onSettingsClick = {
+                    navController.navigate(TvRoute.Settings.route)
                 }
             )
         }
@@ -84,6 +86,14 @@ fun TvNavGraph() {
                     }
                 )
             }
+        }
+
+        composable(TvRoute.Settings.route) {
+            TvSettingsScreen(
+                onBack = { navController.popBackStack() },
+                onStreamingServicesClick = { navController.navigate(TvRoute.StreamingSettings.route) },
+                onDiagnosticsClick = { navController.navigate(TvRoute.Diagnostics.route) }
+            )
         }
 
         composable(TvRoute.StreamingSettings.route) {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsScreen.kt
@@ -1,0 +1,162 @@
+package com.justb81.watchbuddy.tv.ui.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Switch
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.tv.material3.*
+import com.justb81.watchbuddy.R
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun TvSettingsScreen(
+    onBack: () -> Unit,
+    onStreamingServicesClick: () -> Unit,
+    onDiagnosticsClick: () -> Unit,
+    viewModel: TvSettingsViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 48.dp, vertical = 32.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.tv_settings_title),
+                fontSize = 32.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+            )
+
+            Spacer(Modifier.height(32.dp))
+
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                SettingsToggleRow(
+                    title = stringResource(R.string.tv_settings_phone_discovery_title),
+                    subtitle = stringResource(R.string.tv_settings_phone_discovery_subtitle),
+                    checked = uiState.isPhoneDiscoveryEnabled,
+                    onCheckedChange = viewModel::setPhoneDiscoveryEnabled,
+                )
+                SettingsToggleRow(
+                    title = stringResource(R.string.tv_settings_autostart_title),
+                    subtitle = stringResource(R.string.tv_settings_autostart_subtitle),
+                    checked = uiState.isAutostartEnabled,
+                    onCheckedChange = viewModel::setAutostartEnabled,
+                )
+                SettingsNavigationRow(
+                    title = stringResource(R.string.tv_settings_streaming_services),
+                    onClick = onStreamingServicesClick,
+                )
+                SettingsNavigationRow(
+                    title = stringResource(R.string.tv_settings_diagnostics),
+                    onClick = onDiagnosticsClick,
+                )
+            }
+
+            Spacer(Modifier.weight(1f))
+
+            OutlinedButton(onClick = onBack) {
+                Text(stringResource(R.string.tv_back))
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun SettingsToggleRow(
+    title: String,
+    subtitle: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Surface(
+        onClick = { onCheckedChange(!checked) },
+        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp)),
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.3f),
+            focusedContainerColor = MaterialTheme.colorScheme.surface,
+        ),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.01f),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = title,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Medium,
+                    color = Color.White,
+                )
+                Text(
+                    text = subtitle,
+                    fontSize = 13.sp,
+                    color = Color.White.copy(alpha = 0.5f),
+                )
+            }
+            Switch(
+                checked = checked,
+                onCheckedChange = null,
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun SettingsNavigationRow(
+    title: String,
+    onClick: () -> Unit,
+) {
+    Surface(
+        onClick = onClick,
+        shape = ClickableSurfaceDefaults.shape(RoundedCornerShape(12.dp)),
+        colors = ClickableSurfaceDefaults.colors(
+            containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.3f),
+            focusedContainerColor = MaterialTheme.colorScheme.surface,
+        ),
+        scale = ClickableSurfaceDefaults.scale(focusedScale = 1.01f),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp, vertical = 20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = title,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Medium,
+                color = Color.White,
+            )
+            Text(
+                text = "›",
+                fontSize = 20.sp,
+                color = Color.White.copy(alpha = 0.5f),
+            )
+        }
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModel.kt
@@ -1,0 +1,64 @@
+package com.justb81.watchbuddy.tv.ui.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+data class TvSettingsUiState(
+    val isPhoneDiscoveryEnabled: Boolean = true,
+    val isAutostartEnabled: Boolean = false,
+)
+
+@HiltViewModel
+class TvSettingsViewModel @Inject constructor(
+    private val repository: StreamingPreferencesRepository
+) : ViewModel() {
+
+    companion object {
+        private const val TAG = "TvSettingsViewModel"
+    }
+
+    private val _uiState = MutableStateFlow(TvSettingsUiState())
+    val uiState: StateFlow<TvSettingsUiState> = _uiState.asStateFlow()
+
+    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
+        DiagnosticLog.error(TAG, "settings prefs write failed", throwable)
+    }
+
+    private fun launchSafe(block: suspend CoroutineScope.() -> Unit): Job =
+        viewModelScope.launch(coroutineExceptionHandler, block = block)
+
+    init {
+        launchSafe {
+            combine(
+                repository.isPhoneDiscoveryEnabled,
+                repository.isAutostartEnabled,
+            ) { discovery, autostart ->
+                TvSettingsUiState(
+                    isPhoneDiscoveryEnabled = discovery,
+                    isAutostartEnabled = autostart,
+                )
+            }
+            .catch { e -> DiagnosticLog.error(TAG, "settings prefs observation failed", e) }
+            .collect { _uiState.value = it }
+        }
+    }
+
+    fun setPhoneDiscoveryEnabled(enabled: Boolean) {
+        _uiState.update { it.copy(isPhoneDiscoveryEnabled = enabled) }
+        launchSafe { repository.setPhoneDiscoveryEnabled(enabled) }
+    }
+
+    fun setAutostartEnabled(enabled: Boolean) {
+        _uiState.update { it.copy(isAutostartEnabled = enabled) }
+        launchSafe { repository.setAutostartEnabled(enabled) }
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModel.kt
@@ -8,7 +8,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -38,17 +42,14 @@ class TvSettingsViewModel @Inject constructor(
 
     init {
         launchSafe {
-            combine(
-                repository.isPhoneDiscoveryEnabled,
-                repository.isAutostartEnabled,
-            ) { discovery, autostart ->
-                TvSettingsUiState(
-                    isPhoneDiscoveryEnabled = discovery,
-                    isAutostartEnabled = autostart,
-                )
-            }
-            .catch { e -> DiagnosticLog.error(TAG, "settings prefs observation failed", e) }
-            .collect { _uiState.value = it }
+            repository.isPhoneDiscoveryEnabled
+                .catch { e -> DiagnosticLog.error(TAG, "settings prefs observation failed", e) }
+                .collect { enabled -> _uiState.update { it.copy(isPhoneDiscoveryEnabled = enabled) } }
+        }
+        launchSafe {
+            repository.isAutostartEnabled
+                .catch { e -> DiagnosticLog.error(TAG, "settings prefs observation failed", e) }
+                .collect { enabled -> _uiState.update { it.copy(isAutostartEnabled = enabled) } }
         }
     }
 

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -64,6 +64,20 @@
     <string name="tv_error_phone_unreachable">Begleit-App nicht erreichbar. Zwischengespeicherte Daten werden angezeigt.</string>
     <string name="tv_error_phone_unreachable_no_cache">Begleit-App nicht erreichbar. Stelle sicher, dass WatchBuddy auf deinem Handy läuft.</string>
 
+    <!-- Einstellungen -->
+    <string name="tv_settings_title">Einstellungen</string>
+    <string name="tv_settings_button">Einstellungen</string>
+    <string name="tv_settings_phone_discovery_title">Handysuche</string>
+    <string name="tv_settings_phone_discovery_subtitle">Netzwerk nach WatchBuddy-Handys durchsuchen</string>
+    <string name="tv_settings_autostart_title">Autostart beim Booten</string>
+    <string name="tv_settings_autostart_subtitle">Suche automatisch starten, wenn der Fernseher eingeschaltet wird</string>
+    <string name="tv_settings_streaming_services">Streamingdienste</string>
+    <string name="tv_settings_diagnostics">Diagnose</string>
+
+    <!-- Hintergrundservice-Benachrichtigung -->
+    <string name="tv_discovery_notification_channel_name">WatchBuddy-Suche</string>
+    <string name="tv_discovery_notification_text">Suche nach WatchBuddy-Handys…</string>
+
     <!-- Streaming settings -->
     <string name="tv_streaming_settings_button">Dienste</string>
     <string name="tv_streaming_settings_title">Streamingdienste</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -64,6 +64,20 @@
     <string name="tv_error_phone_unreachable">Aplicación compañera inaccesible. Mostrando datos en caché.</string>
     <string name="tv_error_phone_unreachable_no_cache">Aplicación compañera inaccesible. Asegúrate de que WatchBuddy está en ejecución en tu teléfono.</string>
 
+    <!-- Ajustes -->
+    <string name="tv_settings_title">Ajustes</string>
+    <string name="tv_settings_button">Ajustes</string>
+    <string name="tv_settings_phone_discovery_title">Detección de teléfonos</string>
+    <string name="tv_settings_phone_discovery_subtitle">Buscar teléfonos WatchBuddy en la red</string>
+    <string name="tv_settings_autostart_title">Inicio automático</string>
+    <string name="tv_settings_autostart_subtitle">Iniciar la detección automáticamente cuando se enciende el televisor</string>
+    <string name="tv_settings_streaming_services">Servicios de streaming</string>
+    <string name="tv_settings_diagnostics">Diagnóstico</string>
+
+    <!-- Notificación del servicio en segundo plano -->
+    <string name="tv_discovery_notification_channel_name">Detección WatchBuddy</string>
+    <string name="tv_discovery_notification_text">Buscando teléfonos WatchBuddy…</string>
+
     <!-- Streaming settings -->
     <string name="tv_streaming_settings_button">Servicios</string>
     <string name="tv_streaming_settings_title">Servicios de streaming</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -64,6 +64,20 @@
     <string name="tv_error_phone_unreachable">Application compagnon inaccessible. Affichage des données en cache.</string>
     <string name="tv_error_phone_unreachable_no_cache">Application compagnon inaccessible. Assurez-vous que WatchBuddy est en cours d\'exécution sur votre téléphone.</string>
 
+    <!-- Paramètres -->
+    <string name="tv_settings_title">Paramètres</string>
+    <string name="tv_settings_button">Paramètres</string>
+    <string name="tv_settings_phone_discovery_title">Détection de téléphones</string>
+    <string name="tv_settings_phone_discovery_subtitle">Rechercher les téléphones WatchBuddy sur le réseau</string>
+    <string name="tv_settings_autostart_title">Démarrage automatique</string>
+    <string name="tv_settings_autostart_subtitle">Lancer la détection automatiquement au démarrage du téléviseur</string>
+    <string name="tv_settings_streaming_services">Services de streaming</string>
+    <string name="tv_settings_diagnostics">Diagnostic</string>
+
+    <!-- Notification du service de fond -->
+    <string name="tv_discovery_notification_channel_name">Détection WatchBuddy</string>
+    <string name="tv_discovery_notification_text">Recherche de téléphones WatchBuddy…</string>
+
     <!-- Streaming settings -->
     <string name="tv_streaming_settings_button">Services</string>
     <string name="tv_streaming_settings_title">Services de streaming</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -64,6 +64,20 @@
     <string name="tv_error_phone_unreachable">Companion app unreachable. Showing cached data.</string>
     <string name="tv_error_phone_unreachable_no_cache">Companion app unreachable. Make sure WatchBuddy is running on your phone.</string>
 
+    <!-- Generic Settings hub -->
+    <string name="tv_settings_title">Settings</string>
+    <string name="tv_settings_button">Settings</string>
+    <string name="tv_settings_phone_discovery_title">Phone discovery</string>
+    <string name="tv_settings_phone_discovery_subtitle">Scan the network for WatchBuddy phones</string>
+    <string name="tv_settings_autostart_title">Autostart at boot</string>
+    <string name="tv_settings_autostart_subtitle">Start discovery automatically when the TV turns on</string>
+    <string name="tv_settings_streaming_services">Streaming services</string>
+    <string name="tv_settings_diagnostics">Diagnostics</string>
+
+    <!-- Discovery background service notification -->
+    <string name="tv_discovery_notification_channel_name">WatchBuddy Discovery</string>
+    <string name="tv_discovery_notification_text">Searching for WatchBuddy phones…</string>
+
     <!-- Streaming settings -->
     <string name="tv_streaming_settings_button">Services</string>
     <string name="tv_streaming_settings_title">Streaming Services</string>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/boot/BootReceiverTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/boot/BootReceiverTest.kt
@@ -1,0 +1,96 @@
+package com.justb81.watchbuddy.tv.boot
+
+import android.content.Intent
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
+import io.mockk.*
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [BootReceiver].
+ *
+ * Constructs the receiver directly (bypassing Hilt) so the preference guard
+ * logic can be tested without a full Android environment.
+ */
+@DisplayName("BootReceiver")
+class BootReceiverTest {
+
+    private val repository: StreamingPreferencesRepository = mockk()
+    private lateinit var receiver: BootReceiver
+
+    @BeforeEach
+    fun setUp() {
+        DiagnosticLog.clear()
+        receiver = BootReceiver()
+        receiver.preferencesRepository = repository
+    }
+
+    @AfterEach
+    fun tearDown() {
+        DiagnosticLog.clear()
+        unmockkStatic(androidx.core.content.ContextCompat::class)
+    }
+
+    @Test
+    fun `does nothing when autostart is disabled`() {
+        every { repository.isAutostartEnabled } returns flowOf(false)
+        mockkStatic(androidx.core.content.ContextCompat::class)
+        val context = mockk<android.content.Context>(relaxed = true)
+
+        receiver.onReceive(context, Intent(Intent.ACTION_BOOT_COMPLETED))
+
+        verify(exactly = 0) {
+            androidx.core.content.ContextCompat.startForegroundService(any(), any())
+        }
+    }
+
+    @Test
+    fun `ignores intents that are not BOOT_COMPLETED`() {
+        every { repository.isAutostartEnabled } returns flowOf(true)
+        mockkStatic(androidx.core.content.ContextCompat::class)
+        val context = mockk<android.content.Context>(relaxed = true)
+
+        receiver.onReceive(context, Intent(Intent.ACTION_PACKAGE_ADDED))
+
+        verify(exactly = 0) {
+            androidx.core.content.ContextCompat.startForegroundService(any(), any())
+        }
+    }
+
+    @Test
+    fun `starts TvDiscoveryService when autostart is enabled`() {
+        every { repository.isAutostartEnabled } returns flowOf(true)
+        mockkStatic(androidx.core.content.ContextCompat::class)
+        every { androidx.core.content.ContextCompat.startForegroundService(any(), any()) } returns mockk()
+        val context = mockk<android.content.Context>(relaxed = true)
+
+        receiver.onReceive(context, Intent(Intent.ACTION_BOOT_COMPLETED))
+
+        verify(exactly = 1) {
+            androidx.core.content.ContextCompat.startForegroundService(context, any())
+        }
+    }
+
+    @Test
+    fun `emits DiagnosticLog breadcrumb when service start fails`() {
+        every { repository.isAutostartEnabled } returns flowOf(true)
+        mockkStatic(androidx.core.content.ContextCompat::class)
+        every {
+            androidx.core.content.ContextCompat.startForegroundService(any(), any())
+        } throws SecurityException("background start restricted")
+        val context = mockk<android.content.Context>(relaxed = true)
+
+        receiver.onReceive(context, Intent(Intent.ACTION_BOOT_COMPLETED))
+
+        val events = DiagnosticLog.snapshot()
+        assertTrue(
+            events.any { it.tag == "tv.boot.autostart.failed" },
+            "Expected tv.boot.autostart.failed breadcrumb in DiagnosticLog"
+        )
+    }
+}

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/boot/BootReceiverTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/boot/BootReceiverTest.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.tv.boot
 
+import android.content.Context
 import android.content.Intent
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
@@ -12,22 +13,31 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 /**
- * Unit tests for [BootReceiver].
+ * Unit tests for [BootReceiver.handleBootIntent].
  *
- * Constructs the receiver directly (bypassing Hilt) so the preference guard
- * logic can be tested without a full Android environment.
+ * Tests call the companion-object function directly to avoid triggering Hilt's
+ * injection machinery (which requires an Application context) and to work around
+ * Android stub limitations (Intent constructors don't store fields under
+ * isReturnDefaultValues=true).
  */
 @DisplayName("BootReceiver")
 class BootReceiverTest {
 
     private val repository: StreamingPreferencesRepository = mockk()
-    private lateinit var receiver: BootReceiver
+    private val context: Context = mockk(relaxed = true)
+
+    private val bootIntent: Intent = mockk<Intent>().also {
+        every { it.action } returns Intent.ACTION_BOOT_COMPLETED
+    }
+    private val otherIntent: Intent = mockk<Intent>().also {
+        every { it.action } returns Intent.ACTION_PACKAGE_ADDED
+    }
 
     @BeforeEach
     fun setUp() {
         DiagnosticLog.clear()
-        receiver = BootReceiver()
-        receiver.preferencesRepository = repository
+        mockkStatic(androidx.core.content.ContextCompat::class)
+        every { androidx.core.content.ContextCompat.startForegroundService(any(), any()) } returns mockk()
     }
 
     @AfterEach
@@ -39,10 +49,8 @@ class BootReceiverTest {
     @Test
     fun `does nothing when autostart is disabled`() {
         every { repository.isAutostartEnabled } returns flowOf(false)
-        mockkStatic(androidx.core.content.ContextCompat::class)
-        val context = mockk<android.content.Context>(relaxed = true)
 
-        receiver.onReceive(context, Intent(Intent.ACTION_BOOT_COMPLETED))
+        BootReceiver.handleBootIntent(context, bootIntent, repository)
 
         verify(exactly = 0) {
             androidx.core.content.ContextCompat.startForegroundService(any(), any())
@@ -52,10 +60,8 @@ class BootReceiverTest {
     @Test
     fun `ignores intents that are not BOOT_COMPLETED`() {
         every { repository.isAutostartEnabled } returns flowOf(true)
-        mockkStatic(androidx.core.content.ContextCompat::class)
-        val context = mockk<android.content.Context>(relaxed = true)
 
-        receiver.onReceive(context, Intent(Intent.ACTION_PACKAGE_ADDED))
+        BootReceiver.handleBootIntent(context, otherIntent, repository)
 
         verify(exactly = 0) {
             androidx.core.content.ContextCompat.startForegroundService(any(), any())
@@ -65,11 +71,8 @@ class BootReceiverTest {
     @Test
     fun `starts TvDiscoveryService when autostart is enabled`() {
         every { repository.isAutostartEnabled } returns flowOf(true)
-        mockkStatic(androidx.core.content.ContextCompat::class)
-        every { androidx.core.content.ContextCompat.startForegroundService(any(), any()) } returns mockk()
-        val context = mockk<android.content.Context>(relaxed = true)
 
-        receiver.onReceive(context, Intent(Intent.ACTION_BOOT_COMPLETED))
+        BootReceiver.handleBootIntent(context, bootIntent, repository)
 
         verify(exactly = 1) {
             androidx.core.content.ContextCompat.startForegroundService(context, any())
@@ -79,13 +82,11 @@ class BootReceiverTest {
     @Test
     fun `emits DiagnosticLog breadcrumb when service start fails`() {
         every { repository.isAutostartEnabled } returns flowOf(true)
-        mockkStatic(androidx.core.content.ContextCompat::class)
         every {
             androidx.core.content.ContextCompat.startForegroundService(any(), any())
         } throws SecurityException("background start restricted")
-        val context = mockk<android.content.Context>(relaxed = true)
 
-        receiver.onReceive(context, Intent(Intent.ACTION_BOOT_COMPLETED))
+        BootReceiver.handleBootIntent(context, bootIntent, repository)
 
         val events = DiagnosticLog.snapshot()
         assertTrue(

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepositoryTest.kt
@@ -1,11 +1,14 @@
 package com.justb81.watchbuddy.tv.data
 
 import android.content.Context
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
 import com.justb81.watchbuddy.tv.MainDispatcherRule
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
@@ -14,12 +17,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
-import org.junit.jupiter.api.io.TempDir
-import java.io.File
 
 /**
- * Tests for the new preference keys added in issue #344.
- * Uses an isolated file-backed DataStore per test method to avoid shared state.
+ * Tests for the preference keys added in issue #344.
+ *
+ * Uses an in-memory [DataStore] backed by [MutableStateFlow] so there are no
+ * file I/O or Android-runtime dependencies in the JVM unit-test environment.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @DisplayName("StreamingPreferencesRepository — discovery and autostart prefs")
@@ -31,21 +34,14 @@ class StreamingPreferencesRepositoryTest {
         val mainDispatcherRule = MainDispatcherRule()
     }
 
-    @TempDir
-    lateinit var tempDir: File
-
     private lateinit var repository: StreamingPreferencesRepository
 
     @BeforeEach
     fun setUp() {
-        val prefsFile = File(tempDir, "streaming_prefs.preferences_pb")
-        val dataStore = PreferenceDataStoreFactory.create(
-            scope = kotlinx.coroutines.CoroutineScope(
-                mainDispatcherRule.testDispatcher + SupervisorJob()
-            ),
-            produceFile = { prefsFile }
+        repository = StreamingPreferencesRepository(
+            context = mockk<Context>(relaxed = true),
+            dataStore = InMemoryPreferencesDataStore(),
         )
-        repository = StreamingPreferencesRepository(mockk<Context>(relaxed = true), dataStore)
     }
 
     @Nested
@@ -92,5 +88,24 @@ class StreamingPreferencesRepositoryTest {
             repository.setAutostartEnabled(false)
             assertFalse(repository.isAutostartEnabled.first())
         }
+    }
+}
+
+/**
+ * Pure-JVM in-memory [DataStore] for unit tests.
+ *
+ * Stores [Preferences] in a [MutableStateFlow] so reads and writes are
+ * observable without any file I/O or Android runtime.
+ */
+private class InMemoryPreferencesDataStore : DataStore<Preferences> {
+
+    private val _prefs = MutableStateFlow(emptyPreferences())
+
+    override val data: Flow<Preferences> = _prefs
+
+    override suspend fun updateData(transform: suspend (t: Preferences) -> Preferences): Preferences {
+        val updated = transform(_prefs.value)
+        _prefs.value = updated
+        return updated
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepositoryTest.kt
@@ -1,0 +1,96 @@
+package com.justb81.watchbuddy.tv.data
+
+import android.content.Context
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.justb81.watchbuddy.tv.MainDispatcherRule
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+/**
+ * Tests for the new preference keys added in issue #344.
+ * Uses an isolated file-backed DataStore per test method to avoid shared state.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("StreamingPreferencesRepository — discovery and autostart prefs")
+class StreamingPreferencesRepositoryTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcherRule = MainDispatcherRule()
+    }
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var repository: StreamingPreferencesRepository
+
+    @BeforeEach
+    fun setUp() {
+        val prefsFile = File(tempDir, "streaming_prefs.preferences_pb")
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = kotlinx.coroutines.CoroutineScope(
+                mainDispatcherRule.testDispatcher + SupervisorJob()
+            ),
+            produceFile = { prefsFile }
+        )
+        repository = StreamingPreferencesRepository(mockk<Context>(relaxed = true), dataStore)
+    }
+
+    @Nested
+    @DisplayName("isPhoneDiscoveryEnabled")
+    inner class PhoneDiscoveryEnabledTest {
+
+        @Test
+        fun `defaults to true when not set`() = runTest {
+            assertTrue(repository.isPhoneDiscoveryEnabled.first())
+        }
+
+        @Test
+        fun `persists false value`() = runTest {
+            repository.setPhoneDiscoveryEnabled(false)
+            assertFalse(repository.isPhoneDiscoveryEnabled.first())
+        }
+
+        @Test
+        fun `persists true value after setting false`() = runTest {
+            repository.setPhoneDiscoveryEnabled(false)
+            repository.setPhoneDiscoveryEnabled(true)
+            assertTrue(repository.isPhoneDiscoveryEnabled.first())
+        }
+    }
+
+    @Nested
+    @DisplayName("isAutostartEnabled")
+    inner class AutostartEnabledTest {
+
+        @Test
+        fun `defaults to false when not set`() = runTest {
+            assertFalse(repository.isAutostartEnabled.first())
+        }
+
+        @Test
+        fun `persists true value`() = runTest {
+            repository.setAutostartEnabled(true)
+            assertTrue(repository.isAutostartEnabled.first())
+        }
+
+        @Test
+        fun `persists false value after setting true`() = runTest {
+            repository.setAutostartEnabled(true)
+            repository.setAutostartEnabled(false)
+            assertFalse(repository.isAutostartEnabled.first())
+        }
+    }
+}

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
@@ -8,6 +8,7 @@ import com.justb81.watchbuddy.core.model.LlmBackend
 import io.mockk.*
 import okhttp3.OkHttpClient
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -26,6 +27,11 @@ class PhoneDiscoveryManagerTest {
     fun setUp() {
         every { context.getSystemService(Context.NSD_SERVICE) } returns nsdManager
         manager = PhoneDiscoveryManager(context, httpClient, bleScanner)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        manager.stopDiscovery()
     }
 
     // ── DiscoveredPhone construction helpers ───────────────────────────────────

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
@@ -368,12 +368,9 @@ class PhoneDiscoveryManagerTest {
         @Test
         fun `setEnabled(true) is idempotent when already discovering`() {
             manager.startDiscovery()
-            clearMocks(nsdManager, answers = false)
-            every { nsdManager.discoverServices(any(), any(), any()) } just runs
-
             manager.setEnabled(true)
-
-            verify(exactly = 0) { nsdManager.discoverServices(any(), any(), any()) }
+            // discoverServices called exactly once (from startDiscovery), not again from setEnabled
+            verify(exactly = 1) { nsdManager.discoverServices(any(), any(), any()) }
         }
 
         @Test

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
@@ -353,6 +353,50 @@ class PhoneDiscoveryManagerTest {
 
     // ── constants ──────────────────────────────────────────────────────────────
 
+    // ── setEnabled ─────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("setEnabled")
+    inner class SetEnabledTest {
+
+        @Test
+        fun `setEnabled(true) starts discovery when not already discovering`() {
+            manager.setEnabled(true)
+            verify { nsdManager.discoverServices(any(), any(), any()) }
+        }
+
+        @Test
+        fun `setEnabled(true) is idempotent when already discovering`() {
+            manager.startDiscovery()
+            clearMocks(nsdManager, answers = false)
+            every { nsdManager.discoverServices(any(), any(), any()) } just runs
+
+            manager.setEnabled(true)
+
+            verify(exactly = 0) { nsdManager.discoverServices(any(), any(), any()) }
+        }
+
+        @Test
+        fun `setEnabled(false) stops discovery and clears phone list`() {
+            manager.startDiscovery()
+            val serviceInfo = mockk<android.net.nsd.NsdServiceInfo>()
+            every { serviceInfo.serviceName } returns "test"
+            manager.setDiscoveredPhonesForTest(
+                listOf(makePhone(capability = null, name = "test"))
+            )
+
+            manager.setEnabled(false)
+
+            assertTrue(manager.discoveredPhones.value.isEmpty())
+        }
+
+        @Test
+        fun `setEnabled(false) is a no-op when not discovering`() {
+            manager.setEnabled(false)
+            assertTrue(manager.discoveredPhones.value.isEmpty())
+        }
+    }
+
     @Test
     fun `SERVICE_TYPE constant is correct`() {
         assertEquals("_watchbuddy._tcp.", PhoneDiscoveryManager.SERVICE_TYPE)

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
@@ -5,8 +5,10 @@ import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.tv.MainDispatcherRule
+import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
 import com.justb81.watchbuddy.tv.data.TvShowCache
 import com.justb81.watchbuddy.tv.data.UserSessionRepository
+import com.justb81.watchbuddy.tv.discovery.TvDiscoveryService
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneApiService
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
@@ -38,6 +40,7 @@ class TvHomeViewModelTest {
     private val phoneApiClientFactory: PhoneApiClientFactory = mockk()
     private val userSessionRepository: UserSessionRepository = mockk()
     private val tvShowCache: TvShowCache = mockk(relaxed = true)
+    private val streamingPreferencesRepository: StreamingPreferencesRepository = mockk()
     private val phonesFlow = MutableStateFlow<List<PhoneDiscoveryManager.DiscoveredPhone>>(emptyList())
     private val phoneApiService: PhoneApiService = mockk()
 
@@ -53,11 +56,21 @@ class TvHomeViewModelTest {
         every { userSessionRepository.selectedUserIds } returns flowOf(emptySet())
         every { phoneDiscovery.startDiscovery() } just runs
         every { phoneDiscovery.stopDiscovery() } just runs
+        every { phoneDiscovery.setEnabled(any()) } just runs
         every { phoneDiscovery.getBestPhone() } returns null
+        every { streamingPreferencesRepository.isPhoneDiscoveryEnabled } returns flowOf(true)
+        // Ensure TvDiscoveryService is not seen as running during tests
+        TvDiscoveryService.setRunningForTest(false)
     }
 
     private fun createViewModel(): TvHomeViewModel {
-        return TvHomeViewModel(phoneDiscovery, phoneApiClientFactory, userSessionRepository, tvShowCache)
+        return TvHomeViewModel(
+            phoneDiscovery,
+            phoneApiClientFactory,
+            userSessionRepository,
+            tvShowCache,
+            streamingPreferencesRepository,
+        )
     }
 
     // ── Basic load behaviour ───────────────────────────────────────────────────
@@ -161,11 +174,11 @@ class TvHomeViewModelTest {
     }
 
     @Test
-    fun `onCleared stops discovery`() = runTest {
+    fun `onCleared stops discovery when TvDiscoveryService is not running`() = runTest {
+        TvDiscoveryService.setRunningForTest(false)
         val viewModel = createViewModel()
         advanceUntilIdle()
 
-        // Trigger onCleared via reflection
         val method = viewModel.javaClass.getDeclaredMethod("onCleared")
         method.isAccessible = true
         method.invoke(viewModel)
@@ -174,9 +187,32 @@ class TvHomeViewModelTest {
     }
 
     @Test
-    fun `init starts discovery`() = runTest {
+    fun `onCleared skips stopDiscovery when TvDiscoveryService is running`() = runTest {
+        TvDiscoveryService.setRunningForTest(true)
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val method = viewModel.javaClass.getDeclaredMethod("onCleared")
+        method.isAccessible = true
+        method.invoke(viewModel)
+
+        verify(exactly = 0) { phoneDiscovery.stopDiscovery() }
+        TvDiscoveryService.setRunningForTest(false)
+    }
+
+    @Test
+    fun `init enables discovery via setEnabled when discovery preference is true`() = runTest {
         createViewModel()
-        verify { phoneDiscovery.startDiscovery() }
+        advanceUntilIdle()
+        verify { phoneDiscovery.setEnabled(true) }
+    }
+
+    @Test
+    fun `init disables discovery via setEnabled when discovery preference is false`() = runTest {
+        every { streamingPreferencesRepository.isPhoneDiscoveryEnabled } returns flowOf(false)
+        createViewModel()
+        advanceUntilIdle()
+        verify { phoneDiscovery.setEnabled(false) }
     }
 
     @Test

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModelTest.kt
@@ -1,0 +1,150 @@
+package com.justb81.watchbuddy.tv.ui.settings
+
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.tv.MainDispatcherRule
+import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
+import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("TvSettingsViewModel")
+class TvSettingsViewModelTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcherRule = MainDispatcherRule()
+    }
+
+    private val repository: StreamingPreferencesRepository = mockk()
+    private lateinit var viewModel: TvSettingsViewModel
+
+    @BeforeEach
+    fun setUp() {
+        DiagnosticLog.clear()
+        every { repository.isPhoneDiscoveryEnabled } returns flowOf(true)
+        every { repository.isAutostartEnabled } returns flowOf(false)
+        coEvery { repository.setPhoneDiscoveryEnabled(any()) } just runs
+        coEvery { repository.setAutostartEnabled(any()) } just runs
+        viewModel = TvSettingsViewModel(repository)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        DiagnosticLog.clear()
+    }
+
+    @Test
+    fun `initial uiState reflects repository defaults`() = runTest {
+        advanceUntilIdle()
+        val state = viewModel.uiState.value
+        assertTrue(state.isPhoneDiscoveryEnabled)
+        assertFalse(state.isAutostartEnabled)
+    }
+
+    @Test
+    fun `initial uiState reflects repository values when discovery is disabled`() = runTest {
+        every { repository.isPhoneDiscoveryEnabled } returns flowOf(false)
+        viewModel = TvSettingsViewModel(repository)
+        advanceUntilIdle()
+        assertFalse(viewModel.uiState.value.isPhoneDiscoveryEnabled)
+    }
+
+    @Test
+    fun `initial uiState reflects repository values when autostart is enabled`() = runTest {
+        every { repository.isAutostartEnabled } returns flowOf(true)
+        viewModel = TvSettingsViewModel(repository)
+        advanceUntilIdle()
+        assertTrue(viewModel.uiState.value.isAutostartEnabled)
+    }
+
+    @Nested
+    @DisplayName("setPhoneDiscoveryEnabled")
+    inner class SetPhoneDiscoveryEnabledTest {
+
+        @Test
+        fun `updates uiState optimistically`() {
+            viewModel.setPhoneDiscoveryEnabled(false)
+            assertFalse(viewModel.uiState.value.isPhoneDiscoveryEnabled)
+        }
+
+        @Test
+        fun `persists to repository`() = runTest {
+            viewModel.setPhoneDiscoveryEnabled(false)
+            advanceUntilIdle()
+            coVerify { repository.setPhoneDiscoveryEnabled(false) }
+        }
+
+        @Test
+        fun `persists enabled=true to repository`() = runTest {
+            viewModel.setPhoneDiscoveryEnabled(true)
+            advanceUntilIdle()
+            coVerify { repository.setPhoneDiscoveryEnabled(true) }
+        }
+    }
+
+    @Nested
+    @DisplayName("setAutostartEnabled")
+    inner class SetAutostartEnabledTest {
+
+        @Test
+        fun `updates uiState optimistically`() {
+            viewModel.setAutostartEnabled(true)
+            assertTrue(viewModel.uiState.value.isAutostartEnabled)
+        }
+
+        @Test
+        fun `persists to repository`() = runTest {
+            viewModel.setAutostartEnabled(true)
+            advanceUntilIdle()
+            coVerify { repository.setAutostartEnabled(true) }
+        }
+    }
+
+    @Nested
+    @DisplayName("ErrorLogging")
+    inner class ErrorLoggingTest {
+
+        @Test
+        fun `flow observation failure logs via DiagnosticLog`() = runTest {
+            val error = RuntimeException("DataStore read failed")
+            every { repository.isPhoneDiscoveryEnabled } returns flow { throw error }
+
+            viewModel = TvSettingsViewModel(repository)
+            advanceUntilIdle()
+
+            val errors = DiagnosticLog.snapshot().filter { it.level == DiagnosticLog.Level.ERROR }
+            assertTrue(errors.isNotEmpty(), "Expected an error entry in DiagnosticLog")
+            assertTrue(
+                errors.any { it.message.contains("settings prefs observation failed") },
+                "Expected 'settings prefs observation failed' in log"
+            )
+        }
+
+        @Test
+        fun `write failure logs via DiagnosticLog`() = runTest {
+            coEvery { repository.setPhoneDiscoveryEnabled(any()) } throws RuntimeException("write failed")
+
+            viewModel.setPhoneDiscoveryEnabled(false)
+            advanceUntilIdle()
+
+            val errors = DiagnosticLog.snapshot().filter { it.level == DiagnosticLog.Level.ERROR }
+            assertTrue(errors.isNotEmpty(), "Expected an error entry in DiagnosticLog")
+            assertTrue(
+                errors.any { it.message.contains("settings prefs write failed") },
+                "Expected 'settings prefs write failed' in log"
+            )
+        }
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -269,6 +269,26 @@ real network handoff. Each churn briefly yanks the NSD advertisement off the net
 callback and skips the full `unregister → 300 ms → register` dance when the new IPv4
 matches the cached one.
 
+## TV Boot Autostart and Background Discovery
+
+`TvDiscoveryService` is a foreground service (`foregroundServiceType="connectedDevice"`) that
+keeps `PhoneDiscoveryManager` alive after the TV boots. It is started by `BootReceiver`
+(registered for `ACTION_BOOT_COMPLETED`, `exported=false`) when the user has enabled the
+"Start at Boot" preference in TV Settings.
+
+Lifecycle:
+- `BootReceiver.onReceive` reads `isAutostartEnabled` from `StreamingPreferencesRepository`
+  synchronously (`runBlocking`) and calls `ContextCompat.startForegroundService` when true.
+- `TvDiscoveryService.onStartCommand` calls `PhoneDiscoveryManager.setEnabled(true)` and
+  then starts observing both `isPhoneDiscoveryEnabled` and `isAutostartEnabled`. When both
+  become false (user disabled discovery *and* autostart from TV Settings), the service calls
+  `stopSelf()`.
+- `TvHomeViewModel.onCleared` checks `TvDiscoveryService.isRunning` before stopping
+  discovery — if the service owns the lifecycle, the ViewModel leaves discovery running.
+
+`PhoneDiscoveryManager.setEnabled(Boolean)` is idempotent: calling `setEnabled(true)` when
+already discovering, or `setEnabled(false)` when idle, are both no-ops.
+
 ## Diagnostics View
 
 Both apps expose a **Diagnostics** screen under Settings → Diagnostics. It renders the


### PR DESCRIPTION
## Summary

- **TvSettingsScreen / TvSettingsViewModel** — new generic Settings screen reachable from the TV home screen; hosts two toggles (phone-discovery on/off, boot autostart on/off) plus navigation rows to Streaming Services and Diagnostics
- **Phone-discovery toggle** — `StreamingPreferencesRepository` gains `isPhoneDiscoveryEnabled` (default `true`) and `PhoneDiscoveryManager.setEnabled(Boolean)` (idempotent); disabling clears the discovered-phone list, re-enabling restarts NSD/BLE scanning
- **Boot autostart** — `BootReceiver` reads `isAutostartEnabled` on `BOOT_COMPLETED` and starts `TvDiscoveryService`; the foreground service (`connectedDevice`) self-stops when both prefs become false; `TvHomeViewModel.onCleared` skips `stopDiscovery()` while the service is running

Closes #344

## Test plan

- [ ] `StreamingPreferencesRepositoryTest` — defaults, persist true/false for both new keys (JUnit 5, `@TempDir` DataStore, no Robolectric)
- [ ] `BootReceiverTest` — disabled autostart → no service start; wrong action → no start; enabled → `startForegroundService` called; exception → DiagnosticLog breadcrumb
- [ ] `TvSettingsViewModelTest` — initial state matches repo defaults, optimistic toggle update, write-through, error logging
- [ ] `PhoneDiscoveryManagerTest` (SetEnabledTest) — starts discovery, idempotent when running, stops+clears, no-op when idle
- [ ] `TvHomeViewModelTest` (updated) — `setEnabled(true)` called on init, `setEnabled(false)` when pref false, skip stopDiscovery when service running

https://claude.ai/code/session_01G64TDgFwjhDYM8aUSaLKCC