### PR TITLE
fix: include Android unit tests in README Code Statistics

### DIFF
--- a/scripts/update-readme-stats.sh
+++ b/scripts/update-readme-stats.sh
@@ -62,7 +62,10 @@ print(f"{summary.get('"'"'nFiles'"'"', 0)}\t{summary.get('"'"'code'"'"', 0)}")
 '
 }
 
-# Sum JUnit XML counts under <module>/**/build/test-results/test/*.xml.
+# Sum JUnit XML counts under <module>/**/build/test-results/testDebugUnitTest/*.xml.
+# The Android Gradle Plugin writes unit-test results per build variant
+# (testDebugUnitTest / testReleaseUnitTest); matching only the debug variant
+# avoids double-counting when `./gradlew test` runs both.
 # Output: "<tests>\t<failures>\t<errors>\t<skipped>"
 junit_counts() {
   local module="$1"
@@ -71,7 +74,7 @@ import glob, os, sys, xml.etree.ElementTree as ET
 
 module = sys.argv[1]
 total = failures = errors = skipped = 0
-pattern = os.path.join(module, "**", "build", "test-results", "test", "*.xml")
+pattern = os.path.join(module, "**", "build", "test-results", "testDebugUnitTest", "*.xml")
 for path in glob.glob(pattern, recursive=True):
     try:
         root = ET.parse(path).getroot()


### PR DESCRIPTION
## Summary

- The README "Code Statistics" table was rendering `—` in the Tests column for every Android module (`app-phone`, `app-tv`, `core`) while `backend` correctly reported 86.
- Root cause: `scripts/update-readme-stats.sh` globbed JUnit XML under `<module>/**/build/test-results/test/*.xml` — the pure-JVM Gradle convention. All three Android modules apply `com.android.library` / `com.android.application`, so AGP writes unit-test results to `build/test-results/testDebugUnitTest/` (and `testReleaseUnitTest/`) instead. The old glob matched zero files.
- Changed the glob to `testDebugUnitTest`, matching only the debug variant so we don't double-count when `./gradlew test` runs both variants. Updated the adjacent comment to match.

The next `stats.yml` run on `main` will regenerate the table with populated Android test counts. No other files needed to change: `stats.yml` already runs `./gradlew test` before invoking the script, and the `backend` path is unaffected (it branches to `jest_counts()` on module name).

## Test plan

- [ ] CI: `Test & Build` is green on this PR.
- [ ] After merge, the next `Refresh README code-statistics table` workflow run on `main` produces a follow-up commit updating `README.md` with non-zero test counts for `app-phone`, `app-tv`, `core` and an updated **Total**.
- [ ] `backend` row still shows 86 (regression check on the Jest path).

> Note: `scripts/precommit.sh` did not exercise Gradle/Kotlin checks on this change — `scripts/**` isn't in the CI `paths-filter`, so the script scope is empty and the hook skipped. No Kotlin/Gradle code was touched.

https://claude.ai/code/session_01K7KF76YWoBjwjVxktzRu5J

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7KF76YWoBjwjVxktzRu5J)_