### PR TITLE
ci: make failing PR build logs agent-accessible

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write
   security-events: write
   actions: read
@@ -216,3 +216,133 @@ jobs:
         with:
           name: watchbuddy-tv-debug
           path: app-tv/build/outputs/apk/debug/*.apk
+
+      # Surface the failing job's raw log to PR reviewers (humans) and to
+      # automated agents (MCP). Posts a filtered failure excerpt as a PR
+      # comment keyed by the `<!-- watchbuddy-build-log -->` marker, and
+      # commits the full unfiltered log to the dedicated `ci-logs` branch
+      # where agents can fetch it via `get_file_contents`.
+      # See CLAUDE.md § "Monitoring PR checks & accessing build logs".
+      - name: Post failing build log
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        env:
+          MARKER: '<!-- watchbuddy-build-log -->'
+          CURRENT_JOB: ${{ github.job }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const run_id = context.runId;
+            const pr = context.issue.number;
+
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              { owner, repo, run_id, per_page: 100 },
+            );
+            const job =
+              jobs.find((j) => j.name.startsWith(process.env.CURRENT_JOB)) ||
+              jobs.find((j) => j.conclusion === 'failure');
+            if (!job) {
+              core.warning('No failing job found in this run');
+              return;
+            }
+
+            const resp = await github.request(
+              'GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs',
+              { owner, repo, job_id: job.id },
+            );
+            const raw =
+              typeof resp.data === 'string'
+                ? resp.data
+                : Buffer.from(resp.data).toString('utf8');
+
+            const patterns = [
+              /^FAILURE:/i,
+              /^BUILD FAILED/i,
+              /> Task .* FAILED/,
+              /\.kt:\d+:\d+:/,
+              /^\s*Error: /i,
+              /<failure[\s>]/,
+              / error /,
+              /^Exception |Caused by: /,
+              /AssertionError|AssertionFailedError/,
+              /Prettier.*would reformat/i,
+            ];
+            const lines = raw.split('\n');
+            const keep = new Set();
+            lines.forEach((ln, i) => {
+              if (patterns.some((p) => p.test(ln))) {
+                const start = Math.max(0, i - 5);
+                const end = Math.min(lines.length - 1, i + 20);
+                for (let k = start; k <= end; k++) keep.add(k);
+              }
+            });
+            const excerpt = [...keep]
+              .sort((a, b) => a - b)
+              .map((i) => lines[i])
+              .join('\n');
+            const clipped =
+              excerpt.length > 55000
+                ? excerpt.slice(-55000) + '\n… (truncated — see full log link)'
+                : excerpt;
+
+            const safeJobName = job.name.replace(/[^\w.-]/g, '_');
+            const logPath = `pr-${pr}/run-${run_id}-${safeJobName}.log`;
+            let sha;
+            try {
+              const existing = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path: logPath,
+                ref: 'ci-logs',
+              });
+              sha = existing.data.sha;
+            } catch (e) {
+              // new file — no existing sha
+            }
+            await github.rest.repos.createOrUpdateFileContents({
+              owner,
+              repo,
+              path: logPath,
+              branch: 'ci-logs',
+              message: `ci-logs: ${job.name} (PR #${pr}, run ${run_id})`,
+              content: Buffer.from(raw).toString('base64'),
+              sha,
+            });
+            const fullLogUrl =
+              `https://github.com/${owner}/${repo}/blob/ci-logs/${logPath}`;
+
+            const body = [
+              process.env.MARKER,
+              `### Build failure — \`${job.name}\` (run ${run_id})`,
+              `Full log: ${fullLogUrl}`,
+              `Agent access: \`pull_request_read\` with \`method: "get_comments"\` for this excerpt;`,
+              `\`get_file_contents\` with \`ref: "ci-logs"\`, \`path: "${logPath}"\` for the full log.`,
+              '',
+              '```text',
+              clipped || '(no filter matches — see full log link above)',
+              '```',
+            ].join('\n');
+
+            const existingComments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: pr, per_page: 100 },
+            );
+            const found = existingComments.find(
+              (c) => c.body && c.body.includes(process.env.MARKER),
+            );
+            if (found) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: found.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr,
+                body,
+              });
+            }

--- a/.github/workflows/ci-logs-prune.yml
+++ b/.github/workflows/ci-logs-prune.yml
@@ -1,0 +1,83 @@
+name: Prune ci-logs branch
+
+# Keeps the `ci-logs` side branch bounded by removing log files for PRs that
+# are already closed or merged. See CLAUDE.md § "Monitoring PR checks &
+# accessing build logs" for the log-posting flow this cleans up after.
+
+on:
+  schedule:
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  prune:
+    name: Prune closed-PR log directories
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+
+            let tree;
+            try {
+              const root = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path: '',
+                ref: 'ci-logs',
+              });
+              tree = Array.isArray(root.data) ? root.data : [];
+            } catch (e) {
+              core.info('ci-logs branch does not exist yet — nothing to prune');
+              return;
+            }
+
+            const prDirs = tree.filter(
+              (e) => e.type === 'dir' && /^pr-\d+$/.test(e.name),
+            );
+            core.info(`Found ${prDirs.length} pr-* directories on ci-logs`);
+
+            for (const dir of prDirs) {
+              const prNumber = Number(dir.name.replace(/^pr-/, ''));
+              let pr;
+              try {
+                pr = await github.rest.pulls.get({
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                });
+              } catch (e) {
+                core.warning(
+                  `Could not fetch PR #${prNumber}: ${e.message} — skipping`,
+                );
+                continue;
+              }
+              if (pr.data.state !== 'closed') {
+                core.info(`PR #${prNumber} is still open — keeping logs`);
+                continue;
+              }
+
+              const files = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path: dir.path,
+                ref: 'ci-logs',
+              });
+              const entries = Array.isArray(files.data) ? files.data : [];
+              for (const file of entries) {
+                if (file.type !== 'file') continue;
+                core.info(`Deleting ${file.path} (PR #${prNumber} closed)`);
+                await github.rest.repos.deleteFile({
+                  owner,
+                  repo,
+                  path: file.path,
+                  branch: 'ci-logs',
+                  message: `ci-logs: prune PR #${prNumber} (${pr.data.state})`,
+                  sha: file.sha,
+                });
+              }
+            }

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -7,6 +7,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
 jobs:
   changes:
     name: Detect Changes
@@ -54,3 +59,130 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      # Surface the failing job's raw log to PR reviewers (humans) and to
+      # automated agents (MCP). Posts a filtered failure excerpt as a PR
+      # comment keyed by the `<!-- watchbuddy-backend-log -->` marker, and
+      # commits the full unfiltered log to the dedicated `ci-logs` branch
+      # where agents can fetch it via `get_file_contents`.
+      # See CLAUDE.md § "Monitoring PR checks & accessing build logs".
+      - name: Post failing backend log
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        env:
+          MARKER: '<!-- watchbuddy-backend-log -->'
+          CURRENT_JOB: ${{ github.job }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const run_id = context.runId;
+            const pr = context.issue.number;
+
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              { owner, repo, run_id, per_page: 100 },
+            );
+            const job =
+              jobs.find((j) => j.name.startsWith(process.env.CURRENT_JOB)) ||
+              jobs.find((j) => j.conclusion === 'failure');
+            if (!job) {
+              core.warning('No failing job found in this run');
+              return;
+            }
+
+            const resp = await github.request(
+              'GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs',
+              { owner, repo, job_id: job.id },
+            );
+            const raw =
+              typeof resp.data === 'string'
+                ? resp.data
+                : Buffer.from(resp.data).toString('utf8');
+
+            const patterns = [
+              / error /,
+              /^\s*Error: /i,
+              /Prettier.*would reformat/i,
+              /AssertionError|expect\(.*\)\.to/,
+              /^\s*at .+ \(.+:\d+:\d+\)/,
+              /FAIL /,
+              /Tests:.*failed/i,
+            ];
+            const lines = raw.split('\n');
+            const keep = new Set();
+            lines.forEach((ln, i) => {
+              if (patterns.some((p) => p.test(ln))) {
+                const start = Math.max(0, i - 5);
+                const end = Math.min(lines.length - 1, i + 20);
+                for (let k = start; k <= end; k++) keep.add(k);
+              }
+            });
+            const excerpt = [...keep]
+              .sort((a, b) => a - b)
+              .map((i) => lines[i])
+              .join('\n');
+            const clipped =
+              excerpt.length > 55000
+                ? excerpt.slice(-55000) + '\n… (truncated — see full log link)'
+                : excerpt;
+
+            const safeJobName = job.name.replace(/[^\w.-]/g, '_');
+            const logPath = `pr-${pr}/run-${run_id}-${safeJobName}.log`;
+            let sha;
+            try {
+              const existing = await github.rest.repos.getContent({
+                owner,
+                repo,
+                path: logPath,
+                ref: 'ci-logs',
+              });
+              sha = existing.data.sha;
+            } catch (e) {
+              // new file — no existing sha
+            }
+            await github.rest.repos.createOrUpdateFileContents({
+              owner,
+              repo,
+              path: logPath,
+              branch: 'ci-logs',
+              message: `ci-logs: ${job.name} (PR #${pr}, run ${run_id})`,
+              content: Buffer.from(raw).toString('base64'),
+              sha,
+            });
+            const fullLogUrl =
+              `https://github.com/${owner}/${repo}/blob/ci-logs/${logPath}`;
+
+            const body = [
+              process.env.MARKER,
+              `### Backend failure — \`${job.name}\` (run ${run_id})`,
+              `Full log: ${fullLogUrl}`,
+              `Agent access: \`pull_request_read\` with \`method: "get_comments"\` for this excerpt;`,
+              `\`get_file_contents\` with \`ref: "ci-logs"\`, \`path: "${logPath}"\` for the full log.`,
+              '',
+              '```text',
+              clipped || '(no filter matches — see full log link above)',
+              '```',
+            ].join('\n');
+
+            const existingComments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: pr, per_page: 100 },
+            );
+            const found = existingComments.find(
+              (c) => c.body && c.body.includes(process.env.MARKER),
+            );
+            if (found) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: found.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pr,
+                body,
+              });
+            }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ The only exceptions are **localization string resources** (`values-de/`, `values
 2. Create a feature branch from `main`
 3. Make changes and commit using Conventional Commits (see below)
 4. Push the branch and open a PR against `main`
-5. **Wait for a green CI build** (`build-android.yml`) — do not continue if the build is red; fix the issue first
+5. **Wait for a green CI build** (`build-android.yml`) — do not continue if the build is red; fix the issue first (see "Monitoring PR checks & accessing build logs" below)
 6. **Auto-merge when green.** Once every required build step on the PR has completed successfully, the agent may merge the PR into `main` automatically (e.g. via `enable_pr_auto_merge` or by merging directly after CI passes). Use a squash merge and delete the branch after merge.
 7. If CI fails or a required check is still pending, do NOT merge — fix the failure or wait.
 
@@ -167,6 +167,34 @@ The only exceptions are **localization string resources** (`values-de/`, `values
 | Release (automated) | `release-please--` | `release-please--branches--main` |
 
 The `release-please--` prefix is reserved for the automated release-please bot — never create branches with this prefix manually.
+
+### Monitoring PR checks & accessing build logs
+
+The MCP toolset has **no** `get_workflow_run_logs` / `list_workflow_runs` / `download_artifact` tool, and raw GitHub Actions log URLs require auth that agents do not have — the Actions UI is a dead end for automated agents. To close that gap, `build-android.yml` and `test-backend.yml` each have an `if: failure()` step that (a) posts a filtered failure excerpt as a PR comment and (b) commits the unfiltered full log to the dedicated `ci-logs` branch. Both channels are reachable through MCP.
+
+**1. Check overall CI status first:**
+
+- `mcp__github__pull_request_read` with `method: "get_check_runs"` → per-job `status` / `conclusion` / `details_url`. Expect `Test & Build` (from `build-android.yml`) and `Backend Tests` (from `test-backend.yml`); the `changes` path-filter jobs may legitimately be skipped.
+- `mcp__github__pull_request_read` with `method: "get_status"` → compact combined commit status.
+
+**2. Read the filtered failure excerpt via PR comments:**
+
+- `mcp__github__pull_request_read` with `method: "get_comments"`. Match by marker at the start of `body`:
+  - `<!-- watchbuddy-build-log -->` — Android build / detekt / Android Lint / unit-test failure from `build-android.yml`.
+  - `<!-- watchbuddy-backend-log -->` — ESLint / Prettier / Jest failure from `test-backend.yml`.
+  - `<!-- watchbuddy-lint-report -->` — per-module detekt + Android Lint finding counts (separate concern, see § Static analysis); useful when CI is green-but-noisy rather than red.
+- Excerpts are upserted per run — always read the latest comment with the marker.
+- The excerpt is a regex-filtered slice (gradle `FAILED` / detekt violations / Android Lint `Error:` / JUnit `<failure>` / ESLint error lines / Prettier mismatches / JVM stack traces) with ~20 lines of surrounding context per match, capped at ~55 000 chars.
+
+**3. Fetch the full unfiltered log:**
+
+- `mcp__github__get_file_contents` with `owner: "justb81"`, `repo: "watchbuddy"`, `ref: "ci-logs"`, `path: "pr-<PR_NUMBER>/run-<RUN_ID>-<JOB_NAME>.log"`. The exact path is printed at the top of the failure-excerpt comment.
+- Use this when the 20-line filter context misses the root cause (e.g. a warning emitted much earlier in the log).
+- The `ci-logs` branch is pruned weekly by `ci-logs-prune.yml`, which deletes log directories belonging to closed/merged PRs.
+
+**4. Wait for CI without polling:** subscribe with `mcp__github__subscribe_pr_activity` and react to the CI completion webhook event instead of polling `get_check_runs`.
+
+**5. Last-resort fallback:** if even the full log doesn't explain the failure, surface the failing check's `details_url` to the user and stop — do not attempt to scrape GitHub Actions HTML.
 
 ### Versioning
 - release-please with Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)


### PR DESCRIPTION
## Summary

MCP-only agents currently have no way to see *why* a PR build failed — there is no `get_workflow_run_logs` tool, no `gh` CLI, and Actions log URLs require auth we don't have. This PR closes that gap by capturing the failing job's real log inside CI and routing it to two MCP-reachable channels.

- **Filtered failure excerpt → PR comment.** A new `if: failure()` step in `build-android.yml` and `test-backend.yml` downloads its own job log via `GET /actions/jobs/{job_id}/logs` (using `GITHUB_TOKEN` with `actions: read`), greps for tool-specific failure patterns (gradle `FAILED`, detekt violations, Android Lint errors, JUnit failures, ESLint errors, Prettier mismatches, JVM stack traces) with 20 lines of context per match, and upserts a PR comment keyed by `<!-- watchbuddy-build-log -->` or `<!-- watchbuddy-backend-log -->`. Agents read via `pull_request_read` → `get_comments`.
- **Full unfiltered log → `ci-logs` branch.** The same step commits the raw log to a dedicated side branch at `pr-<N>/run-<RUN_ID>-<JOB_NAME>.log`. Agents read via `get_file_contents` with `ref: "ci-logs"`. GitHub REST doesn't support file attachments on PR comments — the drag-and-drop UI path is browser-only — so the side branch is the closest equivalent reachable from MCP.
- **Branch bounded by pruning.** New `ci-logs-prune.yml` runs weekly and deletes log directories for closed/merged PRs.
- **CLAUDE.md** gains a "Monitoring PR checks & accessing build logs" subsection documenting both markers, the `ci-logs` path convention, and the `subscribe_pr_activity` wait pattern as an alternative to polling.
- The `ci-logs` branch is seeded with a README-only orphan commit so the first `createOrUpdateFileContents` call has a parent to write against.

## Test plan

- [ ] Open a throwaway PR that deliberately breaks one Kotlin unit test and confirm: (a) `Test & Build` fails, (b) a PR comment appears with marker `<!-- watchbuddy-build-log -->`, a `Full log:` link to `ci-logs`, and a `text` code block containing gradle `FAILED` lines with surrounding context, (c) the linked file exists on the `ci-logs` branch and contains the raw log, (d) a second commit on the same PR updates the same comment (no duplicates).
- [ ] Repeat for `test-backend.yml` by breaking one ESLint rule; expect marker `<!-- watchbuddy-backend-log -->`.
- [ ] End-to-end MCP verification on the broken PR: `pull_request_read` `method: "get_comments"` returns both markers; `get_file_contents` `ref: "ci-logs"` returns the log file.
- [ ] Manually run `ci-logs-prune.yml` via `workflow_dispatch` against a ci-logs branch containing a closed-PR directory and confirm the directory's files are deleted while open-PR directories are untouched.
- [ ] Confirm this PR itself triggers the new step when it fails (or doesn't trigger when green).

🤖 Generated with [Claude Code](https://claude.ai/code)