### PR TITLE
feat(tv): Recent events section on Diagnostics + debug media-session firehose

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/StreamingPreferencesRepository.kt
@@ -26,6 +26,7 @@ class StreamingPreferencesRepository @Inject constructor(
     private val phoneDiscoveryKey = booleanPreferencesKey("phone_discovery_enabled")
     private val autostartKey = booleanPreferencesKey("autostart_enabled")
     private val showNonInstalledKey = booleanPreferencesKey("show_non_installed_providers")
+    private val debugLogMediaSessionKey = booleanPreferencesKey("debug_log_media_session")
 
     /** Whether phone discovery (NSD + BLE) should be active. Defaults to true. */
     val isPhoneDiscoveryEnabled: Flow<Boolean> = context.streamingDataStore.data
@@ -45,6 +46,16 @@ class StreamingPreferencesRepository @Inject constructor(
         .catch { emit(emptyPreferences()) }
         .map { prefs -> prefs[showNonInstalledKey] ?: false }
 
+    /**
+     * Debug: when true, [MediaSessionScrobbler] writes a `DiagnosticLog.event` for every
+     * raw media-session poll tick so every package/title/state/position/duration is
+     * visible in TV Diagnostics. Off by default — this is firehose output intended for
+     * troubleshooting scrobble miss reports.
+     */
+    val debugLogMediaSession: Flow<Boolean> = context.streamingDataStore.data
+        .catch { emit(emptyPreferences()) }
+        .map { prefs -> prefs[debugLogMediaSessionKey] ?: false }
+
     suspend fun getShowNonInstalledProviders(): Boolean =
         showNonInstalledProviders.first()
 
@@ -58,5 +69,9 @@ class StreamingPreferencesRepository @Inject constructor(
 
     suspend fun setShowNonInstalledProviders(show: Boolean) {
         context.streamingDataStore.edit { prefs -> prefs[showNonInstalledKey] = show }
+    }
+
+    suspend fun setDebugLogMediaSession(enabled: Boolean) {
+        context.streamingDataStore.edit { prefs -> prefs[debugLogMediaSessionKey] = enabled }
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/TvDiscoveryService.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/TvDiscoveryService.kt
@@ -65,14 +65,21 @@ class TvDiscoveryService : Service() {
     private fun observePreferences() {
         if (observerJob != null) return
         observerJob = scope.launch {
-            preferences.isPhoneDiscoveryEnabled.collect { discovery ->
-                if (discovery) {
-                    phoneDiscovery.setEnabled(true)
-                    startScrobblerIfPermitted()
-                } else {
-                    DiagnosticLog.event(TAG, "phone discovery disabled — stopping self")
-                    scrobbler.stopListening()
-                    stopSelf()
+            launch {
+                preferences.isPhoneDiscoveryEnabled.collect { discovery ->
+                    if (discovery) {
+                        phoneDiscovery.setEnabled(true)
+                        startScrobblerIfPermitted()
+                    } else {
+                        DiagnosticLog.event(TAG, "phone discovery disabled — stopping self")
+                        scrobbler.stopListening()
+                        stopSelf()
+                    }
+                }
+            }
+            launch {
+                preferences.debugLogMediaSession.collect { enabled ->
+                    scrobbler.debugLogMediaSession = enabled
                 }
             }
         }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
@@ -1,6 +1,7 @@
 package com.justb81.watchbuddy.tv.scrobbler
 
 import android.util.Log
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher
@@ -52,6 +53,10 @@ class TvScrobbleDispatcher @Inject constructor(
         val phones = availablePhones()
         if (phones.isEmpty()) {
             Log.w(TAG, "No phones available — scrobble ${action.name.lowercase()} skipped")
+            DiagnosticLog.warn(
+                TAG,
+                "scrobble ${action.name.lowercase()} dropped — no phones reachable",
+            )
             return
         }
         val request = PhoneScrobbleRequest(show = show, episode = episode, progress = progress)

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -19,6 +20,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.tv.material3.*
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 
@@ -178,6 +180,36 @@ fun TvDiagnosticsScreen(
             }
 
             item {
+                Text(
+                    text = stringResource(R.string.tv_diagnostics_section_recent_events).uppercase(),
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White.copy(alpha = 0.7f),
+                    modifier = Modifier.padding(top = 8.dp, bottom = 4.dp, start = 4.dp),
+                )
+            }
+
+            if (uiState.recentEvents.isEmpty()) {
+                item {
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+                        onClick = {},
+                    ) {
+                        Text(
+                            text = stringResource(R.string.tv_diagnostics_value_no_events),
+                            color = Color.White.copy(alpha = 0.5f),
+                            modifier = Modifier.padding(16.dp),
+                        )
+                    }
+                }
+            } else {
+                items(uiState.recentEvents) { entry ->
+                    RecentEventRow(entry)
+                }
+            }
+
+            item {
                 Spacer(Modifier.height(16.dp))
                 OutlinedButton(onClick = onBack) {
                     Text(stringResource(R.string.tv_back))
@@ -248,6 +280,51 @@ private fun PhoneRow(label: String, value: String) {
     ) {
         Text(label, fontSize = 12.sp, color = Color.White.copy(alpha = 0.7f))
         Text(value, fontSize = 12.sp, color = Color.White)
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun RecentEventRow(entry: DiagnosticLog.Entry) {
+    val status = when (entry.level) {
+        DiagnosticLog.Level.DEBUG -> Status.NEUTRAL
+        DiagnosticLog.Level.INFO -> Status.OK
+        DiagnosticLog.Level.WARN -> Status.WARN
+        DiagnosticLog.Level.ERROR -> Status.FAIL
+    }
+    val message = entry.throwableSummary?.let { "${entry.message} → $it" } ?: entry.message
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+        onClick = {},
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(10.dp)
+                    .background(statusColor(status), RoundedCornerShape(2.dp)),
+            )
+            Spacer(Modifier.width(12.dp))
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = "${formatAge(entry.timestampMs)} · ${entry.tag}",
+                    fontSize = 12.sp,
+                    color = Color.White.copy(alpha = 0.6f),
+                )
+                Text(
+                    text = message,
+                    fontSize = 13.sp,
+                    color = Color.White,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
     }
 }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
@@ -5,6 +5,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.BuildConfig
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,6 +14,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -26,6 +28,7 @@ data class TvDiagnosticsUiState(
     val notificationAccessGranted: Boolean = false,
     val scrobblerListening: Boolean = false,
     val lastCandidate: MediaSessionScrobbler.LastCandidate? = null,
+    val recentEvents: List<DiagnosticLog.Entry> = emptyList(),
     val versionName: String = BuildConfig.VERSION_NAME,
     val versionCode: Int = BuildConfig.VERSION_CODE,
 )
@@ -70,7 +73,19 @@ class TvDiagnosticsViewModel @Inject constructor(
                     lastCandidate = s.second,
                 )
             }.collect { snapshot ->
-                _uiState.update { snapshot.copy(notificationAccessGranted = it.notificationAccessGranted) }
+                _uiState.update {
+                    snapshot.copy(
+                        notificationAccessGranted = it.notificationAccessGranted,
+                        recentEvents = it.recentEvents,
+                    )
+                }
+            }
+        }
+
+        viewModelScope.launch {
+            DiagnosticLog.updates.onStart { emit(Unit) }.collect {
+                val latest = DiagnosticLog.snapshot().asReversed().take(MAX_RECENT_EVENTS)
+                _uiState.update { it.copy(recentEvents = latest) }
             }
         }
     }
@@ -86,5 +101,9 @@ class TvDiagnosticsViewModel @Inject constructor(
                 .contains(application.packageName)
         }.getOrDefault(false)
         _uiState.update { it.copy(notificationAccessGranted = granted) }
+    }
+
+    companion object {
+        private const val MAX_RECENT_EVENTS = 100
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsScreen.kt
@@ -128,6 +128,13 @@ fun TvSettingsScreen(
             subtitle = stringResource(R.string.tv_diagnostics_title),
             onClick = onDiagnosticsClick,
         ),
+        SettingsRow.Toggle(
+            key = "debug_log_media_session",
+            title = stringResource(R.string.tv_settings_debug_log_media_session_title),
+            subtitle = stringResource(R.string.tv_settings_debug_log_media_session_subtitle),
+            enabled = uiState.debugLogMediaSession,
+            onChange = viewModel::setDebugLogMediaSession,
+        ),
     )
 
     TvSettingsBodyContent(rows = rows, onBack = onBack)

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModel.kt
@@ -24,6 +24,7 @@ data class TvSettingsUiState(
     val isAutostartEnabled: Boolean = false,
     val isNotificationAccessGranted: Boolean = false,
     val showNonInstalledProviders: Boolean = false,
+    val debugLogMediaSession: Boolean = false,
 )
 
 @HiltViewModel
@@ -49,19 +50,30 @@ class TvSettingsViewModel @Inject constructor(
                 repository.isPhoneDiscoveryEnabled,
                 repository.isAutostartEnabled,
                 repository.showNonInstalledProviders,
-            ) { discovery, autostart, nonInstalled -> Triple(discovery, autostart, nonInstalled) }
+                repository.debugLogMediaSession,
+            ) { discovery, autostart, nonInstalled, debugLog ->
+                Snapshot(discovery, autostart, nonInstalled, debugLog)
+            }
                 .catch { e -> DiagnosticLog.error(TAG, "tv settings observation failed", e) }
-                .collect { (discovery, autostart, nonInstalled) ->
+                .collect { snapshot ->
                     _uiState.update {
                         it.copy(
-                            isPhoneDiscoveryEnabled = discovery,
-                            isAutostartEnabled = autostart,
-                            showNonInstalledProviders = nonInstalled,
+                            isPhoneDiscoveryEnabled = snapshot.discovery,
+                            isAutostartEnabled = snapshot.autostart,
+                            showNonInstalledProviders = snapshot.nonInstalled,
+                            debugLogMediaSession = snapshot.debugLog,
                         )
                     }
                 }
         }
     }
+
+    private data class Snapshot(
+        val discovery: Boolean,
+        val autostart: Boolean,
+        val nonInstalled: Boolean,
+        val debugLog: Boolean,
+    )
 
     fun setPhoneDiscoveryEnabled(enabled: Boolean) {
         _uiState.update { it.copy(isPhoneDiscoveryEnabled = enabled) }
@@ -76,6 +88,11 @@ class TvSettingsViewModel @Inject constructor(
     fun setShowNonInstalledProviders(show: Boolean) {
         _uiState.update { it.copy(showNonInstalledProviders = show) }
         launchSafe { repository.setShowNonInstalledProviders(show) }
+    }
+
+    fun setDebugLogMediaSession(enabled: Boolean) {
+        _uiState.update { it.copy(debugLogMediaSession = enabled) }
+        launchSafe { repository.setDebugLogMediaSession(enabled) }
     }
 
     /**

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -73,6 +73,8 @@
     <string name="tv_settings_show_non_installed_title">Nicht installierte Dienste anzeigen</string>
     <string name="tv_settings_show_non_installed_subtitle">Auch Streamingdienste anzeigen, die nicht auf diesem Fernseher installiert sind</string>
     <string name="tv_settings_diagnostics">Diagnose</string>
+    <string name="tv_settings_debug_log_media_session_title">Debug: jede Mediensitzung protokollieren</string>
+    <string name="tv_settings_debug_log_media_session_subtitle">Schreibt jede erkannte Mediensitzung ins Ereignisprotokoll</string>
     <string name="tv_settings_notification_access_title">Benachrichtigungszugriff</string>
     <string name="tv_settings_notification_access_subtitle">Erforderlich für Scrobbling – damit WatchBuddy erkennt, was am TV läuft</string>
     <string name="tv_settings_status_granted">Erteilt</string>
@@ -124,6 +126,8 @@
     <string name="tv_diagnostics_value_yes">Ja</string>
     <string name="tv_diagnostics_value_no">Nein</string>
     <string name="tv_diagnostics_value_no_phones">Noch keine Telefone gefunden.</string>
+    <string name="tv_diagnostics_section_recent_events">Letzte Ereignisse</string>
+    <string name="tv_diagnostics_value_no_events">Noch keine Ereignisse</string>
 
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (Build %2$d)</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -73,6 +73,8 @@
     <string name="tv_settings_show_non_installed_title">Mostrar servicios no instalados</string>
     <string name="tv_settings_show_non_installed_subtitle">Mostrar también servicios de streaming no instalados en este televisor</string>
     <string name="tv_settings_diagnostics">Diagnósticos</string>
+    <string name="tv_settings_debug_log_media_session_title">Depuración: registrar cada sesión multimedia</string>
+    <string name="tv_settings_debug_log_media_session_subtitle">Registra cada sesión multimedia detectada en el registro de eventos</string>
     <string name="tv_settings_notification_access_title">Acceso a notificaciones</string>
     <string name="tv_settings_notification_access_subtitle">Necesario para el scrobble: permite a WatchBuddy detectar lo que se reproduce en el televisor</string>
     <string name="tv_settings_status_granted">Concedido</string>
@@ -124,6 +126,8 @@
     <string name="tv_diagnostics_value_yes">Sí</string>
     <string name="tv_diagnostics_value_no">No</string>
     <string name="tv_diagnostics_value_no_phones">No se han encontrado teléfonos.</string>
+    <string name="tv_diagnostics_section_recent_events">Eventos recientes</string>
+    <string name="tv_diagnostics_value_no_events">Sin eventos aún</string>
 
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -73,6 +73,8 @@
     <string name="tv_settings_show_non_installed_title">Afficher les services non installés</string>
     <string name="tv_settings_show_non_installed_subtitle">Afficher aussi les services de streaming non installés sur ce téléviseur</string>
     <string name="tv_settings_diagnostics">Diagnostics</string>
+    <string name="tv_settings_debug_log_media_session_title">Débogage : consigner chaque session média</string>
+    <string name="tv_settings_debug_log_media_session_subtitle">Consigne chaque session média détectée dans le journal d\'événements</string>
     <string name="tv_settings_notification_access_title">Accès aux notifications</string>
     <string name="tv_settings_notification_access_subtitle">Requis pour le scrobble — permet à WatchBuddy de détecter ce qui est lu sur le téléviseur</string>
     <string name="tv_settings_status_granted">Accordé</string>
@@ -124,6 +126,8 @@
     <string name="tv_diagnostics_value_yes">Oui</string>
     <string name="tv_diagnostics_value_no">Non</string>
     <string name="tv_diagnostics_value_no_phones">Aucun téléphone détecté.</string>
+    <string name="tv_diagnostics_section_recent_events">Événements récents</string>
+    <string name="tv_diagnostics_value_no_events">Aucun événement</string>
 
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -73,6 +73,8 @@
     <string name="tv_settings_show_non_installed_title">Show unavailable services</string>
     <string name="tv_settings_show_non_installed_subtitle">Also show streaming services not installed on this TV</string>
     <string name="tv_settings_diagnostics">Diagnostics</string>
+    <string name="tv_settings_debug_log_media_session_title">Debug: log every media session</string>
+    <string name="tv_settings_debug_log_media_session_subtitle">Writes every detected media session to the event log</string>
     <string name="tv_settings_notification_access_title">Notification access</string>
     <string name="tv_settings_notification_access_subtitle">Required for scrobbling — lets WatchBuddy see what\'s playing on the TV</string>
     <string name="tv_settings_status_granted">Granted</string>
@@ -124,6 +126,8 @@
     <string name="tv_diagnostics_value_yes">Yes</string>
     <string name="tv_diagnostics_value_no">No</string>
     <string name="tv_diagnostics_value_no_phones">No phones discovered yet.</string>
+    <string name="tv_diagnostics_section_recent_events">Recent events</string>
+    <string name="tv_diagnostics_value_no_events">No events yet</string>
 
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModelTest.kt
@@ -1,0 +1,90 @@
+package com.justb81.watchbuddy.tv.ui.diagnostics
+
+import android.app.Application
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
+import com.justb81.watchbuddy.tv.MainDispatcherRule
+import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("TvDiagnosticsViewModel")
+class TvDiagnosticsViewModelTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val mainDispatcherRule = MainDispatcherRule()
+    }
+
+    private val application: Application = mockk(relaxed = true)
+    private val phoneDiscovery: PhoneDiscoveryManager = mockk(relaxed = true)
+    private val scrobbler: MediaSessionScrobbler = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        DiagnosticLog.clear()
+        every { phoneDiscovery.discoveryActive } returns MutableStateFlow(false)
+        every { phoneDiscovery.bleScanState } returns
+            MutableStateFlow(PhoneDiscoveryManager.BleScanState.IDLE)
+        every { phoneDiscovery.bleScanErrorCode } returns MutableStateFlow<Int?>(null)
+        every { phoneDiscovery.lastHeartbeatTick } returns MutableStateFlow(0L)
+        every { phoneDiscovery.discoveredPhones } returns MutableStateFlow(emptyList())
+        every { scrobbler.isListening } returns MutableStateFlow(false)
+        every { scrobbler.lastCandidate } returns MutableStateFlow(null)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        DiagnosticLog.clear()
+    }
+
+    @Test
+    fun `recentEvents is empty on fresh VM`() = runTest {
+        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler)
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.recentEvents.isEmpty())
+    }
+
+    @Test
+    fun `single event is projected with correct level and newest-first order`() = runTest {
+        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler)
+        advanceUntilIdle()
+
+        DiagnosticLog.event("TAG", "hello")
+        advanceUntilIdle()
+
+        val events = vm.uiState.value.recentEvents
+        assertEquals(1, events.size)
+        assertEquals("TAG", events[0].tag)
+        assertEquals("hello", events[0].message)
+        assertEquals(DiagnosticLog.Level.INFO, events[0].level)
+    }
+
+    @Test
+    fun `recentEvents is truncated to 100 entries newest first`() = runTest {
+        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler)
+        advanceUntilIdle()
+
+        repeat(150) { i -> DiagnosticLog.event("TAG", "msg $i") }
+        advanceUntilIdle()
+
+        val events = vm.uiState.value.recentEvents
+        assertEquals(100, events.size)
+        assertEquals("msg 149", events[0].message)
+        assertEquals("msg 50", events[99].message)
+    }
+}

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsViewModelTest.kt
@@ -43,9 +43,11 @@ class TvSettingsViewModelTest {
         every { repository.isPhoneDiscoveryEnabled } returns flowOf(true)
         every { repository.isAutostartEnabled } returns flowOf(false)
         every { repository.showNonInstalledProviders } returns flowOf(false)
+        every { repository.debugLogMediaSession } returns flowOf(false)
         coEvery { repository.setPhoneDiscoveryEnabled(any()) } just runs
         coEvery { repository.setAutostartEnabled(any()) } just runs
         coEvery { repository.setShowNonInstalledProviders(any()) } just runs
+        coEvery { repository.setDebugLogMediaSession(any()) } just runs
     }
 
     @AfterEach
@@ -135,5 +137,17 @@ class TvSettingsViewModelTest {
         vm.refreshNotificationAccess()
 
         assertFalse(vm.uiState.value.isNotificationAccessGranted)
+    }
+
+    @Test
+    fun `setDebugLogMediaSession writes through and optimistically updates state`() = runTest {
+        val vm = TvSettingsViewModel(application, repository)
+        advanceUntilIdle()
+
+        vm.setDebugLogMediaSession(true)
+        advanceUntilIdle()
+
+        coVerify { repository.setDebugLogMediaSession(true) }
+        assertTrue(vm.uiState.value.debugLogMediaSession)
     }
 }

--- a/core/src/main/java/com/justb81/watchbuddy/core/logging/DiagnosticLog.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/logging/DiagnosticLog.kt
@@ -1,6 +1,10 @@
 package com.justb81.watchbuddy.core.logging
 
 import android.util.Log
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import java.text.SimpleDateFormat
 import java.util.ArrayDeque
 import java.util.Date
@@ -37,6 +41,19 @@ object DiagnosticLog {
 
     private val buffer = ArrayDeque<Entry>(MAX_ENTRIES)
     private val lock = Any()
+
+    private val _updates = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    /**
+     * Emits a tick after every [append] so reactive consumers (e.g. the TV diagnostics
+     * screen) can refresh their view without polling. Consumers snapshot on each tick
+     * and pick whatever slice they want — the flow itself carries no payload to keep
+     * it cheap.
+     */
+    val updates: SharedFlow<Unit> = _updates.asSharedFlow()
 
     private val timestampFormatter: ThreadLocal<SimpleDateFormat> =
         object : ThreadLocal<SimpleDateFormat>() {
@@ -96,6 +113,7 @@ object DiagnosticLog {
             buffer.addLast(entry)
         }
         mirrorToLogcat(entry, throwable)
+        _updates.tryEmit(Unit)
     }
 
     private fun summarizeThrowable(t: Throwable): String {

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -77,6 +77,17 @@ class MediaSessionScrobbler @Inject constructor(
     private var currentlyScrobbling: String? = null
 
     /**
+     * Debug firehose toggle. When true, every poll tick writes a per-session breadcrumb
+     * to [DiagnosticLog] (package, title, state, position, duration) regardless of
+     * confidence, plus a near-miss line when a title fails to clear [OVERLAY_THRESHOLD].
+     *
+     * Set from the TV layer (see `TvDiscoveryService.observePreferences`) based on the
+     * "Debug: log every media session" setting. The phone leaves this `false`.
+     */
+    @Volatile
+    var debugLogMediaSession: Boolean = false
+
+    /**
      * Last observed playback progress per media title, captured on every poll that yields
      * a usable `position/duration`. Feeds the implicit-stop dispatched by [reconcileVanished]
      * when a session disappears without ever emitting STATE_STOPPED (issue #402).
@@ -99,17 +110,23 @@ class MediaSessionScrobbler @Inject constructor(
                     reconcileVanished(liveTitles)
                     sessions.forEach { controller ->
                         val packageName = controller.packageName
-                        val metadata = controller.metadata ?: return@forEach
-                        val playbackState = controller.playbackState ?: return@forEach
-                        val title = metadata.getString(android.media.MediaMetadata.METADATA_KEY_TITLE)
-                            ?: return@forEach
+                        val metadata = controller.metadata
+                        val playbackState = controller.playbackState
+                        val rawTitle = metadata
+                            ?.getString(android.media.MediaMetadata.METADATA_KEY_TITLE)
+                        val durationMs = metadata
+                            ?.getLong(android.media.MediaMetadata.METADATA_KEY_DURATION) ?: -1L
+                        val state = playbackState?.state ?: -1
+                        val positionMs = playbackState?.position ?: -1L
+                        logSessionIfDebug(packageName, rawTitle, state, positionMs, durationMs)
+                        if (metadata == null || playbackState == null || rawTitle == null) return@forEach
                         val progress = computeProgress(playbackState, metadata)
-                        if (progress != null) recordProgress(title, progress)
+                        if (progress != null) recordProgress(rawTitle, progress)
                         when (playbackState.state) {
-                            PlaybackState.STATE_PLAYING -> processPlayingMedia(packageName, title, progress)
-                            PlaybackState.STATE_PAUSED -> handleScrobblePause(title, progress)
+                            PlaybackState.STATE_PLAYING -> processPlayingMedia(packageName, rawTitle, progress)
+                            PlaybackState.STATE_PAUSED -> handleScrobblePause(rawTitle, progress)
                             PlaybackState.STATE_STOPPED,
-                            PlaybackState.STATE_NONE -> handleScrobbleStop(title, progress)
+                            PlaybackState.STATE_NONE -> handleScrobbleStop(rawTitle, progress)
                             else -> {}
                         }
                     }
@@ -123,6 +140,21 @@ class MediaSessionScrobbler @Inject constructor(
 
     internal fun recordProgress(title: String, progress: Float) {
         lastProgressByTitle[title] = progress
+    }
+
+    internal fun logSessionIfDebug(
+        packageName: String,
+        title: String?,
+        state: Int,
+        positionMs: Long,
+        durationMs: Long,
+    ) {
+        if (!debugLogMediaSession) return
+        DiagnosticLog.event(
+            TAG,
+            "session pkg=$packageName title='${title ?: "(null)"}' state=$state " +
+                "pos=${positionMs}ms dur=${durationMs}ms",
+        )
     }
 
     /**
@@ -170,13 +202,24 @@ class MediaSessionScrobbler @Inject constructor(
 
     private suspend fun processPlayingMedia(packageName: String, rawTitle: String, progress: Float?) {
         if (rawTitle == currentlyScrobbling) return
-        val candidate = matchTitle(packageName, rawTitle) ?: return
+        val candidate = matchTitle(packageName, rawTitle)
+        if (candidate == null) {
+            if (debugLogMediaSession) {
+                DiagnosticLog.debug(TAG, "no match for '$rawTitle' — best confidence null")
+            }
+            return
+        }
         if (candidate.confidence >= AUTO_SCROBBLE_THRESHOLD) {
             autoScrobble(candidate, progress)
             _lastCandidate.value = LastCandidate(candidate, System.currentTimeMillis(), autoScrobbled = true)
         } else if (candidate.confidence >= OVERLAY_THRESHOLD) {
             _pendingConfirmation.emit(candidate)
             _lastCandidate.value = LastCandidate(candidate, System.currentTimeMillis(), autoScrobbled = false)
+        } else if (debugLogMediaSession) {
+            DiagnosticLog.debug(
+                TAG,
+                "no match for '$rawTitle' — best confidence ${candidate.confidence}",
+            )
         }
     }
 

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerDebugLogTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerDebugLogTest.kt
@@ -1,0 +1,96 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import android.content.Context
+import android.media.session.MediaSessionManager
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.core.tmdb.TmdbApiService
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("MediaSessionScrobbler — debugLogMediaSession firehose")
+class MediaSessionScrobblerDebugLogTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val tmdbApiService: TmdbApiService = mockk()
+    private val watchedShowSource: WatchedShowSource = mockk()
+    private val scrobbleDispatcher: ScrobbleDispatcher = mockk()
+    private lateinit var scrobbler: MediaSessionScrobbler
+
+    @BeforeEach
+    fun setUp() {
+        val mockSessionManager = mockk<MediaSessionManager>(relaxed = true)
+        every { context.getSystemService(Context.MEDIA_SESSION_SERVICE) } returns mockSessionManager
+        every { mockSessionManager.getActiveSessions(any()) } returns emptyList()
+        scrobbler = MediaSessionScrobbler(context, tmdbApiService, watchedShowSource, scrobbleDispatcher)
+        DiagnosticLog.clear()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        DiagnosticLog.clear()
+    }
+
+    @Test
+    fun `does not log session breadcrumb when flag is off`() {
+        scrobbler.debugLogMediaSession = false
+
+        scrobbler.logSessionIfDebug(
+            packageName = "com.netflix.ninja",
+            title = "Breaking Bad S01E01",
+            state = 3,
+            positionMs = 1234L,
+            durationMs = 2600000L,
+        )
+
+        val sessionEntries = DiagnosticLog.snapshot()
+            .filter { it.message.startsWith("session pkg=") }
+        assertTrue(sessionEntries.isEmpty())
+    }
+
+    @Test
+    fun `logs exactly one session breadcrumb per call when flag is on`() {
+        scrobbler.debugLogMediaSession = true
+
+        scrobbler.logSessionIfDebug(
+            packageName = "com.netflix.ninja",
+            title = "Breaking Bad S01E01",
+            state = 3,
+            positionMs = 1234L,
+            durationMs = 2600000L,
+        )
+
+        val sessionEntries = DiagnosticLog.snapshot()
+            .filter { it.message.startsWith("session pkg=") }
+        assertEquals(1, sessionEntries.size)
+        val entry = sessionEntries.single()
+        assertEquals(DiagnosticLog.Level.INFO, entry.level)
+        assertTrue(entry.message.contains("pkg=com.netflix.ninja"))
+        assertTrue(entry.message.contains("title='Breaking Bad S01E01'"))
+        assertTrue(entry.message.contains("state=3"))
+        assertTrue(entry.message.contains("pos=1234ms"))
+        assertTrue(entry.message.contains("dur=2600000ms"))
+    }
+
+    @Test
+    fun `renders null title as literal placeholder`() {
+        scrobbler.debugLogMediaSession = true
+
+        scrobbler.logSessionIfDebug(
+            packageName = "com.netflix.ninja",
+            title = null,
+            state = -1,
+            positionMs = -1L,
+            durationMs = -1L,
+        )
+
+        val entry = DiagnosticLog.snapshot()
+            .single { it.message.startsWith("session pkg=") }
+        assertTrue(entry.message.contains("title='(null)'"))
+    }
+}


### PR DESCRIPTION
## Summary

Implements #407. Surfaces the shared `DiagnosticLog` ring buffer live on the TV diagnostics screen and adds a gated "Debug: log every media session" setting so scrobble misses can be reconstructed on-device.

- `DiagnosticLog` gains a unit-tick `SharedFlow` (`updates`) emitted after every `append(...)`. Existing consumers (`DiagnosticShare`, `CrashReporter`, tests) are untouched.
- `TvDiagnosticsViewModel` adds a `recentEvents: List<DiagnosticLog.Entry>` field in its `uiState`, refreshed reactively from the new tick — truncated to 100 entries, newest first.
- `TvDiagnosticsScreen` renders a "Recent events" section above the Back button, with the existing status-color dot idiom (DEBUG→neutral, INFO→ok, WARN→warn, ERROR→fail) and `throwableSummary` appended inline.
- New `debugLogMediaSession` preference in `StreamingPreferencesRepository` + `TvSettingsScreen` toggle. When on, `MediaSessionScrobbler` writes a `DiagnosticLog.event` for every poll tick (`pkg/title/state/pos/dur`) and a `DiagnosticLog.debug` for below-threshold near-misses. The flag is a `@Volatile var` on the scrobbler, owned by `TvDiscoveryService.observePreferences` (no core Hilt plumbing).
- `TvScrobbleDispatcher` now always writes a `DiagnosticLog.warn("scrobble … dropped — no phones reachable")` when `availablePhones()` is empty — not flag-gated, since the drop reason is valuable in production.
- Strings in `values/`, `values-de/`, `values-fr/`, `values-es/`.
- Tests: `TvDiagnosticsViewModelTest` (empty / single-entry projection / 150→100 truncation), extended `TvSettingsViewModelTest` (debug-toggle write-through), `MediaSessionScrobblerDebugLogTest` (flag off / flag on / null title rendering).

## Test plan

- [ ] CI: `./gradlew test detektAll :app-phone:lintDebug :app-tv:lintDebug` clean
- [ ] CI: `:app-tv:testDebugUnitTest` passes including the new `TvDiagnosticsViewModelTest`
- [ ] Manual: sideload debug APK on Android TV, Settings → Diagnostics shows "Recent events" above Back; toggle Phone discovery and watch breadcrumbs appear live
- [ ] Manual: with debug toggle on, playing Netflix produces one "session pkg=..." entry per 30s poll tick; toggle off and the firehose stops
- [ ] Manual: with no phones discovered, trigger a scrobble and confirm a red warn-level "scrobble … dropped — no phones reachable" entry appears
- [ ] Locale smoke: switch TV language to DE/FR/ES and confirm the section header, empty state, and debug-toggle strings translate

> **Note:** pre-commit ran in a sandboxed environment without the Android SDK, so the Gradle scope (`test` / `detektAll` / `lintDebug`) was skipped locally. CI (`Test & Build`) is the real gate for Kotlin/Android changes on this PR.

Closes #407

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwbMDLeeZSBSUZa9xhiuC3)_