### PR TITLE
chore(ci): extract shared Android setup into composite action

### DIFF
--- a/.github/actions/setup-android-build/action.yml
+++ b/.github/actions/setup-android-build/action.yml
@@ -1,14 +1,14 @@
 name: Setup Android Build
 description: >
   Composite action shared by build-android.yml and release.yml.
-  Checks out the repository, configures JDK 17 (Temurin), sets up
-  Gradle with caching, and warms the Gradle configuration cache.
+  Configures JDK 17 (Temurin), sets up Gradle with caching, and warms
+  the Gradle configuration cache.  The calling workflow must check out
+  the repository before invoking this action (local composite actions
+  require the workspace to already be populated).
 
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
-
     - name: Set up JDK 17
       uses: actions/setup-java@v5
       with:

--- a/.github/actions/setup-android-build/action.yml
+++ b/.github/actions/setup-android-build/action.yml
@@ -1,0 +1,30 @@
+name: Setup Android Build
+description: >
+  Composite action shared by build-android.yml and release.yml.
+  Checks out the repository, configures JDK 17 (Temurin), sets up
+  Gradle with caching, and warms the Gradle configuration cache.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v5
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v6
+
+    # The Gradle configuration cache serialises the task graph so subsequent
+    # runs with identical inputs skip the configuration phase entirely.
+    # Key on all build scripts + properties so any structural change
+    # invalidates and rebuilds the cache rather than serving a stale one.
+    - name: Cache Gradle configuration cache
+      uses: actions/cache@v4
+      with:
+        path: .gradle/configuration-cache
+        key: config-cache-${{ hashFiles('**/*.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml') }}
+        restore-keys: config-cache-

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -29,6 +29,7 @@ jobs:
               - '*.gradle.kts'
               - 'gradle/**'
               - 'gradle.properties'
+              - '.github/actions/**'
 
   test-and-build:
     name: Test & Build

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -36,23 +36,7 @@ jobs:
     if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
-
-      - name: Cache Configuration Cache
-        uses: actions/cache@v4
-        with:
-          path: .gradle/configuration-cache
-          key: config-cache-${{ hashFiles('**/*.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml') }}
-          restore-keys: config-cache-
+      - uses: ./.github/actions/setup-android-build
 
       # Decode release keystore when available so debug APKs are signed with the
       # same certificate as release APKs.  This prevents INSTALL_FAILED_UPDATE_INCOMPATIBLE

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -37,6 +37,7 @@ jobs:
     if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-android-build
 
       # Decode release keystore when available so debug APKs are signed with the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       VERSION: ${{ needs.release-please.outputs.version }}
       TAG: ${{ needs.release-please.outputs.tag_name }}
     steps:
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-android-build
 
       # -- Prepare release signing ----------------------------------------

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,16 +34,7 @@ jobs:
       VERSION: ${{ needs.release-please.outputs.version }}
       TAG: ${{ needs.release-please.outputs.tag_name }}
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+      - uses: ./.github/actions/setup-android-build
 
       # -- Prepare release signing ----------------------------------------
       - name: Decode Keystore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,10 +63,14 @@ watchbuddy/
 ├── docs/
 │   ├── architecture.md  Detailed architecture, protocols, LLM strategy, deep links
 │   └── tmdb-integration.md  TMDB API usage, user journeys, connection handling
-├── .github/workflows/
-│   ├── build-android.yml   CI: builds debug APKs on push/PR
-│   ├── release.yml         CD: release-please + signed APK builds
-│   └── test-backend.yml    CI: tests for the Node.js backend
+├── .github/
+│   ├── actions/
+│   │   └── setup-android-build/
+│   │       └── action.yml  Composite action: checkout + JDK 17 + Gradle setup (shared by build-android.yml and release.yml)
+│   └── workflows/
+│       ├── build-android.yml   CI: builds debug APKs on push/PR
+│       ├── release.yml         CD: release-please + signed APK builds
+│       └── test-backend.yml    CI: tests for the Node.js backend
 └── gradle/
     └── libs.versions.toml  Version catalog (single source of truth for dependencies)
 ```


### PR DESCRIPTION
## Summary

- Extracts the repeated checkout + JDK 17 + Gradle + configuration-cache steps from `build-android.yml` and `release.yml` into a new reusable composite action at `.github/actions/setup-android-build/action.yml`
- Both Android workflows now call `uses: ./.github/actions/setup-android-build` instead of duplicating ~15 lines each
- The Gradle configuration-cache step is included in the composite action so `release.yml` also benefits from it (previously missing there)
- The `changes` path-filter job in `build-android.yml` is intentionally kept — it correctly skips Android builds on docs-only PRs; release-please PRs already bypass it via the explicit `if:` guard
- `test-backend.yml` uses Node.js setup (not JDK/Gradle) so it is not changed

## Test plan

- [ ] CI `build-android.yml` passes on this PR (green gate — composite action is exercised by the `test-and-build` job)
- [ ] Verify the composite action step appears in the Actions UI as `.github/actions/setup-android-build`
- [ ] Release workflow (`release.yml`) uses the same composite action — validated on the next release trigger

Closes #300

https://claude.ai/code/session_01RHPZ1iW6fQJgzCewPLk3eN