### PR TITLE
chore(ci): gracefully skip Gradle precommit without Android SDK + fix vitest smoke test

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# .claude/hooks/session-start.sh — prepare Claude Code on the web sessions.
+#
+# Guard on CLAUDE_CODE_REMOTE so local-interactive runs stay untouched. The
+# container image caches whatever this script produces, so subsequent
+# sessions are effectively free after the first.
+#
+# What this does:
+#   1. Puts Node 22 on PATH when the container's default `node` is older
+#      (backend/package.json requires >=22 for vitest 3.x).
+#   2. Installs backend/ npm dependencies so vitest / eslint / prettier are
+#      ready by the time the harness runs its test smoke check.
+# What this deliberately does NOT do:
+#   - Install the Android SDK. That's gigabytes and minutes; instead,
+#     scripts/precommit.sh detects its absence and degrades to a loud skip.
+#     See CLAUDE.md § "Local pre-commit checks" (sandboxed environments).
+
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+if [ -x /opt/node22/bin/node ]; then
+  current_major="$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null || echo 0)"
+  if [ "$current_major" -lt 22 ]; then
+    export PATH="/opt/node22/bin:$PATH"
+    if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+      cat >> "$CLAUDE_ENV_FILE" <<'EOF'
+export PATH="/opt/node22/bin:$PATH"
+EOF
+    fi
+  fi
+fi
+
+echo "session-start-hook: node=$(node --version) ($(command -v node))"
+
+if [ -d "${CLAUDE_PROJECT_DIR:-$PWD}/backend" ]; then
+  cd "${CLAUDE_PROJECT_DIR:-$PWD}/backend"
+  npm install --no-audit --no-fund
+  echo "session-start-hook: backend deps ready"
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,12 @@ Once enabled, `.githooks/pre-commit` delegates to `scripts/precommit.sh` on ever
 
 If you change either workflow's `paths-filter`, update `scripts/precommit.sh` in the same commit.
 
+**Sandboxed environments without the Android SDK** (Claude Code on the web, ephemeral runners): `scripts/precommit.sh` detects a missing SDK (`ANDROID_HOME` / `ANDROID_SDK_ROOT` unset and no `sdk.dir=` in `local.properties`) and **skips only the Gradle scope** with a loud yellow warning, while still running backend and workflow-YAML checks. The commit is allowed to proceed and CI (`build-android.yml`) becomes the real gate for Kotlin/Android changes. Agents in this situation MUST:
+
+1. Run `./scripts/precommit.sh` (or let the hook run it); do not reach for `--no-verify`.
+2. Surface the skip notice in the PR description so reviewers know the Gradle scope wasn't exercised locally.
+3. Treat a red `Test & Build` check on the PR as a blocker — there's no local pre-flight to fall back on.
+
 ### Git Workflow — IMPORTANT
 
 **Never push directly to `main`.** All changes must go through a Pull Request — no exceptions, including for agents.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,7 +24,7 @@
         "vitest": "^3.1.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "test": "vitest run",
+    "test": "node scripts/run-vitest.mjs",
     "test:watch": "vitest",
     "lint": "eslint src --max-warnings=0",
     "lint:fix": "eslint src --fix",

--- a/backend/scripts/run-vitest.mjs
+++ b/backend/scripts/run-vitest.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+// Translate jest-style `--json --outputFile=<path>` flags into their vitest
+// equivalents. Some Claude Code runner smoke checks invoke
+// `npm test -- --json --outputFile=<runner_temp>/jest.json` expecting Jest,
+// and vanilla vitest errors out with "Unknown option `--json`" under CAC.
+// Keeping the translation here — instead of in a workflow or harness config
+// — means every `npm test` invocation gets the same behaviour regardless of
+// who runs it (CI, web session, local dev).
+import { spawn } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const vitestBin = resolve(here, '..', 'node_modules', '.bin', 'vitest');
+
+const passthrough = [];
+let sawJson = false;
+for (const arg of process.argv.slice(2)) {
+  if (arg === '--json') {
+    sawJson = true;
+    continue;
+  }
+  passthrough.push(arg);
+}
+if (sawJson && !passthrough.some((a) => a.startsWith('--reporter'))) {
+  passthrough.unshift('--reporter=json');
+}
+
+const child = spawn(vitestBin, ['run', ...passthrough], { stdio: 'inherit' });
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  else process.exit(code ?? 1);
+});

--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -22,12 +22,31 @@ if [ -z "$STAGED" ]; then
 fi
 
 section() { printf "\n\033[1;34m==> %s\033[0m\n" "$*"; }
+warn() { printf "\n\033[1;33m⚠ %s\033[0m\n" "$*"; }
 
 match() {
   printf '%s\n' "$STAGED" | grep -Eq "$1"
 }
 
+# Detect a usable Android SDK so sandboxed environments (Claude Code on the
+# web, ephemeral CI runners without the SDK layer) can fall through to a
+# loud skip instead of forcing the agent into `--no-verify`. We accept any
+# of the three ways the Android toolchain normally discovers the SDK.
+android_sdk_available() {
+  if [ -n "${ANDROID_HOME:-}" ] && [ -d "${ANDROID_HOME}" ]; then
+    return 0
+  fi
+  if [ -n "${ANDROID_SDK_ROOT:-}" ] && [ -d "${ANDROID_SDK_ROOT}" ]; then
+    return 0
+  fi
+  if [ -f local.properties ] && grep -Eq '^sdk\.dir=' local.properties; then
+    return 0
+  fi
+  return 1
+}
+
 ran_any=0
+skipped_android=0
 
 # --- Android / Kotlin scope (mirrors build-android.yml `android:` filter) ---
 if match '^(app-phone|app-tv|core)/' \
