### PR TITLE
feat(tv): wire up MediaSession scrobbling end-to-end

### DIFF
--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -28,6 +28,13 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- Scrobble detection — WatchBuddyNotificationListener is declared as a
+         NotificationListenerService so that MediaSessionManager.getActiveSessions()
+         returns the TV's active media controllers. Without this the scrobbler
+         silently sees an empty session list. The user must still toggle
+         WatchBuddy on under Settings → Notification access. -->
+    <uses-permission android:name="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE" />
+
     <!-- Play Store: TV app — no touchscreen, leanback required for correct
          multi-APK device targeting (prevents phone devices from receiving the
          TV AAB which has a higher versionCode). -->
@@ -116,6 +123,20 @@
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
             </intent-filter>
         </receiver>
+
+        <!-- NotificationListenerService used purely to unlock
+             MediaSessionManager.getActiveSessions(). The service does no
+             notification processing — it exists so the user can grant
+             "Notification access" to WatchBuddy, which is the only way the
+             platform lets a non-system app read active MediaSession state. -->
+        <service
+            android:name=".tv.scrobbler.WatchBuddyNotificationListener"
+            android:exported="true"
+            android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
+            <intent-filter>
+                <action android:name="android.service.notification.NotificationListenerService" />
+            </intent-filter>
+        </service>
 
     </application>
 </manifest>

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/TvDiscoveryService.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/TvDiscoveryService.kt
@@ -5,12 +5,16 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
+import android.content.ComponentName
 import android.content.Intent
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
+import com.justb81.watchbuddy.tv.scrobbler.WatchBuddyNotificationListener
 import com.justb81.watchbuddy.tv.ui.TvMainActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -35,6 +39,7 @@ class TvDiscoveryService : Service() {
 
     @Inject lateinit var phoneDiscovery: PhoneDiscoveryManager
     @Inject lateinit var preferences: StreamingPreferencesRepository
+    @Inject lateinit var scrobbler: MediaSessionScrobbler
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var observerJob: Job? = null
@@ -63,17 +68,42 @@ class TvDiscoveryService : Service() {
             preferences.isPhoneDiscoveryEnabled.collect { discovery ->
                 if (discovery) {
                     phoneDiscovery.setEnabled(true)
+                    startScrobblerIfPermitted()
                 } else {
                     DiagnosticLog.event(TAG, "phone discovery disabled — stopping self")
+                    scrobbler.stopListening()
                     stopSelf()
                 }
             }
         }
     }
 
