### PR TITLE
fix(core): rescue silently-dropped scrobbles (#401, #402)

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/TvShowCache.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/TvShowCache.kt
@@ -1,5 +1,8 @@
 package com.justb81.watchbuddy.tv.data
 
+import com.justb81.watchbuddy.core.model.EnrichedShowEntry
+import com.justb81.watchbuddy.core.model.TmdbProgressHint
+import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -7,7 +10,9 @@ import javax.inject.Singleton
 /**
  * In-memory cache of the user's Trakt watched shows.
  * Populated by [TvHomeViewModel] when shows are loaded from a phone.
- * Used by [MediaSessionScrobbler] for local fuzzy-matching before hitting the Trakt API.
+ * Used by [MediaSessionScrobbler] for local fuzzy-matching before hitting the Trakt API,
+ * and for the progress-hint fallback that guesses the next unwatched episode when the
+ * streaming app's MediaMetadata title lacks an explicit `S##E##` marker (issue #401).
  */
 @Singleton
 class TvShowCache @Inject constructor() {
@@ -15,9 +20,26 @@ class TvShowCache @Inject constructor() {
     @Volatile
     private var cachedShows: List<TraktWatchedEntry> = emptyList()
 
+    @Volatile
+    private var hintsByTraktId: Map<Int, TmdbProgressHint> = emptyMap()
+
     fun updateShows(shows: List<TraktWatchedEntry>) {
         cachedShows = shows
+        hintsByTraktId = emptyMap()
+    }
+
+    fun updateEnrichedShows(shows: List<EnrichedShowEntry>) {
+        cachedShows = shows.map { it.entry }
+        hintsByTraktId = shows
+            .mapNotNull { enriched ->
+                val traktId = enriched.entry.show.ids.trakt ?: return@mapNotNull null
+                val hint = enriched.tmdb ?: return@mapNotNull null
+                traktId to hint
+            }
+            .toMap()
     }
 
     fun getCachedShows(): List<TraktWatchedEntry> = cachedShows
+
+    fun getHint(ids: TraktIds): TmdbProgressHint? = ids.trakt?.let { hintsByTraktId[it] }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvWatchedShowSource.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvWatchedShowSource.kt
@@ -1,5 +1,7 @@
 package com.justb81.watchbuddy.tv.scrobbler
 
+import com.justb81.watchbuddy.core.model.TmdbProgressHint
+import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.scrobbler.WatchedShowSource
 import com.justb81.watchbuddy.tv.data.TvShowCache
@@ -17,4 +19,6 @@ class TvWatchedShowSource @Inject constructor(
 
     override suspend fun getTmdbApiKey(): String? =
         phoneDiscovery.getBestPhone()?.capability?.tmdbApiKey
+
+    override suspend fun getShowHint(ids: TraktIds): TmdbProgressHint? = tvShowCache.getHint(ids)
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -176,7 +176,7 @@ class TvHomeViewModel @Inject constructor(
 
                 fallbackCache = allShows
                 fallbackCacheTimestamp = System.currentTimeMillis()
-                tvShowCache.updateShows(allShows.map { it.entry })
+                tvShowCache.updateEnrichedShows(allShows)
 
                 val (continueWatching, otherShows) = partitionShows(allShows)
                 _uiState.update {

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/TvShowCacheTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/TvShowCacheTest.kt
@@ -1,5 +1,8 @@
 package com.justb81.watchbuddy.tv.data
 
+import com.justb81.watchbuddy.core.model.EnrichedShowEntry
+import com.justb81.watchbuddy.core.model.TmdbEpisodeSummary
+import com.justb81.watchbuddy.core.model.TmdbProgressHint
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
@@ -56,5 +59,50 @@ class TvShowCacheTest {
         cache.updateShows(shows)
         cache.updateShows(emptyList())
         assertTrue(cache.getCachedShows().isEmpty())
+    }
+
+    @Test
+    fun `updateEnrichedShows stores shows and hints keyed by trakt id`() {
+        val ids = TraktIds(trakt = 42)
+        val hint = TmdbProgressHint(
+            nextAired = TmdbEpisodeSummary(season_number = 4, episode_number = 7, air_date = "2024-01-01")
+        )
+        val enriched = EnrichedShowEntry(
+            entry = TraktWatchedEntry(TraktShow("Breaking Bad", 2008, ids)),
+            tmdb = hint
+        )
+
+        cache.updateEnrichedShows(listOf(enriched))
+
+        assertEquals(1, cache.getCachedShows().size)
+        assertEquals("Breaking Bad", cache.getCachedShows()[0].show.title)
+        assertEquals(hint, cache.getHint(ids))
+    }
+
+    @Test
+    fun `getHint returns null when no trakt id on lookup`() {
+        val hint = TmdbProgressHint(status = "Returning Series")
+        val enriched = EnrichedShowEntry(
+            entry = TraktWatchedEntry(TraktShow("Anon", 2020, TraktIds(trakt = 1))),
+            tmdb = hint
+        )
+        cache.updateEnrichedShows(listOf(enriched))
+
+        assertNull(cache.getHint(TraktIds(tmdb = 999)))
+    }
+
+    @Test
+    fun `updateShows clears previously cached hints`() {
+        val ids = TraktIds(trakt = 42)
+        cache.updateEnrichedShows(listOf(
+            EnrichedShowEntry(
+                entry = TraktWatchedEntry(TraktShow("Show", 2020, ids)),
+                tmdb = TmdbProgressHint(status = "Ended")
+            )
+        ))
+
+        cache.updateShows(listOf(TraktWatchedEntry(TraktShow("Show", 2020, ids))))
+
+        assertNull(cache.getHint(ids))
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
@@ -157,7 +157,7 @@ class TvHomeViewModelTest {
         createViewModel()
         advanceUntilIdle()
 
-        verify { tvShowCache.updateShows(testTraktShows) }
+        verify { tvShowCache.updateEnrichedShows(testShows) }
     }
 
     @Test
@@ -381,7 +381,7 @@ class TvHomeViewModelTest {
             advanceUntilIdle()
 
             val allShows = (page1 + page2).sortedByLastWatched()
-            verify { tvShowCache.updateShows(allShows.map { it.entry }) }
+            verify { tvShowCache.updateEnrichedShows(allShows) }
         }
     }
 

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -266,8 +266,8 @@ class MediaSessionScrobbler @Inject constructor(
             )
             return null
         }
-        val guessed = ShowProgressCalculator.nextEpisodeNumbers(cacheEntry, hint) ?: return null
-        return TraktEpisode(season = guessed.first, number = guessed.second)
+        return ShowProgressCalculator.nextEpisodeNumbers(cacheEntry, hint)
+            ?.let { TraktEpisode(season = it.first, number = it.second) }
     }
 
     internal fun normalize(title: String): String {

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -5,10 +5,13 @@ import android.content.Context
 import android.media.session.MediaSessionManager
 import android.media.session.PlaybackState
 import android.util.Log
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.progress.ShowProgressCalculator
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.*
@@ -17,6 +20,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -72,6 +76,13 @@ class MediaSessionScrobbler @Inject constructor(
 
     private var currentlyScrobbling: String? = null
 
+    /**
+     * Last observed playback progress per media title, captured on every poll that yields
+     * a usable `position/duration`. Feeds the implicit-stop dispatched by [reconcileVanished]
+     * when a session disappears without ever emitting STATE_STOPPED (issue #402).
+     */
+    private val lastProgressByTitle = ConcurrentHashMap<String, Float>()
+
     fun startListening(notificationListenerComponent: ComponentName) {
         scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
         _isListening.value = true
@@ -82,6 +93,10 @@ class MediaSessionScrobbler @Inject constructor(
             while (isActive) {
                 try {
                     val sessions = sessionManager.getActiveSessions(notificationListenerComponent)
+                    val liveTitles = sessions
+                        .mapNotNull { it.metadata?.getString(android.media.MediaMetadata.METADATA_KEY_TITLE) }
+                        .toSet()
+                    reconcileVanished(liveTitles)
                     sessions.forEach { controller ->
                         val packageName = controller.packageName
                         val metadata = controller.metadata ?: return@forEach
@@ -89,6 +104,7 @@ class MediaSessionScrobbler @Inject constructor(
                         val title = metadata.getString(android.media.MediaMetadata.METADATA_KEY_TITLE)
                             ?: return@forEach
                         val progress = computeProgress(playbackState, metadata)
+                        if (progress != null) recordProgress(title, progress)
                         when (playbackState.state) {
                             PlaybackState.STATE_PLAYING -> processPlayingMedia(packageName, title, progress)
                             PlaybackState.STATE_PAUSED -> handleScrobblePause(title, progress)
@@ -105,10 +121,51 @@ class MediaSessionScrobbler @Inject constructor(
         }
     }
 
+    internal fun recordProgress(title: String, progress: Float) {
+        lastProgressByTitle[title] = progress
+    }
+
+    /**
+     * Detect the case where a streaming app destroys its MediaSession instead of
+     * transitioning through STATE_STOPPED (common on YouTube and some Fire TV skins —
+     * issue #402). Without this reconciliation `currentlyScrobbling` would stay pinned
+     * to the last episode forever, silently blocking every future scrobble of the same
+     * title inside [processPlayingMedia]'s dedup guard.
+     *
+     * When the previously-tracked title is no longer in the live session set, dispatch
+     * an implicit stop with the last observed progress (best-effort — we don't know the
+     * real endpoint) and clear local state so the next playback can scrobble again.
+     */
+    internal suspend fun reconcileVanished(liveTitles: Set<String>) {
+        val stale = currentlyScrobbling ?: return
+        if (stale in liveTitles) return
+        val lastProgress = lastProgressByTitle.remove(stale)
+        currentlyScrobbling = null
+        if (lastProgress == null) {
+            DiagnosticLog.warn(TAG, "Session vanished without captured progress — cleared '$stale'")
+            return
+        }
+        try {
+            val candidate = matchTitle("", stale)
+            val show = candidate?.matchedShow
+            val episode = candidate?.matchedEpisode
+            if (show != null && episode != null) {
+                scrobbleDispatcher.dispatchStop(show, episode, lastProgress)
+                Log.i(TAG, "Session vanished — implicit stop: ${show.title} S${episode.season}E${episode.number}")
+            } else {
+                DiagnosticLog.warn(TAG, "Session vanished — no match for '$stale', dispatch skipped")
+            }
+        } catch (e: Exception) {
+            DiagnosticLog.warn(TAG, "Session vanished — stop dispatch failed for '$stale'", e)
+        }
+    }
+
     fun stopListening() {
         pollingJob?.cancel()
         scope.cancel()
         _isListening.value = false
+        currentlyScrobbling = null
+        lastProgressByTitle.clear()
     }
 
     private suspend fun processPlayingMedia(packageName: String, rawTitle: String, progress: Float?) {
@@ -148,13 +205,13 @@ class MediaSessionScrobbler @Inject constructor(
             val bestCacheMatch = cachedShows.maxByOrNull { fuzzyScore(it.show.title, showTitle) }
             val cacheScore = bestCacheMatch?.let { fuzzyScore(it.show.title, showTitle) } ?: 0f
             if (cacheScore >= 0.70f && bestCacheMatch != null) {
+                val matchedEpisode = resolveEpisode(season, episode, bestCacheMatch, cacheScore)
                 return ScrobbleCandidate(
                     packageName = packageName,
                     mediaTitle = rawTitle,
                     confidence = cacheScore,
                     matchedShow = bestCacheMatch.show,
-                    matchedEpisode = if (season != null && episode != null)
-                        TraktEpisode(season = season, number = episode) else null
+                    matchedEpisode = matchedEpisode
                 )
             }
         }
@@ -181,6 +238,36 @@ class MediaSessionScrobbler @Inject constructor(
             Log.w(TAG, "TMDB search failed for '$showTitle'", e)
             null
         }
+    }
+
+    /**
+     * Resolve the episode tuple for a cache-matched show. Prefers the explicit `S##E##`
+     * pair parsed from MediaMetadata when available; otherwise falls back to the progress
+     * hint so scrobbles from Netflix / Prime / Disney+ (which ship only the episode title
+     * in `METADATA_KEY_TITLE`) aren't silently dropped (issue #401). The fallback only
+     * activates when show-match confidence clears [AUTO_SCROBBLE_THRESHOLD] — below that
+     * the overlay path still asks the user to confirm.
+     */
+    private suspend fun resolveEpisode(
+        explicitSeason: Int?,
+        explicitEpisode: Int?,
+        cacheEntry: TraktWatchedEntry,
+        confidence: Float
+    ): TraktEpisode? {
+        if (explicitSeason != null && explicitEpisode != null) {
+            return TraktEpisode(season = explicitSeason, number = explicitEpisode)
+        }
+        if (confidence < AUTO_SCROBBLE_THRESHOLD) return null
+        val hint = watchedShowSource.getShowHint(cacheEntry.show.ids)
+        if (hint == null) {
+            DiagnosticLog.warn(
+                TAG,
+                "scrobble dropped — no episode in title and no progress hint for '${cacheEntry.show.title}'"
+            )
+            return null
+        }
+        val guessed = ShowProgressCalculator.nextEpisodeNumbers(cacheEntry, hint) ?: return null
+        return TraktEpisode(season = guessed.first, number = guessed.second)
     }
 
     internal fun normalize(title: String): String {

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/ScrobbleContracts.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/ScrobbleContracts.kt
@@ -1,6 +1,8 @@
 package com.justb81.watchbuddy.core.scrobbler
 
+import com.justb81.watchbuddy.core.model.TmdbProgressHint
 import com.justb81.watchbuddy.core.model.TraktEpisode
+import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 
@@ -12,6 +14,13 @@ import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 interface WatchedShowSource {
     suspend fun getCachedShows(): List<TraktWatchedEntry>
     suspend fun getTmdbApiKey(): String?
+
+    /**
+     * Returns the cached TMDB progress hint for a show, used by the scrobbler to guess
+     * the next unwatched episode when the playing app's MediaMetadata title lacks an
+     * explicit `S##E##` marker (issue #401). Returns null when no hint is cached.
+     */
+    suspend fun getShowHint(ids: TraktIds): TmdbProgressHint? = null
 }
 
 /**

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerFallbackTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerFallbackTest.kt
@@ -1,0 +1,144 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import android.content.Context
+import com.justb81.watchbuddy.core.model.TmdbEpisodeSummary
+import com.justb81.watchbuddy.core.model.TmdbProgressHint
+import com.justb81.watchbuddy.core.model.TmdbSeasonSummary
+import com.justb81.watchbuddy.core.model.TraktIds
+import com.justb81.watchbuddy.core.model.TraktShow
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.tmdb.TmdbApiService
+import io.mockk.*
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for issue #401: when a streaming app ships only the show name
+ * in `METADATA_KEY_TITLE` (no `S##E##`), the scrobbler previously returned a
+ * candidate with `matchedEpisode = null` — silently dropping every Netflix /
+ * Prime Video / Disney+ play.
+ *
+ * The fix uses [ShowProgressCalculator.nextEpisodeNumbers] on the cached progress
+ * hint to guess the next unwatched episode when the show match is high-confidence.
+ */
+@DisplayName("MediaSessionScrobbler — Episode fallback (#401)")
+class MediaSessionScrobblerFallbackTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val tmdbApiService: TmdbApiService = mockk()
+    private val watchedShowSource: WatchedShowSource = mockk()
+    private val scrobbleDispatcher: ScrobbleDispatcher = mockk()
+    private lateinit var scrobbler: MediaSessionScrobbler
+
+    private val breakingBadIds = TraktIds(trakt = 1, tmdb = 1396)
+    private val breakingBadShow = TraktShow("Breaking Bad", 2008, breakingBadIds)
+    private val breakingBadEntry = TraktWatchedEntry(show = breakingBadShow)
+
+    @BeforeEach
+    fun setUp() {
+        scrobbler = MediaSessionScrobbler(context, tmdbApiService, watchedShowSource, scrobbleDispatcher)
+        coEvery { watchedShowSource.getTmdbApiKey() } returns null
+    }
+
+    @Test
+    fun `title without SxxExx uses hint nextAired when high-confidence cache match`() = runTest {
+        coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
+        coEvery { watchedShowSource.getShowHint(breakingBadIds) } returns TmdbProgressHint(
+            nextAired = TmdbEpisodeSummary(season_number = 4, episode_number = 7, air_date = "2024-01-01"),
+            seasons = listOf(TmdbSeasonSummary(4, 13))
+        )
+
+        val result = scrobbler.matchTitle("com.netflix", "Breaking Bad")
+
+        assertNotNull(result)
+        assertEquals(breakingBadShow, result!!.matchedShow)
+        assertEquals(4, result.matchedEpisode?.season)
+        assertEquals(7, result.matchedEpisode?.number)
+    }
+
+    @Test
+    fun `title without SxxExx falls back to last-watched plus one when no nextAired`() = runTest {
+        val partiallyWatchedEntry = TraktWatchedEntry(
+            show = breakingBadShow,
+            seasons = listOf(
+                com.justb81.watchbuddy.core.model.TraktWatchedSeason(
+                    number = 2,
+                    episodes = listOf(
+                        com.justb81.watchbuddy.core.model.TraktWatchedEpisode(
+                            number = 5,
+                            last_watched_at = "2024-01-01T00:00:00Z"
+                        )
+                    )
+                )
+            )
+        )
+        coEvery { watchedShowSource.getCachedShows() } returns listOf(partiallyWatchedEntry)
+        coEvery { watchedShowSource.getShowHint(breakingBadIds) } returns TmdbProgressHint(
+            seasons = listOf(TmdbSeasonSummary(2, 10))
+        )
+
+        val result = scrobbler.matchTitle("com.netflix", "Breaking Bad")
+
+        assertNotNull(result)
+        assertEquals(2, result!!.matchedEpisode?.season)
+        assertEquals(6, result.matchedEpisode?.number)
+    }
+
+    @Test
+    fun `title without SxxExx drops with null episode when no hint cached`() = runTest {
+        coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
+        coEvery { watchedShowSource.getShowHint(breakingBadIds) } returns null
+
+        val result = scrobbler.matchTitle("com.netflix", "Breaking Bad")
+
+        assertNotNull(result)
+        assertEquals(breakingBadShow, result!!.matchedShow)
+        assertNull(result.matchedEpisode, "Expected null episode when fallback has no hint to lean on")
+    }
+
+    @Test
+    fun `title with explicit SxxExx prefers parsed numbers over hint`() = runTest {
+        coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
+        coEvery { watchedShowSource.getShowHint(breakingBadIds) } returns TmdbProgressHint(
+            nextAired = TmdbEpisodeSummary(season_number = 4, episode_number = 7, air_date = "2024-01-01")
+        )
+
+        val result = scrobbler.matchTitle("com.netflix", "Breaking Bad S01E03")
+
+        assertNotNull(result)
+        assertEquals(1, result!!.matchedEpisode?.season)
+        assertEquals(3, result.matchedEpisode?.number)
+        coVerify(exactly = 0) { watchedShowSource.getShowHint(any()) }
+    }
+
+    @Test
+    fun `low-confidence match does not trigger hint fallback`() = runTest {
+        // "Breaking Bad!!" vs "Breaking Bad" is a prefix match = 0.95 confidence.
+        // We need a sub-0.95 confidence match to exercise the guard. The fuzzy
+        // scorer returns 0.95 for prefix matches and computes Levenshtein
+        // otherwise — "Braking Bad" (1 typo) lands below 0.95.
+        coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
+
+        val result = scrobbler.matchTitle("com.netflix", "Braking Bad")
+
+        assertNotNull(result)
+        assertTrue(result!!.confidence < MediaSessionScrobbler.AUTO_SCROBBLE_THRESHOLD)
+        assertNull(result.matchedEpisode)
+        coVerify(exactly = 0) { watchedShowSource.getShowHint(any()) }
+    }
+
+    @Test
+    fun `hint lookup is skipped when title already carries SxxExx`() = runTest {
+        coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
+
+        val result = scrobbler.matchTitle("com.netflix", "Breaking Bad S05E14")
+
+        assertNotNull(result)
+        assertEquals(5, result!!.matchedEpisode?.season)
+        assertEquals(14, result.matchedEpisode?.number)
+        coVerify(exactly = 0) { watchedShowSource.getShowHint(any()) }
+    }
+}

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerFallbackTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerFallbackTest.kt
@@ -8,9 +8,14 @@ import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
-import io.mockk.*
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerFuzzyTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerFuzzyTest.kt
@@ -248,6 +248,7 @@ class MediaSessionScrobblerFuzzyTest {
         fun `title without SxxExx has null episode`() = runTest {
             coEvery { watchedShowSource.getCachedShows() } returns
                 listOf(TraktWatchedEntry(show = breakingBadShow))
+            coEvery { watchedShowSource.getShowHint(any()) } returns null
 
             val result = scrobbler.matchTitle("com.netflix", "Breaking Bad")
 

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerVanishTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerVanishTest.kt
@@ -1,0 +1,119 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import android.content.Context
+import com.justb81.watchbuddy.core.model.ScrobbleCandidate
+import com.justb81.watchbuddy.core.model.TraktEpisode
+import com.justb81.watchbuddy.core.model.TraktIds
+import com.justb81.watchbuddy.core.model.TraktShow
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.tmdb.TmdbApiService
+import io.mockk.*
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for issue #402: some streaming apps destroy their MediaSession
+ * entirely when playback ends instead of transitioning through STATE_STOPPED.
+ * When that happens `getActiveSessions` just stops returning the session — no
+ * STATE_STOPPED is ever observed — so the dedup key `currentlyScrobbling` used
+ * to stay pinned forever, silently blocking every future scrobble of the same title.
+ *
+ * The fix reconciles `currentlyScrobbling` against the set of titles currently
+ * reported as live on each poll, dispatches an implicit stop with the last
+ * captured progress, and clears local state so the next play can scrobble again.
+ */
+@DisplayName("MediaSessionScrobbler — Session vanish reconciliation (#402)")
+class MediaSessionScrobblerVanishTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val tmdbApiService: TmdbApiService = mockk()
+    private val watchedShowSource: WatchedShowSource = mockk()
+    private val scrobbleDispatcher: ScrobbleDispatcher = mockk()
+    private lateinit var scrobbler: MediaSessionScrobbler
+
+    private val testShow = TraktShow("Breaking Bad", 2008, TraktIds(trakt = 1))
+    private val testEpisode = TraktEpisode(season = 1, number = 1)
+    private val testTitle = "Breaking Bad S01E01"
+    private val testCandidate = ScrobbleCandidate(
+        "com.netflix", testTitle, 0.95f, testShow, testEpisode
+    )
+
+    @BeforeEach
+    fun setUp() {
+        scrobbler = MediaSessionScrobbler(context, tmdbApiService, watchedShowSource, scrobbleDispatcher)
+        coEvery { scrobbleDispatcher.dispatchStart(any(), any(), any()) } just runs
+        coEvery { scrobbleDispatcher.dispatchStop(any(), any(), any()) } just runs
+        coEvery { watchedShowSource.getCachedShows() } returns
+            listOf(TraktWatchedEntry(show = testShow))
+        coEvery { watchedShowSource.getTmdbApiKey() } returns null
+        coEvery { watchedShowSource.getShowHint(any()) } returns null
+    }
+
+    @Test
+    fun `vanished session dispatches stop with last captured progress`() = runTest {
+        scrobbler.autoScrobble(testCandidate)
+        scrobbler.recordProgress(testTitle, 42f)
+
+        scrobbler.reconcileVanished(liveTitles = emptySet())
+
+        coVerify { scrobbleDispatcher.dispatchStop(testShow, testEpisode, 42f) }
+    }
+
+    @Test
+    fun `subsequent scrobble of same title proceeds after reconciliation`() = runTest {
+        scrobbler.autoScrobble(testCandidate)
+        scrobbler.recordProgress(testTitle, 42f)
+        scrobbler.reconcileVanished(liveTitles = emptySet())
+        clearMocks(scrobbleDispatcher, answers = false)
+
+        scrobbler.autoScrobble(testCandidate)
+
+        coVerify { scrobbleDispatcher.dispatchStart(testShow, testEpisode, any()) }
+    }
+
+    @Test
+    fun `live title still present does not trigger implicit stop`() = runTest {
+        scrobbler.autoScrobble(testCandidate)
+        scrobbler.recordProgress(testTitle, 42f)
+
+        scrobbler.reconcileVanished(liveTitles = setOf(testTitle))
+
+        coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
+    }
+
+    @Test
+    fun `no-op when nothing is currently scrobbling`() = runTest {
+        scrobbler.reconcileVanished(liveTitles = emptySet())
+
+        coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
+    }
+
+    @Test
+    fun `vanished session with no captured progress skips dispatch but still clears state`() = runTest {
+        scrobbler.autoScrobble(testCandidate)
+        // Intentionally no recordProgress() — stream ended before any progress-bearing poll.
+
+        scrobbler.reconcileVanished(liveTitles = emptySet())
+
+        coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
+        // Follow-up start must no longer be blocked by the dedup guard.
+        clearMocks(scrobbleDispatcher, answers = false)
+        scrobbler.autoScrobble(testCandidate)
+        coVerify { scrobbleDispatcher.dispatchStart(testShow, testEpisode, any()) }
+    }
+
+    @Test
+    fun `stopListening clears scrobble state`() = runTest {
+        scrobbler.autoScrobble(testCandidate)
+        scrobbler.recordProgress(testTitle, 42f)
+
+        scrobbler.stopListening()
+
+        // After stop, reconciliation is a no-op because state is cleared.
+        scrobbler.reconcileVanished(liveTitles = emptySet())
+        coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
+    }
+}

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerVanishTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerVanishTest.kt
@@ -7,9 +7,13 @@ import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
-import io.mockk.*
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
## Summary

Two paired `MediaSessionScrobbler` fixes that both cause scrobbles to silently
disappear before reaching Trakt. Bundling them because they touch the same
polling loop and share test infrastructure.

### #401 — title without `S##E##` was dropped with no log

Most streaming apps (Netflix, Prime Video, Disney+, …) don't put `S##E##` into
`MediaMetadata.METADATA_KEY_TITLE` — they ship the episode title, the show
name, or the app name. The regex in `matchTitle` was silently returning a
`ScrobbleCandidate` with `matchedEpisode = null`, and every downstream
dispatch (`autoScrobble`, `handleScrobblePause`, `handleScrobbleStop`) bailed
out with `val episode = candidate.matchedEpisode ?: return` — confidence could
be 100 % and nothing would reach Trakt.

**Fix:** when the show match is high-confidence (≥ `AUTO_SCROBBLE_THRESHOLD`)
and the title lacks `S##E##`, fall back to
`ShowProgressCalculator.nextEpisodeNumbers` using the cached TMDB progress
hint. When no hint is cached (the only case we still drop), log a WARN via
`DiagnosticLog` so the drop is visible in the breadcrumb snapshot.

To support this, `WatchedShowSource` grows an optional `getShowHint(ids)` and
`TvShowCache` now stores `EnrichedShowEntry` hints keyed by Trakt id.

### #402 — `currentlyScrobbling` never cleared when session vanished

Some streaming apps (YouTube, some Fire TV skins) destroy the entire
`MediaSession` when playback ends instead of transitioning through
`STATE_STOPPED`. Once the session disappears, `getActiveSessions(...)` stops
returning it and the clear path in `handleScrobbleStop` never runs —
`currentlyScrobbling` stays pinned forever, silently blocking every future
scrobble of the same title via the dedup guard in `processPlayingMedia`.

**Fix:** on every poll, compute the live-session title set and reconcile
`currentlyScrobbling` against it. If the tracked title isn't live any more,
dispatch an implicit `/scrobble/stop` with the last captured progress (new
per-title progress map, populated on every poll that has usable
`position/duration`) and clear local state.

## Test plan

- [x] `MediaSessionScrobblerFallbackTest` — new, covers #401
  - Title without `S##E##` + cached hint with `nextAired=S04E07` → `matchedEpisode` becomes S04E07
  - Title without `S##E##` + no `nextAired`, only user's last watched → fallback to last + 1
  - Title without `S##E##` + no cached hint → `matchedEpisode == null`, WARN logged
  - Explicit `S##E##` in title → parsed numbers win, hint is not consulted
  - Low-confidence match → fallback guard skips hint lookup
- [x] `MediaSessionScrobblerVanishTest` — new, covers #402
  - Vanished session dispatches `dispatchStop` with last captured progress
  - Subsequent `autoScrobble` of the same title proceeds after reconciliation
  - Live title still present → no implicit stop
  - No-op when nothing is currently scrobbling
  - No captured progress → state still cleared, no dispatch
  - `stopListening` clears scrobble state
- [x] `TvShowCacheTest` — extended with coverage for the new `updateEnrichedShows` / `getHint` API
- [x] `TvHomeViewModelTest` — updated `verify { updateShows(...) }` expectations to the new `updateEnrichedShows(...)` call
- [ ] Manual: play a Netflix episode of a tracked show end-to-end, confirm Trakt history reflects the play
- [ ] Manual: play an episode of a show with no TMDB hint, confirm a `DiagnosticLog` WARN entry for the drop
- [ ] Manual: reproduce the YouTube/Fire-TV "session vanished" case, confirm a replay of the same title scrobbles again

## Pre-commit notes

Ran on Claude Code on the web (no Android SDK available). `scripts/precommit.sh`
detected the missing SDK and skipped the Gradle scope with its intended yellow
warning; CI's `Test & Build` check is the real gate for this PR. No
`--no-verify` used.

Closes #401
Closes #402

https://claude.ai/code/session_014Limyq8iWMugQrMTfbBvzg