### PR TITLE
chore: bump compileSdk from 36 to 37

### DIFF
--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 
 android {
     namespace = "com.justb81.watchbuddy"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.justb81.watchbuddy"

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "com.justb81.watchbuddy"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.justb81.watchbuddy"   // same package as phone app!

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.justb81.watchbuddy.core"
-    compileSdk = 36
+    compileSdk = 37
 
     buildFeatures {
         buildConfig = true


### PR DESCRIPTION
## Summary

- Bumps `compileSdk` from **36** (Android 16) to **37** (Android 17) in all three Android modules: `app-phone`, `app-tv`, `core`.
- `targetSdk` (35) and `minSdk` (34 phone / 31 TV+core) are intentionally **left untouched** — bumping `targetSdk` pulls in runtime behaviour changes (FGS type tightening, photo-picker updates, etc.) and belongs in a separate PR.
- No changes to `gradle/libs.versions.toml`: AGP 9.2.0 + Kotlin 2.3.21 + Compose BOM 2026.04.01 are already recent enough to target API 37.
- No other files in the repo reference `compileSdk` or a hard-coded SDK platform version, and no CI workflow / composite action pins an SDK platform (`setup-android-build/action.yml` delegates platform provisioning to AGP's auto-download).

## Files changed

| File | Line | Change |
|------|------|--------|
| `app-phone/build.gradle.kts` | 15 | `compileSdk = 36` → `compileSdk = 37` |
| `app-tv/build.gradle.kts`    | 11 | `compileSdk = 36` → `compileSdk = 37` |
| `core/build.gradle.kts`      | 10 | `compileSdk = 36` → `compileSdk = 37` |

## Local pre-commit skip notice

This branch was built in a sandboxed Claude Code on the web environment without the Android SDK. `./scripts/precommit.sh` detected the missing SDK and **skipped the Gradle scope** (test / detektAll / lintDebug) with a yellow warning, per the documented policy in `CLAUDE.md` § Local pre-commit checks. Backend and workflow-YAML scopes were not triggered (no matching files changed). **CI (`build-android.yml`) is the real gate for this change** — treat a red `Test & Build` check as a blocker.

## Possible follow-up: lint baselines

`app-tv/lint-baseline.xml:50` currently records a stale `compileSdk 35 available: 36` warning. After the bump, Android Lint may either auto-resolve it or emit a new `36 available: 37` entry. If `:app-tv:lintDebug` (or `:app-phone:lintDebug`) fails CI because of a new finding beyond the baseline, regenerate with `./gradlew :app-phone:updateLintBaseline :app-tv:updateLintBaseline` and amend this PR.

## Possible follow-up: CI SDK install

If AGP fails to auto-download the API 37 platform on the CI runner, the remediation is a one-line `sdkmanager "platforms;android-37"` step in `.github/actions/setup-android-build/action.yml`. Not added pre-emptively — waiting for CI to tell us whether it's needed.

## Test plan

- [ ] `Test & Build` check (`build-android.yml`) passes on this PR
- [ ] `Backend Tests` check passes (path filter should skip it — Kotlin-only change)
- [ ] No new detekt / Android Lint findings beyond baselines in the PR summary comment (`<!-- watchbuddy-lint-report -->`)
- [ ] Squash-merge and delete branch once green

https://claude.ai/code/session_01D8U3XQ1yBmqbZQbAP6hYok

---
_Generated by [Claude Code](https://claude.ai/code/session_01D8U3XQ1yBmqbZQbAP6hYok)_