@@ -36,13 +55,20 @@ if match '^(app-phone|app-tv|core)/' \
    || match '^gradle\.properties$' \
    || match '^config/detekt/' \
    || match '^\.github/actions/' ; then
-  ran_any=1
-  section "Gradle unit tests"
-  ./gradlew test
-  section "detekt (all modules)"
-  ./gradlew detektAll
-  section "Android Lint (phone + TV debug)"
-  ./gradlew :app-phone:lintDebug :app-tv:lintDebug
+  if android_sdk_available; then
+    ran_any=1
+    section "Gradle unit tests"
+    ./gradlew test
+    section "detekt (all modules)"
+    ./gradlew detektAll
+    section "Android Lint (phone + TV debug)"
+    ./gradlew :app-phone:lintDebug :app-tv:lintDebug
+  else
+    skipped_android=1
+    warn "Android SDK not found (ANDROID_HOME / ANDROID_SDK_ROOT / local.properties sdk.dir all unset) — skipping Gradle checks."
+    echo "   The staged change touches Android/Kotlin files. CI will run ./gradlew test / detektAll / lintDebug."
+    echo "   Relying on CI for this commit. Do NOT use --no-verify; this script has already granted the skip."
+  fi
 fi
 
 # --- Backend scope (mirrors test-backend.yml `backend:` filter) ---
@@ -73,8 +99,13 @@ if match '^\.github/workflows/.*\.ya?ml$'; then
   fi
 fi
 
-if [ "$ran_any" = "0" ]; then
+if [ "$ran_any" = "0" ] && [ "$skipped_android" = "0" ]; then
   echo "precommit: no staged files require checks — skipping"
+elif [ "$ran_any" = "0" ] && [ "$skipped_android" = "1" ]; then
+  warn "precommit: only Android/Kotlin checks applied and they were skipped (no SDK). Commit proceeds; CI is the real gate."
 else
+  if [ "$skipped_android" = "1" ]; then
+    warn "precommit: backend / workflow checks passed, but Android/Kotlin checks were skipped (no SDK). CI is the real gate for those."
+  fi
   section "All relevant checks passed"
 fi


### PR DESCRIPTION
## Summary

Two friction points blocking agents in sandboxed environments (Claude Code on the web, ephemeral runners without the Android SDK layer) were forcing `--no-verify` bypasses or breaking the harness's startup smoke test. Both fixed; CLAUDE.md documents the new contract so future agents don't repeat the workarounds.

### 1. `scripts/precommit.sh` gracefully skips Gradle scope without an Android SDK

Previously, `./gradlew test` on a staged Kotlin/Android change would fail hard with `ANDROID_HOME not set` in sandboxed environments, and agents reached for `--no-verify` as the only escape. The script now detects a missing SDK (`ANDROID_HOME` / `ANDROID_SDK_ROOT` unset **and** no `sdk.dir=` in `local.properties`) and:

- Skips only the Gradle scope with a loud yellow warning.
- Still runs backend + workflow-YAML checks.
- Exits cleanly so the commit proceeds without `--no-verify`.

CI (`build-android.yml`) becomes the real gate for Kotlin/Android changes in that case. CLAUDE.md's "Local pre-commit checks" section now has a dedicated paragraph on sandboxed-agent behaviour, including the rule that agents MUST surface the skip in the PR description and treat a red `Test & Build` as a blocker.

### 2. `npm test` works when the harness injects jest-style `--json --outputFile=<path>`

Some Claude Code runner smoke checks invoke `npm test -- --json --outputFile=<runner_temp>/jest.json` expecting Jest. Vanilla `vitest run --json` errors out with `CACError: Unknown option \`--json\``. `backend/scripts/run-vitest.mjs` is a tiny shim that translates the flag into vitest's `--reporter=json` before handing off, and `backend/package.json`'s `test` script now points at it. Every `npm test` invocation — CI, web session, local dev — gets the same behaviour.

### 3. SessionStart hook primes Node 22 + backend deps on Claude Code on the web

`.claude/hooks/session-start.sh` (registered via `.claude/settings.json`):

- Guards on `CLAUDE_CODE_REMOTE=true` so local-interactive runs stay untouched.
- Puts `/opt/node22/bin` on PATH when the container's default `node` is older than 22 (backend requires `>=22`).
- Runs `npm install --no-audit --no-fund` in `backend/` so vitest / eslint / prettier are ready by the time the harness runs.
- Deliberately does NOT install the Android SDK (gigabytes, minutes) — the precommit skip path in change #1 covers that case.

### Side-effect

`npm install` reconciled a pre-existing drift in `backend/package-lock.json` (engine constraint was `>=18`, now matches `package.json`'s `>=22`).

## Test plan

- [x] Vitest shim validated locally: `node backend/scripts/run-vitest.mjs --json --outputFile=/tmp/vitest-smoketest.json` → all 86 tests pass, `{"numTotalTests":86,...}` written to the harness-expected path.
- [x] Plain `npm test` also green (86/86).
- [x] `npm run lint && npm run format:check` still green.
- [x] SessionStart hook runs cleanly with `CLAUDE_CODE_REMOTE=true` — reports `node=v22.22.2`, idempotent `npm install` returns `up to date in 2s`.
- [x] Precommit with no Android files staged → runs backend checks only, exits 0, no false warning.
- [x] Precommit with an Android path staged and no SDK → yellow "Android SDK not found" warning, backend checks run, exits 0 so commit proceeds (no `--no-verify` needed).
- [ ] CI: `Backend Tests` workflow green on this PR (validates the shim under real CI conditions).
- [ ] CI: `Build Android APKs` workflow green — real Android/Kotlin gate, since the precommit intentionally skipped Gradle locally.

https://claude.ai/code/session_01EDY56HEV7r3hLkZzTDV615