### PR TITLE
ci: drop unused debug APK builds and shrink CI Gradle work

### DIFF
--- a/.github/actions/setup-android-build/action.yml
+++ b/.github/actions/setup-android-build/action.yml
@@ -1,10 +1,10 @@
 name: Setup Android Build
 description: >
   Composite action shared by build-android.yml and release.yml.
-  Configures JDK 17 (Temurin), sets up Gradle with caching, and warms
-  the Gradle configuration cache.  The calling workflow must check out
-  the repository before invoking this action (local composite actions
-  require the workspace to already be populated).
+  Configures JDK 17 (Temurin) and sets up Gradle with caching.
+  The calling workflow must check out the repository before invoking
+  this action (local composite actions require the workspace to already
+  be populated).
 
 runs:
   using: composite
@@ -15,16 +15,8 @@ runs:
         java-version: '17'
         distribution: 'temurin'
 
+    # setup-gradle manages Gradle's user home (caches, configuration cache,
+    # wrapper) via its built-in caching layer keyed on Gradle and build
+    # inputs; no supplementary actions/cache step is needed.
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v6
-
-    # The Gradle configuration cache serialises the task graph so subsequent
-    # runs with identical inputs skip the configuration phase entirely.
-    # Key on all build scripts + properties so any structural change
-    # invalidates and rebuilds the cache rather than serving a stale one.
-    - name: Cache Gradle configuration cache
-      uses: actions/cache@v5
-      with:
-        path: .gradle/configuration-cache
-        key: config-cache-${{ hashFiles('**/*.gradle.kts', 'gradle.properties', 'gradle/libs.versions.toml') }}
-        restore-keys: config-cache-

--- a/.github/scripts/append-download-links.sh
+++ b/.github/scripts/append-download-links.sh
@@ -19,12 +19,6 @@ DOWNLOADS="${DOWNLOADS}\n\n## Downloads\n"
 DOWNLOADS="${DOWNLOADS}\n| Asset | Link |"
 DOWNLOADS="${DOWNLOADS}\n|-------|------|"
 
-if [ -f "${ASSETS_DIR}/watchbuddy-phone-${VERSION}-debug.apk" ]; then
-    DOWNLOADS="${DOWNLOADS}\n| Phone (debug) | [watchbuddy-phone-${VERSION}-debug.apk](${BASE}/watchbuddy-phone-${VERSION}-debug.apk) |"
-fi
-if [ -f "${ASSETS_DIR}/watchbuddy-tv-${VERSION}-debug.apk" ]; then
-    DOWNLOADS="${DOWNLOADS}\n| TV (debug) | [watchbuddy-tv-${VERSION}-debug.apk](${BASE}/watchbuddy-tv-${VERSION}-debug.apk) |"
-fi
 if [ -f "${ASSETS_DIR}/watchbuddy-phone-${VERSION}-release.apk" ]; then
     DOWNLOADS="${DOWNLOADS}\n| Phone (signed APK) | [watchbuddy-phone-${VERSION}-release.apk](${BASE}/watchbuddy-phone-${VERSION}-release.apk) |"
 fi

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -47,21 +47,8 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-android-build
 
-      # Decode release keystore when available so debug APKs are signed with the
-      # same certificate as release APKs.  This prevents INSTALL_FAILED_UPDATE_INCOMPATIBLE
-      # when users upgrade between debug and release builds.
-      - name: Decode Keystore
-        id: keystore
-        run: |
-          if [ -n "${{ secrets.KEYSTORE_BASE64 }}" ]; then
-            echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > /tmp/release.keystore
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Run unit tests
-        run: ./gradlew test
+        run: ./gradlew testDebugUnitTest
 
       # Static analysis — detekt runs on every subproject; baselines commit the
       # accepted legacy findings. Any new finding fails the build.
