### PR TITLE
fix(tv): fix title line-height overlap and remove redundant Back button on ShowDetail

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -9,9 +9,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -35,6 +38,11 @@ fun ShowDetailScreen(
     val nextEpisode  = (lastEpisode?.number ?: 0) + 1
 
     val services by viewModel.availableServices.collectAsState(initial = emptyList())
+    val watchNowFocus = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        watchNowFocus.requestFocus()
+    }
 
     Box(
         modifier = Modifier
@@ -75,8 +83,11 @@ fun ShowDetailScreen(
             Text(
                 text       = entry.show.title,
                 fontSize   = 40.sp,
+                lineHeight = 46.sp,
                 fontWeight = FontWeight.Bold,
-                color      = Color.White
+                color      = Color.White,
+                maxLines   = 2,
+                overflow   = TextOverflow.Ellipsis
             )
 
             // Year + stats
@@ -128,6 +139,7 @@ fun ShowDetailScreen(
                             )
                         }
                     },
+                    modifier = Modifier.focusRequester(watchNowFocus),
                     colors = ButtonDefaults.colors(
                         containerColor = MaterialTheme.colorScheme.primary
                     )
@@ -141,11 +153,6 @@ fun ShowDetailScreen(
                 // Recap button
                 OutlinedButton(onClick = onRecapClick) {
                     Text(stringResource(R.string.tv_recap))
-                }
-
-                // Back
-                OutlinedButton(onClick = onBack) {
-                    Text(stringResource(R.string.tv_back))
                 }
             }
 


### PR DESCRIPTION
## Summary

Fixes two UI issues on the TV ShowDetail screen:

- **#364 — Title line-height overlap**: Long show titles that wrap to a second line were rendering with overlapping glyphs due to no explicit `lineHeight`. Fixed by setting `lineHeight = 46.sp` (~1.15× the 40.sp font size), plus `maxLines = 2` and `TextOverflow.Ellipsis` as guardrails.
- **#365 — Redundant Back button and wrong default focus**: The action row had a third "Back" button that duplicated the top-left back arrow and the system back key. Removed it. Default D-pad focus now lands on "Watch now" via a `FocusRequester` + `LaunchedEffect(Unit)`, so the primary action is immediately reachable on screen entry.

## Changes

- `app-tv/.../ShowDetailScreen.kt`: Add `lineHeight`/`maxLines`/`TextOverflow.Ellipsis` to title `Text`; remove redundant Back button from action row; attach `FocusRequester` to Watch Now button.

## Test plan

- [ ] Open ShowDetail for a show with a long title (e.g. "The Lord of the Rings: The Rings of Power") — two lines render without overlap; title ellipsizes beyond two lines.
- [ ] Open ShowDetail — D-pad focus starts on "Watch now", not the back arrow.
- [ ] Action row contains only "Watch now" and "What happened so far".
- [ ] Remote back / D-pad back still navigates up correctly.
- [ ] D-pad left/right traversal between the two remaining buttons is smooth.

Closes #364
Closes #365

https://claude.ai/code/session_01Vgo6SM9ciXUeY34VwepF8q