### PR TITLE
chore(build): remove unused ktor-client-content-negotiation from catalog (#296)

### DIFF
--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -192,7 +192,6 @@ dependencies {
     testImplementation(libs.turbine)
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.ktor.server.test.host)
-    testImplementation(libs.ktor.client.content.negotiation)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.androidx.arch.core.testing)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,6 @@ ktor-server-netty = { group = "io.ktor", name = "ktor-server-netty", version.ref
 ktor-server-content-negotiation = { group = "io.ktor", name = "ktor-server-content-negotiation", version.ref = "ktor" }
 ktor-serialization-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-server-test-host = { group = "io.ktor", name = "ktor-server-test-host", version.ref = "ktor" }
-ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 
 # Kotlin Serialization
 kotlinx-serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }


### PR DESCRIPTION
## Summary

Full audit of `gradle/libs.versions.toml` against all three `build.gradle.kts` files. One unused alias found:

- **`ktor-client-content-negotiation`** — declared as `testImplementation` in `app-phone` but no test file ever imports `io.ktor.client.plugins.contentnegotiation.*` or configures the client-side ContentNegotiation plugin. Ktor's `testApplication {}` (from `ktor-server-test-host`) provides its own internal HTTP client; the separate `ktor-client-content-negotiation` artifact is not needed.

All other library and plugin aliases are actively referenced. The `ktor` version entry is retained — it is still used by the five remaining ktor-server-* aliases.

## Audit findings

| Alias | Status | Used by |
|-------|--------|---------|
| `ktor-server-core` | ✅ used | app-phone |
| `ktor-server-netty` | ✅ used | app-phone |
| `ktor-server-content-negotiation` | ✅ used | app-phone |
| `ktor-serialization-json` | ✅ used | app-phone |
| `ktor-server-test-host` | ✅ used | app-phone (tests) |
| `ktor-client-content-negotiation` | ❌ **unused** | nowhere |
| All other ~45 aliases | ✅ used | see build files |

## Test plan

- [x] `gradle/libs.versions.toml` no longer defines `ktor-client-content-negotiation`
- [x] `app-phone/build.gradle.kts` no longer references `libs.ktor.client.content.negotiation`
- [x] CI `build-android.yml` stays green (Gradle resolves without the removed alias)

Closes #296

https://claude.ai/code/session_01X2v2aETS5KE2aVmHjsiHTW