### PR TITLE
chore: add scoped pre-commit script and shared git hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Shared pre-commit hook. Enable once per clone:
+#   git config core.hooksPath .githooks
+# Delegates to scripts/precommit.sh so the check logic stays invokable
+# outside the hook too.
+exec "$(git rev-parse --show-toplevel)/scripts/precommit.sh"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,26 @@ The only exceptions are **localization string resources** (`values-de/`, `values
 - Backend: `npm --prefix backend run lint && npm --prefix backend run format:check` (ESLint 9 flat config + Prettier 3).
 - CI gates every PR: any **new** finding beyond the baselines fails the `Build Android APKs` or `Backend Tests` workflow. SARIF reports are uploaded to GitHub code scanning and a summary comment with the per-module finding counts is posted on each PR (`<!-- watchbuddy-lint-report -->`).
 
+### Local pre-commit checks
+
+`scripts/precommit.sh` runs the same test / detekt / Android Lint / backend-lint / workflow-YAML checks CI runs, scoped to whatever is currently staged (mirrors the `paths-filter` in `build-android.yml` and `test-backend.yml`). Both human contributors and agents MUST run it before every commit — CI's path filter means a workflow-only or docs-only PR is never actually exercised, so bugs that don't touch Kotlin / Gradle / backend files land on main unchecked. The script is the only place that catches those.
+
+**Enable the shared git hook once per clone** (agents should do this at session start if it isn't already set):
+
+```sh
+git config core.hooksPath .githooks
+```
+
+Once enabled, `.githooks/pre-commit` delegates to `scripts/precommit.sh` on every `git commit`. Without the hook, run the script manually: `./scripts/precommit.sh`. Either path fails the commit if any check fails. Do **not** pass `--no-verify` to bypass — follow the guidance in "Executing actions with care" and fix the underlying failure.
+
+**Scoping rules** (must match the CI `paths-filter` sets exactly):
+
+- `app-phone/**`, `app-tv/**`, `core/**`, `*.gradle.kts`, `gradle/**`, `gradle.properties`, `config/detekt/**`, `.github/actions/**` → `./gradlew test detektAll :app-phone:lintDebug :app-tv:lintDebug`
+- `backend/**` → `npm --prefix backend run lint && npm --prefix backend run format:check && npm --prefix backend test`
+- `.github/workflows/*.y?ml` → `python3 yaml.safe_load` on each changed file + `actionlint` when installed
+
+If you change either workflow's `paths-filter`, update `scripts/precommit.sh` in the same commit.
+
 ### Git Workflow — IMPORTANT
 
 **Never push directly to `main`.** All changes must go through a Pull Request — no exceptions, including for agents.
@@ -149,7 +169,7 @@ The only exceptions are **localization string resources** (`values-de/`, `values
    - If any open PR matches, post a single comment on the issue via `mcp__github__add_issue_comment` — e.g. *"Another Claude Code session is already working on this issue — see #\<PR-number\>. Aborting this session to avoid parallel work."* — and stop immediately. Do not create a branch, do not edit files, do not commit.
    - Exception: skip this check when the session is explicitly invoked to continue work on a specific existing PR (e.g. responding to review comments on that PR).
 2. Create a feature branch from `main`
-3. Make changes and commit using Conventional Commits (see below)
+3. Make changes. Before **every** commit run `./scripts/precommit.sh` (or enable `git config core.hooksPath .githooks` once so the shared hook runs automatically) — see "Local pre-commit checks" above. Commit using Conventional Commits (see below)
 4. Push the branch and open a PR against `main`
 5. **Wait for a green CI build** (`build-android.yml`) — do not continue if the build is red; fix the issue first (see "Monitoring PR checks & accessing build logs" below)
 6. **Auto-merge when green.** Once every required build step on the PR has completed successfully, the agent may merge the PR into `main` automatically (e.g. via `enable_pr_auto_merge` or by merging directly after CI passes). Use a squash merge and delete the branch after merge.

--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# scripts/precommit.sh — run CI-equivalent checks locally on what's staged.
+#
+# Invoke directly before `git commit`, or enable the shared hook:
+#   git config core.hooksPath .githooks
+#
+# Scoping mirrors the path filters in .github/workflows/build-android.yml
+# and .github/workflows/test-backend.yml: we only run what the staged
+# diff would trigger on CI. This keeps the common edit loop fast while
+# still catching the failure modes that land on main.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+STAGED="$(git diff --cached --name-only --diff-filter=ACMR || true)"
+
+if [ -z "$STAGED" ]; then
+  echo "precommit: nothing staged — skipping checks"
+  exit 0
+fi
+
+section() { printf "\n\033[1;34m==> %s\033[0m\n" "$*"; }
+
+match() {
+  printf '%s\n' "$STAGED" | grep -Eq "$1"
+}
+
+ran_any=0
+
+# --- Android / Kotlin scope (mirrors build-android.yml `android:` filter) ---
+if match '^(app-phone|app-tv|core)/' \
+   || match '\.gradle\.kts$' \
+   || match '^gradle/' \
+   || match '^gradle\.properties$' \
+   || match '^config/detekt/' \
+   || match '^\.github/actions/' ; then
+  ran_any=1
+  section "Gradle unit tests"
+  ./gradlew test
+  section "detekt (all modules)"
+  ./gradlew detektAll
+  section "Android Lint (phone + TV debug)"
+  ./gradlew :app-phone:lintDebug :app-tv:lintDebug
+fi
+
+# --- Backend scope (mirrors test-backend.yml `backend:` filter) ---
+if match '^backend/'; then
+  ran_any=1
+  section "Backend ESLint"
+  npm --prefix backend run lint
+  section "Backend Prettier check"
+  npm --prefix backend run format:check
+  section "Backend tests"
+  npm --prefix backend test
+fi
+
+# --- Workflow YAML — syntax + actionlint when available ---
+if match '^\.github/workflows/.*\.ya?ml$'; then
+  ran_any=1
+  section "Workflow YAML syntax"
+  while IFS= read -r f; do
+    python3 -c "import sys, yaml; yaml.safe_load(open('$f'))"
+    echo "  OK: $f"
+  done < <(printf '%s\n' "$STAGED" | grep -E '^\.github/workflows/.*\.ya?ml$')
+
+  if command -v actionlint >/dev/null 2>&1; then
+    section "actionlint"
+    actionlint
+  else
+    echo "precommit: actionlint not installed — skipping (install via 'go install github.com/rhysd/actionlint/cmd/actionlint@latest' or 'brew install actionlint')"
+  fi
+fi
+
+if [ "$ran_any" = "0" ]; then
+  echo "precommit: no staged files require checks — skipping"
+else
+  section "All relevant checks passed"
+fi


### PR DESCRIPTION
## Summary

Run the same checks CI runs locally **before** committing, scoped to what's staged so the common loop stays fast. This closes the gap exposed by the recent log-capture work: because `build-android.yml` and `test-backend.yml` both have a `paths-filter` that excludes `.github/workflows/**` and `CLAUDE.md`, workflow-only or docs-only PRs land green on main without ever running any real job — including the log-capture step itself. Local checks catch those.

- **`scripts/precommit.sh`** — scopes by staged diff (same regex set as the CI path filters):
  - `app-phone/**`, `app-tv/**`, `core/**`, `*.gradle.kts`, `gradle/**`, `gradle.properties`, `config/detekt/**`, `.github/actions/**` → `./gradlew test detektAll :app-phone:lintDebug :app-tv:lintDebug`
  - `backend/**` → `npm --prefix backend run lint && format:check && test`
  - `.github/workflows/*.y?ml` → `python3 yaml.safe_load` per file + `actionlint` when installed
  - Exits 0 with a "nothing relevant staged" message when the staged set doesn't touch any scope (so docs-only commits still pass instantly).
- **`.githooks/pre-commit`** — one-line shim that delegates to the script. Enable once per clone: `git config core.hooksPath .githooks`.
- **CLAUDE.md** — new "Local pre-commit checks" subsection documenting the script, hook-enable command, and scoping rules; step 3 of the agent workflow now calls it out explicitly.

Dogfooded: this PR's own commit was created with `core.hooksPath=.githooks` set. The hook ran and correctly reported "no staged files require checks — skipping" because this PR only touches `CLAUDE.md`, `scripts/`, and `.githooks/` — none of which are in any CI scope.

## Test plan

- [x] `./scripts/precommit.sh` with nothing staged → "nothing staged — skipping checks" + exit 0.
- [x] Scope-regex matrix against representative paths: `app-phone/...kt`, `app-tv/build.gradle.kts`, `core/...kt`, `gradle.properties`, `gradle/libs.versions.toml`, `config/detekt/detekt.yml`, `.github/actions/...yml`, `backend/src/app.js`, `.github/workflows/build-android.yml`, `README.md`, `docs/architecture.md` — all land in the expected bucket or `(none)`.
- [ ] Stage a Kotlin edit and run `./scripts/precommit.sh` → confirm gradle `test`, `detektAll`, and `:app-phone:lintDebug :app-tv:lintDebug` all run and the commit is blocked on any failure.
- [ ] Stage a `backend/**` edit → confirm ESLint + Prettier + Jest run.
- [ ] Stage a workflow YAML edit → confirm YAML parses and (if installed) actionlint runs.
- [ ] Verify the hook path by running `git commit` directly (no `--no-verify`) and seeing the section headers from the script appear.

🤖 Generated with [Claude Code](https://claude.ai/code)