@@ -224,33 +211,6 @@ jobs:
             } else {
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
-
-      - name: Build Phone and TV debug APKs (signed)
-        if: steps.keystore.outputs.available == 'true'
-        env:
-          VERSION_CODE: ${{ github.run_number }}
-          KEYSTORE_FILE: /tmp/release.keystore
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
-          TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
-          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-        run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
-
-      - name: Upload Phone APK
-        if: steps.keystore.outputs.available == 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: watchbuddy-phone-debug
-          path: app-phone/build/outputs/apk/debug/*.apk
-
-      - name: Upload TV APK
-        if: steps.keystore.outputs.available == 'true'
-        uses: actions/upload-artifact@v7
-        with:
-          name: watchbuddy-tv-debug
-          path: app-tv/build/outputs/apk/debug/*.apk
 
       # Surface a filtered failure excerpt from the failing job's raw log as
       # a PR comment keyed by the `<!-- watchbuddy-build-log -->` marker, so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,9 @@ jobs:
           fi
 
       # -- Signed release builds (APK + AAB) ------------------------------
-      - name: Build signed Phone release (APK + AAB)
+      # Build phone + TV in a single Gradle invocation so the `core` module
+      # compiles once and the task graph is resolved once.
+      - name: Build signed Phone + TV release (APK + AAB)
         if: steps.keystore.outputs.available == 'true'
         env:
           KEYSTORE_FILE: /tmp/release.keystore
@@ -74,47 +76,12 @@ jobs:
           TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
           TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
-        run: ./gradlew :app-phone:assembleRelease :app-phone:bundleRelease
-
-      - name: Build signed TV release (APK + AAB)
-        if: steps.keystore.outputs.available == 'true'
-        env:
-          KEYSTORE_FILE: /tmp/release.keystore
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          VERSION_NAME: ${{ needs.release-please.outputs.version }}
-          VERSION_CODE: ${{ github.run_number }}
-          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
-          TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
-        run: ./gradlew :app-tv:assembleRelease :app-tv:bundleRelease
-
-      # -- Signed debug APKs (only when keystore is available) ---------------
-      - name: Build debug APKs (signed)
-        if: steps.keystore.outputs.available == 'true'
-        env:
-          VERSION_NAME: ${{ needs.release-please.outputs.version }}
-          VERSION_CODE: ${{ github.run_number }}
-          KEYSTORE_FILE: /tmp/release.keystore
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
-          TOKEN_BACKEND_URL: ${{ secrets.TOKEN_BACKEND_URL }}
-        run: ./gradlew :app-phone:assembleDebug :app-tv:assembleDebug
+        run: ./gradlew :app-phone:assembleRelease :app-phone:bundleRelease :app-tv:assembleRelease :app-tv:bundleRelease
 
       # -- Collect release artifacts ---------------------------------------
       - name: Collect release artifacts
         run: |
           mkdir -p release-assets
-
-          # Signed debug APKs (only present when keystore was available)
-          for apk in app-phone/build/outputs/apk/debug/*.apk; do
-            [ -f "$apk" ] && cp "$apk" "release-assets/watchbuddy-phone-${VERSION}-debug.apk"
-          done
-          for apk in app-tv/build/outputs/apk/debug/*.apk; do
-            [ -f "$apk" ] && cp "$apk" "release-assets/watchbuddy-tv-${VERSION}-debug.apk"
-          done
 
           # Release APKs (when available)
           for apk in app-phone/build/outputs/apk/release/*.apk; do

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y cloc
 
       - name: Run Gradle tests (populate JUnit XML)
-        run: ./gradlew test
+        run: ./gradlew testDebugUnitTest
 
       - name: Run backend tests (populate Jest summary)
         run: |


### PR DESCRIPTION
## Summary

Trim wasted build work from the Android CI and release workflows. The `Test & Build` job was building + uploading signed debug APKs on every PR / main push even though nothing downstream installs them, `release.yml` was re-resolving the Gradle task graph and recompiling `core` across three separate invocations, and every CI run was re-running the same Kotlin tests under both debug **and** release variants.

- **`build-android.yml`** — remove the keystore-decode and signed-debug-APK build/upload steps. Compilation is already exercised by `./gradlew testDebugUnitTest`, `detektAll`, and `:app-phone:lintDebug :app-tv:lintDebug`, so the APKs were pure waste. Also switch `./gradlew test` → `./gradlew testDebugUnitTest`; debug and release test sources are identical here.
- **`stats.yml`** — same `testDebugUnitTest` switch. The stats script (`scripts/update-readme-stats.sh`) already only reads the debug-variant JUnit XML.
- **`release.yml`** — drop the debug-APK build and the `release-assets/*-debug.apk` copy logic. Release consumers install signed release builds via Play Store or the signed-release APKs attached to the GitHub Release; debug builds on a tagged release were confusing and cost ~5-10 min of Gradle time per release. Also merge the separate phone/TV release-build Gradle invocations into one so `core` compiles once.
- **`append-download-links.sh`** — drop the "Phone (debug)" / "TV (debug)" rows that referenced assets that are no longer produced.
- **`setup-android-build/action.yml`** — remove the custom `actions/cache` for `.gradle/configuration-cache`. `gradle/actions/setup-gradle@v6` already manages the full Gradle user home including the config cache, so the step was duplicate work on restore/save.

Expected impact: ~5-8 min off every `Test & Build` run and ~8-12 min off each release publish, with no loss of CI gating coverage.

## Test plan

- [ ] This PR's own `Test & Build` run stays green and completes faster than recent main runs of the same workflow.
- [ ] CI still posts the `<!-- watchbuddy-lint-report -->` static-analysis summary comment.
- [ ] No `watchbuddy-phone-debug` / `watchbuddy-tv-debug` artifacts appear in the Actions run summary.
- [ ] On the next tagged release, `release.yml` runs a single Gradle invocation for signed APKs + AABs, `release-assets/` contains no `*-debug.apk`, and the Play Store upload + GitHub Release attachment (release APKs, AABs, native-debug-symbols, mapping.txt) still succeed.
- [ ] Appended release-notes "Downloads" table no longer lists phone/TV (debug) rows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GELj6ABFFk2EddzdbSN1LG)_