### PR TITLE
chore(deps): bump ksp to 2.3.7 to match kotlin 2.3.21

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.2.0"
 kotlin = "2.3.21"
-ksp = "2.2.20-2.0.2"
+ksp = "2.3.7"
 hilt = "2.59.2"
 compose-bom = "2026.04.01"
 compose-tv = "1.0.1"


### PR DESCRIPTION
## Summary

- Bumps `ksp = "2.3.7"` in `gradle/libs.versions.toml` (was `2.2.20-2.0.2`, stale since Kotlin moved past 2.2.x).
- Clears the `ksp-2.2.20-2.0.2 is too old for kotlin-2.3.21` Gradle warning surfaced in recent CI runs.

## Context

Issue #425 coordinated the Kotlin 2.3.20 + KSP + serialization bump but closed before Kotlin rolled forward to 2.3.21, leaving KSP behind. KSP 2.3.x switched from the composite `<kotlin>-<ksp>` version scheme to a single-number scheme, so there is no `2.3.21-2.0.2` — `2.3.7` is the latest stable release and is forward-compatible with Kotlin 2.3.21 at the patch level.

- KSP release tag: https://github.com/google/ksp/releases/tag/2.3.7
- Maven Central artifact verified: `com.google.devtools.ksp:symbol-processing-api:2.3.7`
- Gradle plugin id `com.google.devtools.ksp` unchanged; only the version string moves.

## Sandbox pre-commit note

Per `CLAUDE.md`, the Claude-on-the-web sandbox has no Android SDK, so `scripts/precommit.sh` skipped the Gradle scope. CI `build-android.yml` is the real gate for this PR.

## Test plan

- [ ] `Test & Build` CI job green on this PR — confirms Hilt / Compose compiler KSP processors still run under the new KSP version against Kotlin 2.3.21, and the "too old for kotlin-2.3.21" warning is gone from the build log.

https://claude.ai/code/session_01SWgswx7LcTUajdLDcHAicp

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWgswx7LcTUajdLDcHAicp)_