### PR TITLE
ci: upload each SARIF file with its own category

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -87,13 +87,48 @@ jobs:
           done < <(find app-phone app-tv core -type f -name "*.sarif" 2>/dev/null)
           ls -la sarif-reports/
 
-      - name: Upload SARIF to GitHub code scanning
+      # CodeQL Action v4 requires a unique category per SARIF run, so each file
+      # is uploaded on its own. See
+      # https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/
+      - name: Upload app-phone detekt SARIF
         if: always()
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: sarif-reports
-          category: watchbuddy-static-analysis
+          sarif_file: sarif-reports/app-phone-detekt.sarif
+          category: app-phone-detekt
+
+      - name: Upload app-phone lint SARIF
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: sarif-reports/app-phone-lint-results-debug.sarif
+          category: app-phone-lint
+
+      - name: Upload app-tv detekt SARIF
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: sarif-reports/app-tv-detekt.sarif
+          category: app-tv-detekt
+
+      - name: Upload app-tv lint SARIF
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: sarif-reports/app-tv-lint-results-debug.sarif
+          category: app-tv-lint
+
+      - name: Upload core detekt SARIF
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: sarif-reports/core-detekt.sarif
+          category: core-detekt
 
       - name: Archive analysis reports
         if: always()


### PR DESCRIPTION
## Summary

- CodeQL Action v4 (per the [2025-07-21 changelog](https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/)) now rejects SARIF payloads with multiple runs under the same category. Our `build-android.yml` was uploading all five module SARIFs (three detekt, two lint) in directory mode under one `watchbuddy-static-analysis` category, so the upload step failed and no findings reached GitHub code scanning — PRs had no inline detekt/lint annotations.
- Replaced the single directory upload with **one `upload-sarif` invocation per SARIF file**, each tagged with a unique `<module>-<tool>` category (`app-phone-detekt`, `app-phone-lint`, `app-tv-detekt`, `app-tv-lint`, `core-detekt`). Each step keeps `if: always()` + `continue-on-error: true` so a missing file or a single failed upload doesn't block the others.
- No changes to the `Collect SARIF reports`, `Archive analysis reports`, or `Post PR lint summary` steps — their code paths already produced stable per-module filenames that the new upload steps reference directly.

## Test plan

- [x] `./scripts/precommit.sh` — workflow-YAML syntax check passes locally.
- [ ] CI (`Test & Build`) goes green on this PR.
- [ ] Each of the five new upload steps shows a non-error status in the Actions UI; no "multiple SARIF runs with the same category" error.
- [ ] GitHub Security → Code scanning shows five distinct categories for this PR's head SHA: `app-phone-detekt`, `app-phone-lint`, `app-tv-detekt`, `app-tv-lint`, `core-detekt`.
- [ ] `<!-- watchbuddy-lint-report -->` PR comment still posts with per-module finding counts (unchanged code path).

> Note: sandbox environment has no Android SDK, so precommit skipped the Gradle scope. CI (`build-android.yml`) is the real gate for Kotlin/Android changes.

https://claude.ai/code/session_01QSi3cW1cZZ6fgGMHQ1883P

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSi3cW1cZZ6fgGMHQ1883P)_