### PR TITLE
fix(phone): exclude Season 0 specials from episodes-behind delta (#357)

### DIFF
--- a/core/src/main/java/com/justb81/watchbuddy/core/progress/ShowProgressCalculator.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/progress/ShowProgressCalculator.kt
@@ -127,7 +127,7 @@ object ShowProgressCalculator {
     private fun latestWatched(entry: TraktWatchedEntry): WatchedRef? {
         var best: WatchedRef? = null
         for (season in entry.seasons) {
-            if (season.number <= 0) continue
+            if (!isRegularSeason(season.number)) continue
             for (ep in season.episodes) {
                 val ts = parseInstant(ep.last_watched_at) ?: continue
                 if (best == null || ts.isAfter(best.instant)) {
@@ -139,9 +139,9 @@ object ShowProgressCalculator {
     }
 
     private fun absoluteOrdinal(season: Int, episode: Int, seasons: List<TmdbSeasonSummary>): Int {
-        if (season <= 0) return 0
+        if (!isRegularSeason(season)) return 0
         val priorSum = seasons
-            .filter { it.season_number in 1 until season }
+            .filter { isRegularSeason(it.season_number) && it.season_number < season }
             .sumOf { it.episode_count }
         return priorSum + episode
     }
@@ -167,3 +167,11 @@ object ShowProgressCalculator {
 
 internal fun formatLabel(season: Int, episode: Int): String =
     "S%02dE%02d".format(season, episode)
+
+/**
+ * Shared predicate for "is this a regular (non-special) season?" — specials
+ * live in season 0 (and never a negative number) and must be excluded from
+ * all progress arithmetic: `latestWatched`, absolute-ordinal sums, and the
+ * "episodes behind" delta.
+ */
+internal fun isRegularSeason(seasonNumber: Int): Boolean = seasonNumber >= 1

--- a/core/src/test/java/com/justb81/watchbuddy/core/progress/ShowProgressCalculatorTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/progress/ShowProgressCalculatorTest.kt
@@ -161,6 +161,72 @@ class ShowProgressCalculatorTest {
             assertTrue(result is ShowProgress.InProgress)
             assertEquals("S01E02", (result as ShowProgress.InProgress).latestWatchedLabel)
         }
+
+        @Test
+        fun `season 0 episode_count does not inflate airedOrdinal across seasons`() {
+            // TMDB returns S0 with 100 specials alongside real seasons. The
+            // S0 episode_count must not be summed into prior-season totals
+            // when computing the gap between watched and aired.
+            val e = entry(Triple(1, 5, "2024-01-05T10:00:00Z"))
+            val h = hint(
+                status = "Returning Series",
+                lastAired = TmdbEpisodeSummary(2, 3, air_date = "2024-02-01"),
+                seasons = listOf(
+                    TmdbSeasonSummary(0, 100), // specials
+                    TmdbSeasonSummary(1, 10),
+                    TmdbSeasonSummary(2, 10)
+                )
+            )
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            assertTrue(result is ShowProgress.InProgress)
+            // watched = S1E5 → 5
+            // aired   = S2E3 → priorSum(S1=10) + 3 = 13  (S0=100 must NOT count)
+            // behind  = 13 - 5 = 8
+            assertEquals(8, (result as ShowProgress.InProgress).episodesBehind)
+        }
+
+        @Test
+        fun `only-specials aired reports zero behind`() {
+            // TMDB says the most recently aired episode is a special. The
+            // calculator must not treat that as a regular episode the user
+            // is behind on.
+            val e = entry(Triple(1, 10, "2024-01-05T10:00:00Z"))
+            val h = hint(
+                status = "Returning Series",
+                lastAired = TmdbEpisodeSummary(0, 47, air_date = "2024-02-01"),
+                nextAired = TmdbEpisodeSummary(2, 1, air_date = "2024-06-01"),
+                seasons = listOf(
+                    TmdbSeasonSummary(0, 50),
+                    TmdbSeasonSummary(1, 10)
+                )
+            )
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            // lastAired is a special → airedOrdinal=0 → behind clamps to 0,
+            // and because there is a next regular aired we expect CaughtUpAiring.
+            assertTrue(result is ShowProgress.CaughtUpAiring)
+        }
+
+        @Test
+        fun `specials watched alongside regulars do not affect behind delta`() {
+            val e = entry(
+                Triple(0, 3, "2024-03-01T10:00:00Z"),   // special
+                Triple(1, 2, "2024-01-01T10:00:00Z"),
+                Triple(1, 3, "2024-01-10T10:00:00Z")
+            )
+            val h = hint(
+                status = "Returning Series",
+                lastAired = TmdbEpisodeSummary(1, 5, air_date = "2024-02-01"),
+                seasons = listOf(
+                    TmdbSeasonSummary(0, 20),
+                    TmdbSeasonSummary(1, 10)
+                )
+            )
+            val result = ShowProgressCalculator.compute(e, h, utc)
+            assertTrue(result is ShowProgress.InProgress)
+            // watched regular = S1E3 → 3, aired regular = S1E5 → 5
+            assertEquals(2, (result as ShowProgress.InProgress).episodesBehind)
+            assertEquals("S01E03", result.latestWatchedLabel)
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Summary

Implements #357 — "Phone HomeScreen: Exclude Season 0 (specials) from 'episodes behind' count."

The `ShowProgressCalculator` already filtered S0 in `latestWatched` and bailed out of `absoluteOrdinal` for non-positive seasons, but the prior-season sum was expressed as `season_number in 1 until season` — easy to regress on. This change:

- Introduces a single shared predicate `isRegularSeason(n) = n >= 1` in `core/progress/`.
- Routes both `latestWatched` and `absoluteOrdinal` (early-return + prior-sum filter) through the predicate so S0 can never leak in via either axis.
- Adds unit tests covering:
  - `S0 episode_count never inflates airedOrdinal across seasons.`
  - `lastAired = special clamps behind to 0 → CaughtUpAiring when a regular is next.`
  - `Specials watched alongside regulars do not affect the behind delta.`

`ShowDetailScreen` is unchanged — specials remain visible and tickable there, per AC.

Closes #357

## Test plan

- [ ] CI `build-android.yml` green (it runs `:core:testDebugUnitTest` transitively).
- [ ] New tests in `ShowProgressCalculatorTest` pass.
- [ ] Existing `ShowProgressCalculatorTest` cases remain green.

https://claude.ai/code/session_01EioZELYpF1HUSCmXERXsVN