### PR TITLE
fix: use connectedDevice FGS type for companion services

### DIFF
--- a/app-phone/src/main/AndroidManifest.xml
+++ b/app-phone/src/main/AndroidManifest.xml
@@ -23,7 +23,15 @@
 
     <!-- Background work (model updates, token refresh) -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <!-- DATA_SYNC: WorkManager's SystemForegroundService runs ModelDownloadWorker
+         as a time-bounded dataSync FGS; keep this permission for that worker.
+         CONNECTED_DEVICE: CompanionService maintains long-lived P2P connectivity
+         with the paired TV (BLE advert + Ktor HTTP server) and must use the
+         connectedDevice type on Android 15/16 to avoid the dataSync 6 h/24 h
+         quota that was killing the service with ForegroundServiceDidNotStop-
+         InTimeException (#459). -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <!-- Play Store: phone app — NOT a TV app. Touchscreen not strictly required
@@ -80,12 +88,16 @@
                 android:resource="@xml/provider_paths" />
         </provider>
 
-        <!-- Companion HTTP server (BLE advertiser + Ktor) -->
+        <!-- Companion HTTP server (BLE advertiser + Ktor). Declared as
+             `connectedDevice` — not `dataSync` — because the service maintains
+             long-lived P2P connectivity with the paired TV. Android 15/16 time-
+             box `dataSync` FGS at ~6 h/24 h which was crashing the service with
+             ForegroundServiceDidNotStopInTimeException (#459). -->
         <service
             android:name=".service.CompanionService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="dataSync" />
+            android:foregroundServiceType="connectedDevice" />
 
         <!-- WorkManager foreground service — required for long-running downloads on Android 10+.
              Merges with WorkManager's own SystemForegroundService manifest entry to declare

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
@@ -76,7 +77,11 @@ class CompanionService : Service() {
         super.onCreate()
         DiagnosticLog.event(TAG, "onCreate")
         ensureNotificationChannel()
-        startForeground(NOTIFICATION_ID, buildNotification())
+        startForeground(
+            NOTIFICATION_ID,
+            buildNotification(),
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+        )
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -22,7 +22,10 @@
          activity hasn't been opened yet. -->
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <!-- TvDiscoveryService maintains long-lived BLE scanning + heartbeat polling
+         against paired phones and must use the connectedDevice FGS type to
+         avoid the Android 15/16 dataSync time quota (#459). -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <!-- Scrobble detection — WatchBuddyNotificationListener is declared as a
@@ -108,13 +111,16 @@
 
         <!-- Background phone discovery service. Runs the BLE scanner when
              "Autostart at TV boot" is enabled so new phones are picked up
-             without the user opening the launcher first. Uses `dataSync`
-             foreground service type to match the phone-side CompanionService. -->
+             without the user opening the launcher first. Declared as
+             `connectedDevice` — the service holds a long-lived connection to
+             the paired phone (BLE scan + /capability heartbeat). `dataSync`
+             would be wrong here because Android 15/16 time-boxes that type at
+             ~6 h/24 h and kills the service (#459). -->
         <service
             android:name=".tv.discovery.TvDiscoveryService"
             android:enabled="true"
             android:exported="false"
-            android:foregroundServiceType="dataSync" />
+            android:foregroundServiceType="connectedDevice" />
 
         <!-- BOOT_COMPLETED receiver — gated on `isAutostartEnabled` preference.
              Must be exported=true: system broadcasts originate from the

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/TvDiscoveryService.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/TvDiscoveryService.kt
@@ -7,6 +7,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.ComponentName
 import android.content.Intent
+import android.content.pm.ServiceInfo
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -49,7 +50,11 @@ class TvDiscoveryService : Service() {
     override fun onCreate() {
         super.onCreate()
         ensureNotificationChannel()
-        startForeground(NOTIFICATION_ID, buildNotification())
+        startForeground(
+            NOTIFICATION_ID,
+            buildNotification(),
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+        )
         DiagnosticLog.event(TAG, "service created")
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,6 +205,16 @@ swipes the app from recents.
 is already true the start is skipped, and `CompanionHttpServer.start()` additionally guards against
 double-binding Netty.
 
+**Foreground service type:** Both `CompanionService` (phone) and `TvDiscoveryService` (TV) run as
+`connectedDevice` foreground services — **not** `dataSync`. The service maintains long-lived P2P
+connectivity with a paired device (BLE advert / scan + Ktor HTTP heartbeat), which is exactly what
+`connectedDevice` is intended for. Android 15/16 time-box `dataSync` FGS at ~6 h per 24 h and kill
+the service with `ForegroundServiceDidNotStopInTimeException` once the quota is exhausted, which
+was crashing the app on Android 16 devices (#459). The runtime `startForeground(id, notification,
+type)` call must pass `ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE` so it matches the
+manifest declaration on Android 14+. The `connectedDevice` type is authorised by the existing
+`BLUETOOTH_ADVERTISE` (phone) / `BLUETOOTH_SCAN` (TV) permissions.
+
 ## Presence Heartbeat (TV)
 
 The TV's `PhoneDiscoveryManager` runs a heartbeat coroutine every 60 seconds that re-fetches


### PR DESCRIPTION
## Summary

On Android 16 (SDK 36), `CompanionService` (phone) was crashing with `ForegroundServiceDidNotStopInTimeException` and then `ForegroundServiceStartNotAllowedException: "Time limit already exhausted for foreground service type dataSync"`. Both services declared `android:foregroundServiceType="dataSync"`, but `dataSync` is time-boxed at ~6 h per 24 h on Android 15/16 — the wrong semantic for a long-lived P2P link with a paired device.

This PR changes the foreground service type from `dataSync` to `connectedDevice` for both `CompanionService` (phone) and `TvDiscoveryService` (TV), which removes the time quota and matches the actual purpose of each service (BLE advertise/scan + HTTP heartbeat between the phone and the paired TV). The `BLUETOOTH_ADVERTISE` (phone) and `BLUETOOTH_SCAN` (TV) permissions already qualify the services for this type.

- `app-phone/src/main/AndroidManifest.xml` — add `FOREGROUND_SERVICE_CONNECTED_DEVICE` permission, keep `FOREGROUND_SERVICE_DATA_SYNC` (still used by `ModelDownloadWorker`/`SystemForegroundService`), flip `CompanionService` FGS type.
- `app-tv/src/main/AndroidManifest.xml` — swap `FOREGROUND_SERVICE_DATA_SYNC` → `FOREGROUND_SERVICE_CONNECTED_DEVICE`, flip `TvDiscoveryService` FGS type.
- `CompanionService.kt` / `TvDiscoveryService.kt` — call the 3-arg `startForeground(id, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE)` so the runtime type matches the manifest on Android 14+.
- `docs/architecture.md` — document the FGS type choice under § "Companion Service Lifecycle".

Closes #459

## Test plan

- [ ] CI `Test & Build` and `Backend Tests` are green.
- [ ] On a real Android 16 device, enable "I am watching TV" and leave the service running for > 6 h — confirm no `ForegroundServiceDidNotStopInTimeException` crash dumps appear under `filesDir/diagnostics/`.
- [ ] `adb shell dumpsys activity services | grep -A 2 CompanionService` reports `foregroundServiceType=CONNECTED_DEVICE` rather than `DATA_SYNC`.
- [ ] Toggle Wi-Fi off/on while the companion service is running — BLE advertiser cycles via the existing 3 s grace path without restart loops.
- [ ] TV: reboot with autostart enabled, confirm `TvDiscoveryService` stays alive past 6 h.

## Notes

- `scripts/precommit.sh` printed its yellow "SDK missing — Gradle scope skipped" notice in the agent sandbox; CI `build-android.yml` is the authoritative gate for Android Lint / detekt / unit tests.
- `ModelDownloadWorker` keeps `FOREGROUND_SERVICE_TYPE_DATA_SYNC` (legitimate time-bounded download), and the merged `SystemForegroundService` manifest entry is unchanged.

https://claude.ai/code/session_01NtqqypU1JL43ZVYVD3tDkJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtqqypU1JL43ZVYVD3tDkJ)_