+    /**
+     * Start [MediaSessionScrobbler] if the user has granted Notification Access
+     * to [WatchBuddyNotificationListener]. Without that grant,
+     * [android.media.session.MediaSessionManager.getActiveSessions] silently
+     * returns an empty list — log a breadcrumb so diagnostics can explain why
+     * scrobbling is inert, and leave phone discovery running regardless.
+     */
+    private fun startScrobblerIfPermitted() {
+        val component = ComponentName(this, WatchBuddyNotificationListener::class.java)
+        val granted = NotificationManagerCompat.getEnabledListenerPackages(this)
+            .contains(packageName)
+        if (granted) {
+            scrobbler.startListening(component)
+            DiagnosticLog.event(TAG, "scrobbler listening")
+        } else {
+            DiagnosticLog.event(
+                TAG,
+                "scrobbler idle — notification access not granted",
+            )
+        }
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         DiagnosticLog.event(TAG, "service destroyed")
+        scrobbler.stopListening()
         observerJob?.cancel()
         scope.cancel()
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/WatchBuddyNotificationListener.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/WatchBuddyNotificationListener.kt
@@ -1,0 +1,33 @@
+package com.justb81.watchbuddy.tv.scrobbler
+
+import android.service.notification.NotificationListenerService
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+
+/**
+ * Placeholder [NotificationListenerService] required to unlock
+ * [android.media.session.MediaSessionManager.getActiveSessions]. Without a
+ * registered notification listener the platform silently returns an empty
+ * list and [com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler]
+ * has nothing to work with.
+ *
+ * We do not process notifications here — the only reason this class exists
+ * is so the user can grant "Notification access" to WatchBuddy in TV
+ * Settings and so we have a valid [android.content.ComponentName] to hand
+ * to [android.media.session.MediaSessionManager].
+ */
+class WatchBuddyNotificationListener : NotificationListenerService() {
+
+    override fun onListenerConnected() {
+        super.onListenerConnected()
+        DiagnosticLog.event(TAG, "listener connected")
+    }
+
+    override fun onListenerDisconnected() {
+        super.onListenerDisconnected()
+        DiagnosticLog.event(TAG, "listener disconnected")
+    }
+
+    companion object {
+        private const val TAG = "NotificationListener"
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/TvMainActivity.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/TvMainActivity.kt
@@ -1,13 +1,16 @@
 package com.justb81.watchbuddy.tv.ui
 
 import android.Manifest
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
+import com.justb81.watchbuddy.tv.discovery.TvDiscoveryService
 import com.justb81.watchbuddy.tv.ui.navigation.TvNavGraph
 import com.justb81.watchbuddy.tv.ui.theme.WatchBuddyTvTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -32,6 +35,26 @@ class TvMainActivity : ComponentActivity() {
             }
         }
     }
+
+    override fun onResume() {
+        super.onResume()
+        // When the user has granted Notification Access, start the foreground
+        // discovery service so scrobbling survives the WatchBuddy TV app being
+        // backgrounded while the user watches Netflix / Disney+ etc.
+        // Without the grant, scrobbling can't work anyway — skip starting the
+        // service so we don't impose a persistent notification on users who
+        // haven't opted into scrobble. Discovery still runs in-process via
+        // TvHomeViewModel for the phone pairing flow.
+        if (isNotificationAccessGranted()) {
+            ContextCompat.startForegroundService(
+                this,
+                Intent(this, TvDiscoveryService::class.java),
+            )
+        }
+    }
+
+    private fun isNotificationAccessGranted(): Boolean =
+        NotificationManagerCompat.getEnabledListenerPackages(this).contains(packageName)
 
     /**
      * Request BLUETOOTH_SCAN so [com.justb81.watchbuddy.tv.discovery.PhoneBleScanner]

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -9,13 +9,17 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.tv.material3.*
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 
 @OptIn(ExperimentalTvMaterial3Api::class)
@@ -25,6 +29,15 @@ fun TvDiagnosticsScreen(
     viewModel: TvDiagnosticsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) viewModel.refreshNotificationAccess()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     Box(
         modifier = Modifier
@@ -99,6 +112,33 @@ fun TvDiagnosticsScreen(
                                 Status.FAIL,
                             )
                         },
+                    ),
+                )
+            }
+
+            item {
+                DiagnosticsSection(
+                    title = stringResource(R.string.tv_diagnostics_section_scrobble),
+                    rows = listOf(
+                        DiagRow(
+                            stringResource(R.string.tv_diagnostics_row_notification_access),
+                            yesNoStr(uiState.notificationAccessGranted),
+                            if (uiState.notificationAccessGranted) Status.OK else Status.FAIL,
+                        ),
+                        DiagRow(
+                            stringResource(R.string.tv_diagnostics_row_scrobbler_listening),
+                            yesNoStr(uiState.scrobblerListening),
+                            when {
+                                uiState.scrobblerListening -> Status.OK
+                                uiState.notificationAccessGranted -> Status.WARN
+                                else -> Status.NEUTRAL
+                            },
+                        ),
+                        DiagRow(
+                            stringResource(R.string.tv_diagnostics_row_last_candidate),
+                            formatLastCandidate(uiState.lastCandidate),
+                            if (uiState.lastCandidate != null) Status.OK else Status.NEUTRAL,
+                        ),
                     ),
                 )
             }
@@ -302,4 +342,12 @@ private fun formatAge(timestampMs: Long): String {
         seconds < 3_600 -> "${seconds / 60}m ago"
         else -> "${seconds / 3_600}h ago"
     }
+}
+
+private fun formatLastCandidate(last: MediaSessionScrobbler.LastCandidate?): String {
+    if (last == null) return "—"
+    val title = last.candidate.matchedShow?.title ?: last.candidate.mediaTitle
+    val pct = (last.candidate.confidence * 100).toInt()
+    val marker = if (last.autoScrobbled) "auto" else "overlay"
+    return "$title @ ${pct}% · $marker · ${formatAge(last.observedAtMs)}"
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
@@ -1,8 +1,11 @@
 package com.justb81.watchbuddy.tv.ui.diagnostics
 
+import android.app.Application
+import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.BuildConfig
+import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -10,6 +13,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -20,6 +24,9 @@ data class TvDiagnosticsUiState(
     val bleScanErrorCode: Int? = null,
     val lastHeartbeatMs: Long = 0L,
     val phones: List<PhoneDiscoveryManager.DiscoveredPhone> = emptyList(),
+    val notificationAccessGranted: Boolean = false,
+    val scrobblerListening: Boolean = false,
+    val lastCandidate: MediaSessionScrobbler.LastCandidate? = null,
     val versionName: String = BuildConfig.VERSION_NAME,
     val versionCode: Int = BuildConfig.VERSION_CODE,
 )
@@ -27,29 +34,33 @@ data class TvDiagnosticsUiState(
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class TvDiagnosticsViewModel @Inject constructor(
+    private val application: Application,
     phoneDiscovery: PhoneDiscoveryManager,
+    scrobbler: MediaSessionScrobbler,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TvDiagnosticsUiState())
     val uiState: StateFlow<TvDiagnosticsUiState> = _uiState.asStateFlow()
 
     init {
-        val partA = combine(
+        refreshNotificationAccess()
+        val discoveryTriple = combine(
             phoneDiscovery.discoveryActive,
             phoneDiscovery.multicastLockHeld,
             phoneDiscovery.bleScanState,
-        ) { active, lock, ble ->
-            Triple(active, lock, ble)
-        }
-        val partB = combine(
+        ) { active, lock, ble -> Triple(active, lock, ble) }
+        val discoveryTail = combine(
             phoneDiscovery.bleScanErrorCode,
             phoneDiscovery.lastHeartbeatTick,
             phoneDiscovery.discoveredPhones,
-        ) { bleErr, tick, phones ->
-            Triple(bleErr, tick, phones)
-        }
+        ) { bleErr, tick, phones -> Triple(bleErr, tick, phones) }
+        val scrobbleState = combine(
+            scrobbler.isListening,
+            scrobbler.lastCandidate,
+        ) { listening, last -> listening to last }
+
         viewModelScope.launch {
-            combine(partA, partB) { a, b ->
+            combine(discoveryTriple, discoveryTail, scrobbleState) { a, b, s ->
                 TvDiagnosticsUiState(
                     discoveryActive = a.first,
                     multicastLockHeld = a.second,
@@ -57,8 +68,26 @@ class TvDiagnosticsViewModel @Inject constructor(
                     bleScanErrorCode = b.first,
                     lastHeartbeatMs = b.second,
                     phones = b.third,
+                    notificationAccessGranted = _uiState.value.notificationAccessGranted,
+                    scrobblerListening = s.first,
+                    lastCandidate = s.second,
                 )
-            }.collect { _uiState.value = it }
+            }.collect { snapshot ->
+                _uiState.update { snapshot.copy(notificationAccessGranted = it.notificationAccessGranted) }
+            }
         }
+    }
+
+    /**
+     * Re-reads the system notification-access allowlist; call on ON_RESUME.
+     * Wrapped in runCatching so unit tests running against a stubbed Android
+     * JAR don't throw on the static [android.provider.Settings.Secure] lookup.
+     */
+    fun refreshNotificationAccess() {
+        val granted = runCatching {
+            NotificationManagerCompat.getEnabledListenerPackages(application)
+                .contains(application.packageName)
+        }.getOrDefault(false)
+        _uiState.update { it.copy(notificationAccessGranted = granted) }
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsScreen.kt
@@ -1,5 +1,7 @@
 package com.justb81.watchbuddy.tv.ui.settings
 
+import android.content.Intent
+import android.provider.Settings
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -16,16 +18,21 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.tv.material3.Card
 import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
@@ -49,6 +56,8 @@ private sealed interface SettingsRow {
         val title: String,
         val subtitle: String,
         val onClick: () -> Unit,
+        val statusLabel: String? = null,
+        val statusOk: Boolean = false,
     ) : SettingsRow
 }
 
@@ -61,6 +70,22 @@ fun TvSettingsScreen(
     viewModel: TvSettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    // Re-read notification-access state every time the screen resumes — the
+    // user flipped it in the system list and there's no broadcast we can
+    // observe, so we must poll on resume to catch the change.
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) viewModel.refreshNotificationAccess()
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    val grantedLabel = stringResource(R.string.tv_settings_status_granted)
+    val notGrantedLabel = stringResource(R.string.tv_settings_status_not_granted)
 
     val rows: List<SettingsRow> = listOf(
         SettingsRow.Toggle(
@@ -76,6 +101,20 @@ fun TvSettingsScreen(
             subtitle = stringResource(R.string.tv_settings_autostart_subtitle),
             enabled = uiState.isAutostartEnabled,
             onChange = viewModel::setAutostartEnabled,
+        ),
+        SettingsRow.Navigate(
+            key = "notification_access",
+            title = stringResource(R.string.tv_settings_notification_access_title),
+            subtitle = stringResource(R.string.tv_settings_notification_access_subtitle),
+            onClick = {
+                context.startActivity(
+                    Intent(Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS).apply {
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    }
+                )
+            },
+            statusLabel = if (uiState.isNotificationAccessGranted) grantedLabel else notGrantedLabel,
+            statusOk = uiState.isNotificationAccessGranted,
         ),
         SettingsRow.Navigate(
             key = "streaming_services",
@@ -206,12 +245,34 @@ private fun NavigateRow(row: SettingsRow.Navigate) {
                     color = Color.White.copy(alpha = 0.6f),
                 )
             }
+            row.statusLabel?.let { label ->
+                StatusChip(label = label, ok = row.statusOk)
+                Spacer(Modifier.size(12.dp))
+            }
             Text(
                 text = "\u203A",
                 fontSize = 22.sp,
                 color = Color.White.copy(alpha = 0.6f),
             )
         }
+    }
+}
+
+@Composable
+private fun StatusChip(label: String, ok: Boolean) {
+    val bg = if (ok) Color(0xFF2E7D32) else Color(0xFFF9A825)
+    Box(
+        modifier = Modifier
+            .background(bg.copy(alpha = 0.25f), RoundedCornerShape(8.dp))
+            .border(1.dp, bg, RoundedCornerShape(8.dp))
+            .padding(horizontal = 10.dp, vertical = 4.dp),
+    ) {
+        Text(
+            text = label,
+            fontSize = 12.sp,
+            fontWeight = FontWeight.Medium,
+            color = Color.White,
+        )
     }
 }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModel.kt
