### PR TITLE
chore(ci): bump setup-node@v6, cache@v5, github-script@v9, paths-filter@v4

### DIFF
--- a/.github/actions/setup-android-build/action.yml
+++ b/.github/actions/setup-android-build/action.yml
@@ -23,7 +23,7 @@ runs:
     # Key on all build scripts + properties so any structural change
     # invalidates and rebuilds the cache rather than serving a stale one.
     - name: Cache Gradle configuration cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: .gradle/configuration-cache
         key: config-cache-${{ hashFiles('**/*.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml') }}

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -24,7 +24,7 @@ jobs:
       android: ${{ steps.filter.outputs.android }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -145,7 +145,7 @@ jobs:
 
       - name: Post PR lint summary
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -258,7 +258,7 @@ jobs:
       # UI. See CLAUDE.md § "Monitoring PR checks & accessing build logs".
       - name: Post failing build log
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           MARKER: '<!-- watchbuddy-build-log -->'
           CURRENT_JOB: ${{ github.job }}

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -23,7 +23,7 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: 'npm'
@@ -67,7 +67,7 @@ jobs:
       # logs".
       - name: Post failing backend log
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           MARKER: '<!-- watchbuddy-backend-log -->'
           CURRENT_JOB: ${{ github.job }}


### PR DESCRIPTION
## Summary

Bumps four GitHub Actions that were trailing the current major per the April 2026 audit in #417. One PR, all version pins only — no workflow refactors.

| Action | Before | After | Files |
|---|---|---|---|
| `actions/setup-node` | v4 | **v6** | `test-backend.yml` |
| `actions/cache` | v4 | **v5** | `setup-android-build/action.yml` |
| `actions/github-script` | v8 | **v9** | `build-android.yml` (x2), `test-backend.yml` |
| `dorny/paths-filter` | v3 | **v4** | `build-android.yml`, `test-backend.yml` |

## Compatibility notes

- **`setup-node@v6`** — Node runtime pin (`node-version: '22'`) is unchanged; v6 still ships Node 22 as a valid target.
- **`cache@v5`** — Switched to a new cache service backend. v4 cache entries are **not readable across the major**, so the first CI run after merge will repopulate Gradle/npm caches from scratch (one cold run, no permanent regression).
- **`github-script@v9`** — Requires the Node 24 runner. All inline `script:` blocks in `build-android.yml` and `test-backend.yml` use only stable octokit surfaces (`github.rest.issues.{listComments,createComment,updateComment}`, `github.rest.actions.listJobsForWorkflowRun`, `github.request`, `github.paginate`, `core.warning`) that are unchanged in v9 — the three PR-comment upserters (`<!-- watchbuddy-lint-report -->`, `<!-- watchbuddy-build-log -->`, `<!-- watchbuddy-backend-log -->`) should behave identically.
- **`paths-filter@v4`** — Requires Node 20+ runner; filter syntax is unchanged from v3.

## Not bumped (intentional)

- `googleapis/release-please-action` — v5.0.0 exists but no `v5` major alias is published upstream yet. Will revisit once that stabilizes.

Other Actions already on current major: `actions/checkout@v6`, `actions/setup-java@v5`, `actions/upload-artifact@v7`, `googleapis/release-please-action@v4`, `gradle/actions/setup-gradle@v6`.

## Test plan

- [x] `./scripts/precommit.sh` — backend + workflow-YAML checks passed locally (Android SDK not present in this sandbox; Gradle scope deferred to CI per `CLAUDE.md` § Local pre-commit checks).
- [ ] `Test & Build` green on this PR (exercises `build-android.yml` + `paths-filter@v4` + `github-script@v9`).
- [ ] `Backend Tests` green on this PR (exercises `test-backend.yml` + `setup-node@v6` + `paths-filter@v4` + `github-script@v9`).
- [ ] If either check fails, the existing `<!-- watchbuddy-build-log -->` / `<!-- watchbuddy-backend-log -->` comment upserter confirms `github-script@v9` behavior.

Closes #417

https://claude.ai/code/session_01SWL5GyGZezfrdcWRh1paDk

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWL5GyGZezfrdcWRh1paDk)_