### PR TITLE
chore(backend): sync package-lock.json with engines.node >=24

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,7 +24,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=24"
       }
     },
     "node_modules/@emnapi/core": {


### PR DESCRIPTION
Follow-up to #462 (commit c9f6244). When `engines.node` was bumped in `backend/package.json` from `>=22` to `>=24`, the corresponding field in `backend/package-lock.json` was not regenerated in time to be part of the original PR. This one-line change syncs it — otherwise `npm install` emits an `EBADENGINE` warning on Node 24 runners because the top-level package entry in the lockfile still advertises `>=22`.

## Test plan

- [ ] `Backend Tests` green on Node 24.

https://claude.ai/code/session_019xAvfPa2yBMZ6w8cC5ErDy

---
_Generated by [Claude Code](https://claude.ai/code/session_019xAvfPa2yBMZ6w8cC5ErDy)_