### PR TITLE
refactor(core): replace nullable TokenProxyService injection with NoOp pattern

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRefreshManager.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRefreshManager.kt
@@ -37,8 +37,9 @@ class TokenRefreshManager @Inject constructor(
     private val tokenRepository: TokenRepository,
     private val settingsRepository: SettingsRepository,
     private val traktApi: TraktApiService,
-    private val tokenProxy: TokenProxyService?,
+    private val tokenProxy: TokenProxyService,
     private val tokenProxyServiceFactory: TokenProxyServiceFactory,
+    @Named("managedBackendAvailable") private val managedBackendAvailable: Boolean,
     @Named("traktClientId") private val clientId: String
 ) {
     private val mutex = Mutex()
@@ -94,11 +95,11 @@ class TokenRefreshManager @Inject constructor(
     }
 
     private suspend fun refreshViaManagedProxy(refreshToken: String): Triple<String, String, Int>? {
-        val proxy = tokenProxy ?: run {
+        if (!managedBackendAvailable) {
             Log.w(TAG, "Managed proxy not available — cannot refresh")
             return null
         }
-        val response = proxy.refreshToken(ProxyRefreshRequest(refresh_token = refreshToken))
+        val response = tokenProxy.refreshToken(ProxyRefreshRequest(refresh_token = refreshToken))
         return Triple(response.access_token, response.refresh_token, response.expires_in)
     }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
@@ -61,11 +61,12 @@ sealed class OnboardingState {
 class OnboardingViewModel @Inject constructor(
     application: Application,
     private val traktApi: TraktApiService,
-    private val tokenProxy: TokenProxyService?,
+    private val tokenProxy: TokenProxyService,
     @param:Named("traktClientId") private val buildConfigClientId: String,
     private val tokenRepository: TokenRepository,
     private val settingsRepository: SettingsRepository,
-    private val tokenProxyServiceFactory: TokenProxyServiceFactory
+    private val tokenProxyServiceFactory: TokenProxyServiceFactory,
+    @Named("managedBackendAvailable") private val managedBackendAvailable: Boolean
 ) : AndroidViewModel(application) {
 
     private val _state = MutableStateFlow<OnboardingState>(OnboardingState.Idle)
@@ -105,7 +106,7 @@ class OnboardingViewModel @Inject constructor(
     ): Pair<String?, NotConfiguredReason?> = when (authMode) {
         AuthMode.MANAGED -> when {
             buildConfigClientId.isBlank() -> null to NotConfiguredReason.MANAGED_MISSING_CLIENT_ID
-            tokenProxy == null -> null to NotConfiguredReason.MANAGED_MISSING_BACKEND
+            !managedBackendAvailable -> null to NotConfiguredReason.MANAGED_MISSING_BACKEND
             else -> buildConfigClientId to null
         }
         AuthMode.SELF_HOSTED -> when {
@@ -200,7 +201,7 @@ class OnboardingViewModel @Inject constructor(
 
                     when (authMode) {
                         AuthMode.MANAGED -> {
-                            val token = tokenProxy!!.exchangeDeviceCode(
+                            val token = tokenProxy.exchangeDeviceCode(
                                 ProxyTokenRequest(code = response.device_code)
                             )
                             accessToken = token.access_token

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRefreshManagerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRefreshManagerTest.kt
@@ -63,6 +63,7 @@ class TokenRefreshManagerTest {
             traktApi = traktApi,
             tokenProxy = tokenProxy,
             tokenProxyServiceFactory = tokenProxyServiceFactory,
+            managedBackendAvailable = true,
             clientId = buildClientId
         )
     }
@@ -119,8 +120,9 @@ class TokenRefreshManagerTest {
                 tokenRepository = tokenRepository,
                 settingsRepository = settingsRepository,
                 traktApi = traktApi,
-                tokenProxy = null,
+                tokenProxy = tokenProxy,
                 tokenProxyServiceFactory = tokenProxyServiceFactory,
+                managedBackendAvailable = false,
                 clientId = buildClientId
             )
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRefreshManagerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRefreshManagerTest.kt
@@ -275,6 +275,7 @@ class TokenRefreshManagerTest {
                 traktApi = traktApi,
                 tokenProxy = tokenProxy,
                 tokenProxyServiceFactory = tokenProxyServiceFactory,
+                managedBackendAvailable = true,
                 clientId = ""
             )
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelRetryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelRetryTest.kt
@@ -82,7 +82,8 @@ class OnboardingViewModelRetryTest {
         buildConfigClientId = BUILD_CLIENT_ID,
         tokenRepository = tokenRepository,
         settingsRepository = settingsRepository,
-        tokenProxyServiceFactory = tokenProxyServiceFactory
+        tokenProxyServiceFactory = tokenProxyServiceFactory,
+        managedBackendAvailable = true
     )
 
     @Nested

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModelTest.kt
@@ -68,7 +68,8 @@ class OnboardingViewModelTest {
 
     private fun createViewModel(
         buildClientId: String = BUILD_CLIENT_ID,
-        proxy: TokenProxyService? = tokenProxy,
+        proxy: TokenProxyService = tokenProxy,
+        managedBackendAvailable: Boolean = true,
     ): OnboardingViewModel = OnboardingViewModel(
         application = application,
         traktApi = traktApi,
@@ -76,7 +77,8 @@ class OnboardingViewModelTest {
         buildConfigClientId = buildClientId,
         tokenRepository = tokenRepository,
         settingsRepository = settingsRepository,
-        tokenProxyServiceFactory = tokenProxyServiceFactory
+        tokenProxyServiceFactory = tokenProxyServiceFactory,
+        managedBackendAvailable = managedBackendAvailable
     )
 
     @Nested
@@ -100,11 +102,11 @@ class OnboardingViewModelTest {
         }
 
         @Test
-        fun `shows NotConfigured with MANAGED_MISSING_BACKEND when token proxy is null`() = runTest {
+        fun `shows NotConfigured with MANAGED_MISSING_BACKEND when managed backend is unavailable`() = runTest {
             every { settingsRepository.settings } returns flowOf(
                 AppSettings(authMode = AuthMode.MANAGED)
             )
-            val vm = createViewModel(proxy = null)
+            val vm = createViewModel(managedBackendAvailable = false)
             vm.requestDeviceCode()
             advanceUntilIdle()
             val state = vm.state.value

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.justb81.watchbuddy.core.network
 
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
+import com.justb81.watchbuddy.core.trakt.NoOpTokenProxyService
 import com.justb81.watchbuddy.core.trakt.TokenProxyService
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import dagger.Module
@@ -85,35 +86,29 @@ object NetworkModule {
         retrofit.create(TmdbApiService::class.java)
 
     /**
-     * Retrofit instance for the token proxy backend.
+     * TokenProxyService for the WatchBuddy managed token proxy backend.
      *
-     * Only provided when [backendUrl] is non-blank — i.e. when
-     * BuildConfig.TOKEN_BACKEND_URL is set in app-phone/build.gradle.kts.
-     * Otherwise [TokenProxyService] is unavailable in the Hilt graph and
-     * the onboarding flow hides the Trakt sign-in option.
+     * Returns a real Retrofit-backed implementation when [backendUrl] is non-blank
+     * (i.e. TOKEN_BACKEND_URL is set in app-phone/build.gradle.kts). Returns a
+     * [NoOpTokenProxyService] when the URL is blank — callers must check the
+     * `@Named("managedBackendAvailable")` flag before invoking proxy methods.
      *
      * Note: The OkHttpClient is intentionally used without Trakt-specific
      * headers — the proxy does not require a 'trakt-api-version' header.
      */
     @Provides
     @Singleton
-    @Named("tokenProxy")
-    fun provideTokenProxyRetrofit(
+    fun provideTokenProxyService(
         backendUrl: @JvmSuppressWildcards String,
         client: OkHttpClient
-    ): Retrofit? {
-        if (backendUrl.isBlank()) return null
+    ): TokenProxyService {
+        if (backendUrl.isBlank()) return NoOpTokenProxyService()
         val url = if (backendUrl.endsWith("/")) backendUrl else "$backendUrl/"
         return Retrofit.Builder()
             .baseUrl(url)
             .client(client)
             .addConverterFactory(WatchBuddyJson.asConverterFactory("application/json".toMediaType()))
             .build()
+            .create(TokenProxyService::class.java)
     }
-
-    @Provides
-    @Singleton
-    fun provideTokenProxyService(
-        @Named("tokenProxy") retrofit: Retrofit?
-    ): TokenProxyService? = retrofit?.create(TokenProxyService::class.java)
 }

--- a/core/src/main/java/com/justb81/watchbuddy/core/trakt/NoOpTokenProxyService.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/trakt/NoOpTokenProxyService.kt
@@ -1,0 +1,10 @@
+package com.justb81.watchbuddy.core.trakt
+
+class NoOpTokenProxyService : TokenProxyService {
+
+    override suspend fun exchangeDeviceCode(body: ProxyTokenRequest): ProxyTokenResponse =
+        throw UnsupportedOperationException("managed backend disabled")
+
+    override suspend fun refreshToken(body: ProxyRefreshRequest): ProxyTokenResponse =
+        throw UnsupportedOperationException("managed backend disabled")
+}

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
@@ -1,5 +1,9 @@
 package com.justb81.watchbuddy.core.network
 
+import com.justb81.watchbuddy.core.trakt.NoOpTokenProxyService
+import com.justb81.watchbuddy.core.trakt.ProxyRefreshRequest
+import com.justb81.watchbuddy.core.trakt.ProxyTokenRequest
+import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.logging.HttpLoggingInterceptor
@@ -90,46 +94,42 @@ class NetworkModuleTest {
     }
 
     @Nested
-    @DisplayName("provideTokenProxyRetrofit")
-    inner class TokenProxyRetrofitTest {
-        @Test
-        fun `returns null for blank URL`() {
-            val result = NetworkModule.provideTokenProxyRetrofit("", OkHttpClient())
-            assertNull(result)
-        }
-
-        @Test
-        fun `returns null for whitespace-only URL`() {
-            val result = NetworkModule.provideTokenProxyRetrofit("   ", OkHttpClient())
-            assertNull(result)
-        }
-
-        @Test
-        fun `returns non-null for valid URL`() {
-            val result = NetworkModule.provideTokenProxyRetrofit("https://example.com", OkHttpClient())
-            assertNotNull(result)
-        }
-
-        @Test
-        fun `appends trailing slash if missing`() {
-            val result = NetworkModule.provideTokenProxyRetrofit("https://example.com", OkHttpClient())
-            assertEquals("https://example.com/", result!!.baseUrl().toString())
-        }
-
-        @Test
-        fun `preserves existing trailing slash`() {
-            val result = NetworkModule.provideTokenProxyRetrofit("https://example.com/", OkHttpClient())
-            assertEquals("https://example.com/", result!!.baseUrl().toString())
-        }
-    }
-
-    @Nested
     @DisplayName("provideTokenProxyService")
     inner class TokenProxyServiceTest {
+
         @Test
-        fun `returns null when retrofit is null`() {
-            val result = NetworkModule.provideTokenProxyService(null)
-            assertNull(result)
+        fun `returns NoOpTokenProxyService for blank URL`() {
+            val result = NetworkModule.provideTokenProxyService("", OkHttpClient())
+            assertInstanceOf(NoOpTokenProxyService::class.java, result)
+        }
+
+        @Test
+        fun `returns NoOpTokenProxyService for whitespace-only URL`() {
+            val result = NetworkModule.provideTokenProxyService("   ", OkHttpClient())
+            assertInstanceOf(NoOpTokenProxyService::class.java, result)
+        }
+
+        @Test
+        fun `returns non-null real service for valid URL`() {
+            val result = NetworkModule.provideTokenProxyService("https://example.com", OkHttpClient())
+            assertNotNull(result)
+            assertFalse(result is NoOpTokenProxyService)
+        }
+
+        @Test
+        fun `NoOpTokenProxyService throws UnsupportedOperationException on exchangeDeviceCode`() {
+            val noop = NoOpTokenProxyService()
+            assertThrows(UnsupportedOperationException::class.java) {
+                runBlocking { noop.exchangeDeviceCode(ProxyTokenRequest("code")) }
+            }
+        }
+
+        @Test
+        fun `NoOpTokenProxyService throws UnsupportedOperationException on refreshToken`() {
+            val noop = NoOpTokenProxyService()
+            assertThrows(UnsupportedOperationException::class.java) {
+                runBlocking { noop.refreshToken(ProxyRefreshRequest("token")) }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Introduces `NoOpTokenProxyService` that throws `UnsupportedOperationException` when the managed backend is disabled, replacing the Hilt anti-pattern of injecting `TokenProxyService?` (nullable)
- `NetworkModule.provideTokenProxyService` now returns a non-null `TokenProxyService` — either a real Retrofit-backed instance (when `TOKEN_BACKEND_URL` is set) or the `NoOpTokenProxyService` sentinel; the intermediate nullable `@Named("tokenProxy") Retrofit?` provider is removed
- `TokenRefreshManager` and `OnboardingViewModel` inject non-null `TokenProxyService` + `@Named("managedBackendAvailable") Boolean`, checking the flag before calling proxy methods instead of null-checking the service

## Test plan

- [ ] `./gradlew :core:test` — `NetworkModuleTest` covers `NoOpTokenProxyService` behaviour and the new non-null provider
- [ ] `./gradlew :app-phone:testDebugUnitTest` — `TokenRefreshManagerTest` and `OnboardingViewModelTest`/`OnboardingViewModelRetryTest` updated for the new constructor signatures
- [ ] CI `build-android.yml` green on this PR

Closes #294

https://claude.ai/code/session_015wy6sVTH5YUAYT4eBF8Yka