@@ -1,5 +1,7 @@
 package com.justb81.watchbuddy.tv.ui.settings
 
+import android.app.Application
+import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
@@ -20,10 +22,12 @@ import javax.inject.Inject
 data class TvSettingsUiState(
     val isPhoneDiscoveryEnabled: Boolean = true,
     val isAutostartEnabled: Boolean = false,
+    val isNotificationAccessGranted: Boolean = false,
 )
 
 @HiltViewModel
 class TvSettingsViewModel @Inject constructor(
+    private val application: Application,
     private val repository: StreamingPreferencesRepository,
 ) : ViewModel() {
 
@@ -38,6 +42,7 @@ class TvSettingsViewModel @Inject constructor(
         viewModelScope.launch(exceptionHandler, block = block)
 
     init {
+        refreshNotificationAccess()
         launchSafe {
             combine(
                 repository.isPhoneDiscoveryEnabled,
@@ -63,6 +68,22 @@ class TvSettingsViewModel @Inject constructor(
     fun setAutostartEnabled(enabled: Boolean) {
         _uiState.update { it.copy(isAutostartEnabled = enabled) }
         launchSafe { repository.setAutostartEnabled(enabled) }
+    }
+
+    /**
+     * Re-read the system notification-access allowlist. Called from the UI
+     * on every ON_RESUME because there is no broadcast to observe — the user
+     * flips the toggle in system Settings and we only learn about it on
+     * return to our own screen. Wrapped in runCatching so unit tests (which
+     * run against a stubbed Android JAR) don't throw on the static
+     * [android.provider.Settings.Secure] lookup inside NotificationManagerCompat.
+     */
+    fun refreshNotificationAccess() {
+        val granted = runCatching {
+            NotificationManagerCompat.getEnabledListenerPackages(application)
+                .contains(application.packageName)
+        }.getOrDefault(false)
+        _uiState.update { it.copy(isNotificationAccessGranted = granted) }
     }
 
     companion object {

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -70,6 +70,10 @@
     <string name="tv_settings_autostart_subtitle">Suche automatisch starten, wenn der Fernseher eingeschaltet wird</string>
     <string name="tv_settings_streaming_services">Streamingdienste</string>
     <string name="tv_settings_diagnostics">Diagnose</string>
+    <string name="tv_settings_notification_access_title">Benachrichtigungszugriff</string>
+    <string name="tv_settings_notification_access_subtitle">Erforderlich für Scrobbling – damit WatchBuddy erkennt, was am TV läuft</string>
+    <string name="tv_settings_status_granted">Erteilt</string>
+    <string name="tv_settings_status_not_granted">Nicht erteilt</string>
     <string name="tv_discovery_notification_channel_name">Telefonsuche</string>
     <string name="tv_discovery_notification_text">Suche im Netzwerk nach WatchBuddy-Telefonen</string>
 
@@ -99,8 +103,12 @@
     <string name="tv_diagnostics_section_connectivity">Verbindung</string>
     <string name="tv_diagnostics_section_nsd">Erkennung (NSD)</string>
     <string name="tv_diagnostics_section_ble">BLE-Scanner</string>
+    <string name="tv_diagnostics_section_scrobble">Scrobble</string>
     <string name="tv_diagnostics_section_phones">Gefundene Telefone</string>
     <string name="tv_diagnostics_section_build">Build-Infos</string>
+    <string name="tv_diagnostics_row_notification_access">Benachrichtigungszugriff</string>
+    <string name="tv_diagnostics_row_scrobbler_listening">Scrobbler aktiv</string>
+    <string name="tv_diagnostics_row_last_candidate">Letzter Treffer</string>
     <string name="tv_diagnostics_row_multicast_lock">Multicast-Lock</string>
     <string name="tv_diagnostics_row_discovery_active">Erkennung aktiv</string>
     <string name="tv_diagnostics_row_last_heartbeat">Letzter Heartbeat</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -70,6 +70,10 @@
     <string name="tv_settings_autostart_subtitle">Iniciar la búsqueda automáticamente al encender el televisor</string>
     <string name="tv_settings_streaming_services">Servicios de streaming</string>
     <string name="tv_settings_diagnostics">Diagnósticos</string>
+    <string name="tv_settings_notification_access_title">Acceso a notificaciones</string>
+    <string name="tv_settings_notification_access_subtitle">Necesario para el scrobble: permite a WatchBuddy detectar lo que se reproduce en el televisor</string>
+    <string name="tv_settings_status_granted">Concedido</string>
+    <string name="tv_settings_status_not_granted">No concedido</string>
     <string name="tv_discovery_notification_channel_name">Descubrimiento de teléfonos</string>
     <string name="tv_discovery_notification_text">Buscando teléfonos WatchBuddy en la red</string>
 
@@ -99,8 +103,12 @@
     <string name="tv_diagnostics_section_connectivity">Conectividad</string>
     <string name="tv_diagnostics_section_nsd">Descubrimiento (NSD)</string>
     <string name="tv_diagnostics_section_ble">Escáner BLE</string>
+    <string name="tv_diagnostics_section_scrobble">Scrobble</string>
     <string name="tv_diagnostics_section_phones">Teléfonos encontrados</string>
     <string name="tv_diagnostics_section_build">Información de build</string>
+    <string name="tv_diagnostics_row_notification_access">Acceso a notificaciones</string>
+    <string name="tv_diagnostics_row_scrobbler_listening">Scrobbler activo</string>
+    <string name="tv_diagnostics_row_last_candidate">Último candidato</string>
     <string name="tv_diagnostics_row_multicast_lock">Bloqueo multicast</string>
     <string name="tv_diagnostics_row_discovery_active">Descubrimiento activo</string>
     <string name="tv_diagnostics_row_last_heartbeat">Último heartbeat</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -70,6 +70,10 @@
     <string name="tv_settings_autostart_subtitle">Lancer la recherche automatiquement au démarrage du téléviseur</string>
     <string name="tv_settings_streaming_services">Services de streaming</string>
     <string name="tv_settings_diagnostics">Diagnostics</string>
+    <string name="tv_settings_notification_access_title">Accès aux notifications</string>
+    <string name="tv_settings_notification_access_subtitle">Requis pour le scrobble — permet à WatchBuddy de détecter ce qui est lu sur le téléviseur</string>
+    <string name="tv_settings_status_granted">Accordé</string>
+    <string name="tv_settings_status_not_granted">Non accordé</string>
     <string name="tv_discovery_notification_channel_name">Recherche de téléphones</string>
     <string name="tv_discovery_notification_text">Recherche de téléphones WatchBuddy sur le réseau</string>
 
@@ -99,8 +103,12 @@
     <string name="tv_diagnostics_section_connectivity">Connectivité</string>
     <string name="tv_diagnostics_section_nsd">Découverte (NSD)</string>
     <string name="tv_diagnostics_section_ble">Scanner BLE</string>
+    <string name="tv_diagnostics_section_scrobble">Scrobble</string>
     <string name="tv_diagnostics_section_phones">Téléphones détectés</string>
     <string name="tv_diagnostics_section_build">Infos build</string>
+    <string name="tv_diagnostics_row_notification_access">Accès aux notifications</string>
+    <string name="tv_diagnostics_row_scrobbler_listening">Scrobbler actif</string>
+    <string name="tv_diagnostics_row_last_candidate">Dernier candidat</string>
     <string name="tv_diagnostics_row_multicast_lock">Verrou multicast</string>
     <string name="tv_diagnostics_row_discovery_active">Découverte active</string>
     <string name="tv_diagnostics_row_last_heartbeat">Dernier heartbeat</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -70,6 +70,10 @@
     <string name="tv_settings_autostart_subtitle">Start discovery automatically when the TV turns on</string>
     <string name="tv_settings_streaming_services">Streaming services</string>
     <string name="tv_settings_diagnostics">Diagnostics</string>
+    <string name="tv_settings_notification_access_title">Notification access</string>
+    <string name="tv_settings_notification_access_subtitle">Required for scrobbling — lets WatchBuddy see what\'s playing on the TV</string>
+    <string name="tv_settings_status_granted">Granted</string>
+    <string name="tv_settings_status_not_granted">Not granted</string>
     <string name="tv_discovery_notification_channel_name">Phone discovery</string>
     <string name="tv_discovery_notification_text">Looking for WatchBuddy phones on the network</string>
 
@@ -99,8 +103,12 @@
     <string name="tv_diagnostics_section_connectivity">Connectivity</string>
     <string name="tv_diagnostics_section_nsd">Discovery (NSD)</string>
     <string name="tv_diagnostics_section_ble">BLE scanner</string>
+    <string name="tv_diagnostics_section_scrobble">Scrobble</string>
     <string name="tv_diagnostics_section_phones">Discovered phones</string>
     <string name="tv_diagnostics_section_build">Build info</string>
+    <string name="tv_diagnostics_row_notification_access">Notification access</string>
+    <string name="tv_diagnostics_row_scrobbler_listening">Scrobbler listening</string>
+    <string name="tv_diagnostics_row_last_candidate">Last candidate</string>
     <string name="tv_diagnostics_row_multicast_lock">Multicast lock</string>
     <string name="tv_diagnostics_row_discovery_active">Discovery active</string>
     <string name="tv_diagnostics_row_last_heartbeat">Last heartbeat</string>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.tv.ui.settings
 
+import android.app.Application
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.tv.MainDispatcherRule
 import com.justb81.watchbuddy.tv.data.StreamingPreferencesRepository
@@ -33,6 +34,7 @@ class TvSettingsViewModelTest {
         val mainDispatcherRule = MainDispatcherRule()
     }
 
+    private val application: Application = mockk(relaxed = true)
     private val repository: StreamingPreferencesRepository = mockk()
 
     @BeforeEach
@@ -54,7 +56,7 @@ class TvSettingsViewModelTest {
         every { repository.isPhoneDiscoveryEnabled } returns flowOf(false)
         every { repository.isAutostartEnabled } returns flowOf(true)
 
-        val vm = TvSettingsViewModel(repository)
+        val vm = TvSettingsViewModel(application, repository)
         advanceUntilIdle()
 
         assertFalse(vm.uiState.value.isPhoneDiscoveryEnabled)
@@ -63,7 +65,7 @@ class TvSettingsViewModelTest {
 
     @Test
     fun `setPhoneDiscoveryEnabled writes through and optimistically updates state`() = runTest {
-        val vm = TvSettingsViewModel(repository)
+        val vm = TvSettingsViewModel(application, repository)
         advanceUntilIdle()
 
         vm.setPhoneDiscoveryEnabled(false)
@@ -75,7 +77,7 @@ class TvSettingsViewModelTest {
 
     @Test
     fun `setAutostartEnabled writes through and optimistically updates state`() = runTest {
-        val vm = TvSettingsViewModel(repository)
+        val vm = TvSettingsViewModel(application, repository)
         advanceUntilIdle()
 
         vm.setAutostartEnabled(true)
@@ -90,7 +92,7 @@ class TvSettingsViewModelTest {
         val discoveryFlow = MutableStateFlow(true)
         every { repository.isPhoneDiscoveryEnabled } returns discoveryFlow
 
-        val vm = TvSettingsViewModel(repository)
+        val vm = TvSettingsViewModel(application, repository)
         advanceUntilIdle()
         assertTrue(vm.uiState.value.isPhoneDiscoveryEnabled)
 
@@ -103,7 +105,7 @@ class TvSettingsViewModelTest {
     fun `observation failure is logged via DiagnosticLog`() = runTest {
         every { repository.isPhoneDiscoveryEnabled } returns flow { throw RuntimeException("boom") }
 
-        TvSettingsViewModel(repository)
+        TvSettingsViewModel(application, repository)
         advanceUntilIdle()
 
         val errors = DiagnosticLog.snapshot().filter { it.level == DiagnosticLog.Level.ERROR }
@@ -114,12 +116,22 @@ class TvSettingsViewModelTest {
     fun `write failure is logged via DiagnosticLog`() = runTest {
         coEvery { repository.setPhoneDiscoveryEnabled(any()) } throws RuntimeException("write boom")
 
-        val vm = TvSettingsViewModel(repository)
+        val vm = TvSettingsViewModel(application, repository)
         advanceUntilIdle()
         vm.setPhoneDiscoveryEnabled(false)
         advanceUntilIdle()
 
         val errors = DiagnosticLog.snapshot().filter { it.level == DiagnosticLog.Level.ERROR }
         assertTrue(errors.any { it.message.contains("tv settings write failed") })
+    }
+
+    @Test
+    fun `refreshNotificationAccess is resilient to stubbed Android JAR`() = runTest {
+        val vm = TvSettingsViewModel(application, repository)
+        advanceUntilIdle()
+
+        vm.refreshNotificationAccess()
+
+        assertFalse(vm.uiState.value.isNotificationAccessGranted)
     }
 }

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -13,7 +13,10 @@ import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -41,8 +44,28 @@ class MediaSessionScrobbler @Inject constructor(
         internal const val OVERLAY_THRESHOLD = 0.70f
     }
 
+    /** Diagnostic snapshot of a candidate the scrobbler recently saw. */
+    data class LastCandidate(
+        val candidate: ScrobbleCandidate,
+        val observedAtMs: Long,
+        val autoScrobbled: Boolean,
+    )
+
     private val _pendingConfirmation = MutableSharedFlow<ScrobbleCandidate>()
     val pendingConfirmation: SharedFlow<ScrobbleCandidate> = _pendingConfirmation
+
+    private val _isListening = MutableStateFlow(false)
+    /** True while [startListening] is active; flips back to false on [stopListening]. */
+    val isListening: StateFlow<Boolean> = _isListening.asStateFlow()
+
+    private val _lastCandidate = MutableStateFlow<LastCandidate?>(null)
+    /**
+     * Most recent candidate observed — regardless of whether it was auto-scrobbled
+     * or emitted to [pendingConfirmation]. Populated only for candidates that
+     * clear [OVERLAY_THRESHOLD]. Intended for diagnostics/UI surfacing so the
+     * user can see "the scrobbler *is* seeing things" even when no match auto-fires.
+     */
+    val lastCandidate: StateFlow<LastCandidate?> = _lastCandidate.asStateFlow()
 
     private var scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var pollingJob: Job? = null
@@ -51,6 +74,7 @@ class MediaSessionScrobbler @Inject constructor(
 
     fun startListening(notificationListenerComponent: ComponentName) {
         scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        _isListening.value = true
         val sessionManager = context.getSystemService(Context.MEDIA_SESSION_SERVICE)
                 as MediaSessionManager
 
@@ -84,6 +108,7 @@ class MediaSessionScrobbler @Inject constructor(
     fun stopListening() {
         pollingJob?.cancel()
         scope.cancel()
+        _isListening.value = false
     }
 
     private suspend fun processPlayingMedia(packageName: String, rawTitle: String, progress: Float?) {
@@ -91,8 +116,10 @@ class MediaSessionScrobbler @Inject constructor(
         val candidate = matchTitle(packageName, rawTitle) ?: return
         if (candidate.confidence >= AUTO_SCROBBLE_THRESHOLD) {
             autoScrobble(candidate, progress)
+            _lastCandidate.value = LastCandidate(candidate, System.currentTimeMillis(), autoScrobbled = true)
         } else if (candidate.confidence >= OVERLAY_THRESHOLD) {
             _pendingConfirmation.emit(candidate)
+            _lastCandidate.value = LastCandidate(candidate, System.currentTimeMillis(), autoScrobbled = false)
         }
     }
 

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerLifecycleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerLifecycleTest.kt
@@ -66,6 +66,16 @@ class MediaSessionScrobblerLifecycleTest {
             scrobbler.startListening(component)
             scrobbler.stopListening()
         }
+
+        @Test
+        fun `isListening reflects start and stop transitions`() {
+            val component = mockk<ComponentName>()
+            assertFalse(scrobbler.isListening.value)
+            scrobbler.startListening(component)
+            assertTrue(scrobbler.isListening.value)
+            scrobbler.stopListening()
+            assertFalse(scrobbler.isListening.value)
+        }
     }
 
     // ── autoScrobble() ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The TV-side scrobble pipeline (`MediaSessionScrobbler`, `TvScrobbleDispatcher`, `ScrobbleOverlay`) was fully implemented and unit-tested, but **never actually ran in production** — `startListening()` was only called from tests, no `NotificationListenerService` was declared, and `MediaSessionManager.getActiveSessions()` silently returned an empty list on Android. This PR fixes the missing wiring so the feature can actually be tested end-to-end on a real Google TV device.

## Changes

- **New `WatchBuddyNotificationListener`** — minimal `NotificationListenerService` so `MediaSessionManager.getActiveSessions()` returns real controllers. Declares `BIND_NOTIFICATION_LISTENER_SERVICE` + the service + `intent-filter` in the TV manifest.
- **Scrobbler lifecycle in `TvDiscoveryService`** — injects `MediaSessionScrobbler` and starts/stops it alongside phone discovery, gated on whether the user has granted Notification Access. Without the grant the service logs a breadcrumb and leaves discovery running; scrobbling is a pure opt-in.
- **Foreground lifetime via `TvMainActivity.onResume()`** — starts `TvDiscoveryService` only when Notification Access is granted, so scrobbling survives the WatchBuddy TV app being backgrounded while the user watches Netflix / Disney+ etc. Users who never grant access see no change.
- **Settings entry** — new "Notification access" row in `TvSettingsScreen` that deep-links into `Settings.ACTION_NOTIFICATION_LISTENER_SETTINGS` and renders a Granted / Not granted status chip, refreshed on `ON_RESUME`.
- **Scrobble diagnostics** — new section in `TvDiagnosticsScreen`: Notification access, Scrobbler listening, Last candidate (title + confidence + auto/overlay marker + age). Backed by new `isListening` and `lastCandidate` `StateFlow`s on `MediaSessionScrobbler`.
- **Translations** — en/de/fr/es.

## Test plan

Unit:
- [ ] `./gradlew :core:testDebugUnitTest :app-tv:testDebugUnitTest` — green (extends `MediaSessionScrobblerLifecycleTest` for `isListening`; updates `TvSettingsViewModelTest` for new `Application` constructor arg).

Manual (requires real TV + phone):
- [ ] Install `:app-tv:installDebug` on a Google TV device with an already-paired phone.
- [ ] Settings → Notification access → toggle WatchBuddy on. Confirm Settings row chip goes to **Granted**.
- [ ] Open Diagnostics. Confirm **Notification access** and **Scrobbler listening** are green; **Last candidate** shows "—".
- [ ] Play an episode in Netflix / Disney+ / Prime Video that is on the phone's Trakt watchlist. Within ~30 s:
  - High confidence (≥ 95 %) → `adb logcat -s MediaSessionScrobbler` prints `Scrobble started: <show> SxxExx`, phone "Now Watching" card appears, Diagnostics shows candidate @ %.
  - Medium confidence (70–95 %) → `ScrobbleOverlay` appears with a 15 s countdown.
- [ ] Pause on TV → phone receives `/scrobble/pause`. Stop / end → `/scrobble/stop`; Trakt history updates if progress ≥ 80 %.
- [ ] With two paired phones: confirm both receive the scrobble in parallel.
- [ ] Revoke Notification Access → Diagnostics "Scrobbler listening" goes red on next `TvDiscoveryService` lifecycle tick; no crash.

## Out of scope

- Moving off the 30 s polling cadence to MediaSession callbacks (larger refactor; not required for testability).
- Phone-side UI — already functional via `CompanionStateManager.lastScrobbleEvent`.

https://claude.ai/code/session_011DNNfugNA5RiozunQk4Q8b