### PR TITLE
feat(tv-diagnostics): show full MediaSession snapshot and scrobble null-TITLE sessions

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -426,70 +426,53 @@ private fun formatLastCandidate(last: MediaSessionScrobbler.LastCandidate?): Str
 @Composable
 private fun MediaSessionSection(last: MediaSessionScrobbler.LastObservedSession?) {
     val title = stringResource(R.string.tv_diagnostics_section_media_session)
-    val nullPlaceholder = stringResource(R.string.tv_diagnostics_value_null)
-    val emPlaceholder = "—"
     val snapshot = last?.snapshot
-    val anyFieldPresent = snapshot != null && snapshot.candidateStrings().isNotEmpty()
     val headerStatus = when {
         last == null -> Status.NEUTRAL
-        anyFieldPresent -> Status.OK
+        snapshot != null && snapshot.candidateStrings().isNotEmpty() -> Status.OK
         else -> Status.WARN
     }
+    val rows = buildMediaSessionRows(last, headerStatus)
+    DiagnosticsSection(title = title, rows = rows)
+}
 
-    val rows = listOf(
+@Composable
+private fun buildMediaSessionRows(
+    last: MediaSessionScrobbler.LastObservedSession?,
+    headerStatus: Status,
+): List<DiagRow> {
+    val em = "—"
+    val snapshot = last?.snapshot
+    return listOf(
         DiagRow(
             stringResource(R.string.tv_diagnostics_row_media_session_package),
-            snapshot?.packageName ?: emPlaceholder,
+            snapshot?.packageName ?: em,
             headerStatus,
         ),
-        DiagRow(
-            stringResource(R.string.tv_diagnostics_row_media_session_title),
-            snapshot?.title ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
-            fieldStatus(snapshot?.title, snapshot != null),
+        stringRow(R.string.tv_diagnostics_row_media_session_title, snapshot, snapshot?.title),
+        stringRow(R.string.tv_diagnostics_row_media_session_display_title, snapshot, snapshot?.displayTitle),
+        stringRow(R.string.tv_diagnostics_row_media_session_display_subtitle, snapshot, snapshot?.displaySubtitle),
+        stringRow(
+            R.string.tv_diagnostics_row_media_session_display_description,
+            snapshot,
+            snapshot?.displayDescription,
         ),
-        DiagRow(
-            stringResource(R.string.tv_diagnostics_row_media_session_display_title),
-            snapshot?.displayTitle ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
-            fieldStatus(snapshot?.displayTitle, snapshot != null),
-        ),
-        DiagRow(
-            stringResource(R.string.tv_diagnostics_row_media_session_display_subtitle),
-            snapshot?.displaySubtitle ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
-            fieldStatus(snapshot?.displaySubtitle, snapshot != null),
-        ),
-        DiagRow(
-            stringResource(R.string.tv_diagnostics_row_media_session_display_description),
-            snapshot?.displayDescription ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
-            fieldStatus(snapshot?.displayDescription, snapshot != null),
-        ),
-        DiagRow(
-            stringResource(R.string.tv_diagnostics_row_media_session_artist),
-            snapshot?.artist ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
-            fieldStatus(snapshot?.artist, snapshot != null),
-        ),
-        DiagRow(
-            stringResource(R.string.tv_diagnostics_row_media_session_album_artist),
-            snapshot?.albumArtist ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
-            fieldStatus(snapshot?.albumArtist, snapshot != null),
-        ),
-        DiagRow(
-            stringResource(R.string.tv_diagnostics_row_media_session_album),
-            snapshot?.album ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
-            fieldStatus(snapshot?.album, snapshot != null),
-        ),
+        stringRow(R.string.tv_diagnostics_row_media_session_artist, snapshot, snapshot?.artist),
+        stringRow(R.string.tv_diagnostics_row_media_session_album_artist, snapshot, snapshot?.albumArtist),
+        stringRow(R.string.tv_diagnostics_row_media_session_album, snapshot, snapshot?.album),
         DiagRow(
             stringResource(R.string.tv_diagnostics_row_media_session_playback_state),
-            last?.playbackState?.toString() ?: emPlaceholder,
+            last?.playbackState?.toString() ?: em,
             Status.NEUTRAL,
         ),
         DiagRow(
             stringResource(R.string.tv_diagnostics_row_media_session_position),
-            last?.positionMs?.let { "${it}ms" } ?: emPlaceholder,
+            last?.positionMs?.let { "${it}ms" } ?: em,
             Status.NEUTRAL,
         ),
         DiagRow(
             stringResource(R.string.tv_diagnostics_row_media_session_duration),
-            last?.durationMs?.let { "${it}ms" } ?: emPlaceholder,
+            last?.durationMs?.let { "${it}ms" } ?: em,
             Status.NEUTRAL,
         ),
         DiagRow(
@@ -498,10 +481,23 @@ private fun MediaSessionSection(last: MediaSessionScrobbler.LastObservedSession?
             Status.NEUTRAL,
         ),
     )
-    DiagnosticsSection(title = title, rows = rows)
 }
 
-private fun fieldStatus(value: String?, sessionObserved: Boolean): Status {
-    if (!sessionObserved) return Status.NEUTRAL
-    return if (value.isNullOrBlank()) Status.WARN else Status.OK
+@Composable
+private fun stringRow(
+    labelRes: Int,
+    snapshot: com.justb81.watchbuddy.core.model.MediaMetadataSnapshot?,
+    value: String?,
+): DiagRow {
+    val display = when {
+        value != null -> value
+        snapshot == null -> "—"
+        else -> stringResource(R.string.tv_diagnostics_value_null)
+    }
+    val status = when {
+        snapshot == null -> Status.NEUTRAL
+        value.isNullOrBlank() -> Status.WARN
+        else -> Status.OK
+    }
+    return DiagRow(stringResource(labelRes), display, status)
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -132,6 +132,10 @@ fun TvDiagnosticsScreen(
             }
 
             item {
+                MediaSessionSection(uiState.lastObservedSession)
+            }
+
+            item {
                 Text(
                     text = stringResource(R.string.tv_diagnostics_section_phones).uppercase(),
                     fontSize = 14.sp,
@@ -417,4 +421,87 @@ private fun formatLastCandidate(last: MediaSessionScrobbler.LastCandidate?): Str
     val pct = (last.candidate.confidence * 100).toInt()
     val marker = if (last.autoScrobbled) "auto" else "overlay"
     return "$title @ ${pct}% · $marker · ${formatAge(last.observedAtMs)}"
+}
+
+@Composable
+private fun MediaSessionSection(last: MediaSessionScrobbler.LastObservedSession?) {
+    val title = stringResource(R.string.tv_diagnostics_section_media_session)
+    val nullPlaceholder = stringResource(R.string.tv_diagnostics_value_null)
+    val emPlaceholder = "—"
+    val snapshot = last?.snapshot
+    val anyFieldPresent = snapshot != null && snapshot.candidateStrings().isNotEmpty()
+    val headerStatus = when {
+        last == null -> Status.NEUTRAL
+        anyFieldPresent -> Status.OK
+        else -> Status.WARN
+    }
+
+    val rows = listOf(
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_media_session_package),
+            snapshot?.packageName ?: emPlaceholder,
+            headerStatus,
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_media_session_title),
+            snapshot?.title ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
+            fieldStatus(snapshot?.title, snapshot != null),
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_media_session_display_title),
+            snapshot?.displayTitle ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
+            fieldStatus(snapshot?.displayTitle, snapshot != null),
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_media_session_display_subtitle),
+            snapshot?.displaySubtitle ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
+            fieldStatus(snapshot?.displaySubtitle, snapshot != null),
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_media_session_display_description),
+            snapshot?.displayDescription ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
+            fieldStatus(snapshot?.displayDescription, snapshot != null),
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_media_session_artist),
+            snapshot?.artist ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
+            fieldStatus(snapshot?.artist, snapshot != null),
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_media_session_album_artist),
+            snapshot?.albumArtist ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
+            fieldStatus(snapshot?.albumArtist, snapshot != null),
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_media_session_album),
+            snapshot?.album ?: if (snapshot == null) emPlaceholder else nullPlaceholder,
+            fieldStatus(snapshot?.album, snapshot != null),
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_media_session_playback_state),
+            last?.playbackState?.toString() ?: emPlaceholder,
+            Status.NEUTRAL,
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_media_session_position),
+            last?.positionMs?.let { "${it}ms" } ?: emPlaceholder,
+            Status.NEUTRAL,
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_media_session_duration),
+            last?.durationMs?.let { "${it}ms" } ?: emPlaceholder,
+            Status.NEUTRAL,
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_media_session_observed_age),
+            formatAge(last?.observedAtMs ?: 0L),
+            Status.NEUTRAL,
+        ),
+    )
+    DiagnosticsSection(title = title, rows = rows)
+}
+
+private fun fieldStatus(value: String?, sessionObserved: Boolean): Status {
+    if (!sessionObserved) return Status.NEUTRAL
+    return if (value.isNullOrBlank()) Status.WARN else Status.OK
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
@@ -28,6 +28,7 @@ data class TvDiagnosticsUiState(
     val notificationAccessGranted: Boolean = false,
     val scrobblerListening: Boolean = false,
     val lastCandidate: MediaSessionScrobbler.LastCandidate? = null,
+    val lastObservedSession: MediaSessionScrobbler.LastObservedSession? = null,
     val recentEvents: List<DiagnosticLog.Entry> = emptyList(),
     val versionName: String = BuildConfig.VERSION_NAME,
     val versionCode: Int = BuildConfig.VERSION_CODE,
@@ -58,7 +59,8 @@ class TvDiagnosticsViewModel @Inject constructor(
         val scrobbleState = combine(
             scrobbler.isListening,
             scrobbler.lastCandidate,
-        ) { listening, last -> listening to last }
+            scrobbler.lastObservedSession,
+        ) { listening, last, observed -> Triple(listening, last, observed) }
 
         viewModelScope.launch {
             combine(discoveryState, discoveryTail, scrobbleState) { a, b, s ->
@@ -71,6 +73,7 @@ class TvDiagnosticsViewModel @Inject constructor(
                     notificationAccessGranted = _uiState.value.notificationAccessGranted,
                     scrobblerListening = s.first,
                     lastCandidate = s.second,
+                    lastObservedSession = s.third,
                 )
             }.collect { snapshot ->
                 _uiState.update {

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -124,6 +124,20 @@
     <string name="tv_diagnostics_value_no_phones">Noch keine Telefone gefunden.</string>
     <string name="tv_diagnostics_section_recent_events">Letzte Ereignisse</string>
     <string name="tv_diagnostics_value_no_events">Noch keine Ereignisse</string>
+    <string name="tv_diagnostics_section_media_session">Letzte Mediensitzung</string>
+    <string name="tv_diagnostics_row_media_session_package">Paket</string>
+    <string name="tv_diagnostics_row_media_session_title">Titel</string>
+    <string name="tv_diagnostics_row_media_session_display_title">Anzeigetitel</string>
+    <string name="tv_diagnostics_row_media_session_display_subtitle">Anzeige-Untertitel</string>
+    <string name="tv_diagnostics_row_media_session_display_description">Anzeigebeschreibung</string>
+    <string name="tv_diagnostics_row_media_session_artist">Künstler</string>
+    <string name="tv_diagnostics_row_media_session_album_artist">Albumkünstler</string>
+    <string name="tv_diagnostics_row_media_session_album">Album</string>
+    <string name="tv_diagnostics_row_media_session_playback_state">Wiedergabestatus</string>
+    <string name="tv_diagnostics_row_media_session_position">Position</string>
+    <string name="tv_diagnostics_row_media_session_duration">Dauer</string>
+    <string name="tv_diagnostics_row_media_session_observed_age">Beobachtet</string>
+    <string name="tv_diagnostics_value_null">(null)</string>
 
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (Build %2$d)</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -128,6 +128,20 @@
     <string name="tv_diagnostics_value_no_phones">No se han encontrado teléfonos.</string>
     <string name="tv_diagnostics_section_recent_events">Eventos recientes</string>
     <string name="tv_diagnostics_value_no_events">Sin eventos aún</string>
+    <string name="tv_diagnostics_section_media_session">Última sesión multimedia</string>
+    <string name="tv_diagnostics_row_media_session_package">Paquete</string>
+    <string name="tv_diagnostics_row_media_session_title">Título</string>
+    <string name="tv_diagnostics_row_media_session_display_title">Título mostrado</string>
+    <string name="tv_diagnostics_row_media_session_display_subtitle">Subtítulo mostrado</string>
+    <string name="tv_diagnostics_row_media_session_display_description">Descripción mostrada</string>
+    <string name="tv_diagnostics_row_media_session_artist">Artista</string>
+    <string name="tv_diagnostics_row_media_session_album_artist">Artista del álbum</string>
+    <string name="tv_diagnostics_row_media_session_album">Álbum</string>
+    <string name="tv_diagnostics_row_media_session_playback_state">Estado de reproducción</string>
+    <string name="tv_diagnostics_row_media_session_position">Posición</string>
+    <string name="tv_diagnostics_row_media_session_duration">Duración</string>
+    <string name="tv_diagnostics_row_media_session_observed_age">Observado</string>
+    <string name="tv_diagnostics_value_null">(null)</string>
 
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -128,6 +128,20 @@
     <string name="tv_diagnostics_value_no_phones">Aucun téléphone détecté.</string>
     <string name="tv_diagnostics_section_recent_events">Événements récents</string>
     <string name="tv_diagnostics_value_no_events">Aucun événement</string>
+    <string name="tv_diagnostics_section_media_session">Dernière session média</string>
+    <string name="tv_diagnostics_row_media_session_package">Paquet</string>
+    <string name="tv_diagnostics_row_media_session_title">Titre</string>
+    <string name="tv_diagnostics_row_media_session_display_title">Titre affiché</string>
+    <string name="tv_diagnostics_row_media_session_display_subtitle">Sous-titre affiché</string>
+    <string name="tv_diagnostics_row_media_session_display_description">Description affichée</string>
+    <string name="tv_diagnostics_row_media_session_artist">Artiste</string>
+    <string name="tv_diagnostics_row_media_session_album_artist">Artiste de l\'album</string>
+    <string name="tv_diagnostics_row_media_session_album">Album</string>
+    <string name="tv_diagnostics_row_media_session_playback_state">État de lecture</string>
+    <string name="tv_diagnostics_row_media_session_position">Position</string>
+    <string name="tv_diagnostics_row_media_session_duration">Durée</string>
+    <string name="tv_diagnostics_row_media_session_observed_age">Observé</string>
+    <string name="tv_diagnostics_value_null">(null)</string>
 
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -124,6 +124,20 @@
     <string name="tv_diagnostics_value_no_phones">No phones discovered yet.</string>
     <string name="tv_diagnostics_section_recent_events">Recent events</string>
     <string name="tv_diagnostics_value_no_events">No events yet</string>
+    <string name="tv_diagnostics_section_media_session">Last media session</string>
+    <string name="tv_diagnostics_row_media_session_package">Package</string>
+    <string name="tv_diagnostics_row_media_session_title">Title</string>
+    <string name="tv_diagnostics_row_media_session_display_title">Display title</string>
+    <string name="tv_diagnostics_row_media_session_display_subtitle">Display subtitle</string>
+    <string name="tv_diagnostics_row_media_session_display_description">Display description</string>
+    <string name="tv_diagnostics_row_media_session_artist">Artist</string>
+    <string name="tv_diagnostics_row_media_session_album_artist">Album artist</string>
+    <string name="tv_diagnostics_row_media_session_album">Album</string>
+    <string name="tv_diagnostics_row_media_session_playback_state">Playback state</string>
+    <string name="tv_diagnostics_row_media_session_position">Position</string>
+    <string name="tv_diagnostics_row_media_session_duration">Duration</string>
+    <string name="tv_diagnostics_row_media_session_observed_age">Observed</string>
+    <string name="tv_diagnostics_value_null">(null)</string>
 
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -100,6 +100,7 @@ class MediaSessionScrobbler @Inject constructor(
     val lastCandidate: StateFlow<LastCandidate?> = _lastCandidate.asStateFlow()
 
     private val _lastObservedSession = MutableStateFlow<LastObservedSession?>(null)
+
     /**
      * Most recent `MediaSession` polled, regardless of match outcome. Populated
      * on every poll tick that encounters at least one session, so the diagnostics
@@ -654,9 +655,10 @@ class MediaSessionScrobbler @Inject constructor(
             currentlySessionKey = null
             return
         }
-        val candidate = matchSnapshot(snapshot) ?: return
-        val show = candidate.matchedShow ?: return
-        val episode = candidate.matchedEpisode ?: return
+        val candidate = matchSnapshot(snapshot)
+        val show = candidate?.matchedShow
+        val episode = candidate?.matchedEpisode
+        if (show == null || episode == null) return
         scrobbleDispatcher.dispatchStop(show, episode, progress)
         currentlySessionKey = null
         Log.i(TAG, "Scrobble stopped: ${show.title} S${episode.season}E${episode.number}")

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -58,6 +58,31 @@ class MediaSessionScrobbler @Inject constructor(
         val autoScrobbled: Boolean,
     )
 
+    /**
+     * Full dump of the most recent `MediaSession` the scrobbler polled, regardless
+     * of whether it produced a scrobble candidate. Intended for the TV diagnostics
+     * view so the user can see exactly which `MediaMetadata` fields the streaming
+     * app published — `METADATA_KEY_TITLE` is frequently null on Plex, Jellyfin,
+     * and some Netflix skins, so surfacing only the title row hides everything.
+     */
+    data class LastObservedSession(
+        val snapshot: MediaMetadataSnapshot,
+        val playbackState: Int,
+        val positionMs: Long,
+        val durationMs: Long,
+        val observedAtMs: Long,
+    )
+
+    /**
+     * Per-session progress snapshot kept around so `reconcileVanished` can dispatch
+     * an implicit stop using the full [MediaMetadataSnapshot] (not just the title)
+     * when the session disappears without transitioning through `STATE_STOPPED`.
+     */
+    internal data class LastKnownProgress(
+        val snapshot: MediaMetadataSnapshot?,
+        val progress: Float,
+    )
+
     private val _pendingConfirmation = MutableSharedFlow<ScrobbleCandidate>()
     val pendingConfirmation: SharedFlow<ScrobbleCandidate> = _pendingConfirmation
 
@@ -74,10 +99,19 @@ class MediaSessionScrobbler @Inject constructor(
      */
     val lastCandidate: StateFlow<LastCandidate?> = _lastCandidate.asStateFlow()
 
+    private val _lastObservedSession = MutableStateFlow<LastObservedSession?>(null)
+    /**
+     * Most recent `MediaSession` polled, regardless of match outcome. Populated
+     * on every poll tick that encounters at least one session, so the diagnostics
+     * view can show every MediaMetadata field even when the scrobble cascade
+     * can't produce a match (e.g. TITLE is null).
+     */
+    val lastObservedSession: StateFlow<LastObservedSession?> = _lastObservedSession.asStateFlow()
+
     private var scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var pollingJob: Job? = null
 
-    private var currentlyScrobbling: String? = null
+    private var currentlySessionKey: String? = null
 
     /**
      * Debug firehose toggle. When true, every poll tick writes a per-session breadcrumb
@@ -91,11 +125,13 @@ class MediaSessionScrobbler @Inject constructor(
     var debugLogMediaSession: Boolean = false
 
     /**
-     * Last observed playback progress per media title, captured on every poll that yields
+     * Last observed playback progress per session key, captured on every poll that yields
      * a usable `position/duration`. Feeds the implicit-stop dispatched by [reconcileVanished]
-     * when a session disappears without ever emitting STATE_STOPPED (issue #402).
+     * when a session disappears without ever emitting STATE_STOPPED (issue #402). Stores the
+     * last-known [MediaMetadataSnapshot] alongside the progress so vanished-stop can re-run
+     * the full multi-field match cascade, not just title-based matching.
      */
-    private val lastProgressByTitle = ConcurrentHashMap<String, Float>()
+    private val lastProgressBySessionKey = ConcurrentHashMap<String, LastKnownProgress>()
 
     fun startListening(notificationListenerComponent: ComponentName) {
         scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -107,39 +143,75 @@ class MediaSessionScrobbler @Inject constructor(
             while (isActive) {
                 try {
                     val sessions = sessionManager.getActiveSessions(notificationListenerComponent)
-                    val liveTitles = sessions
-                        .mapNotNull { it.metadata?.getString(android.media.MediaMetadata.METADATA_KEY_TITLE) }
-                        .toSet()
-                    reconcileVanished(liveTitles)
+                    val liveKeys = mutableSetOf<String>()
+                    var publishedDiagnostics = false
                     sessions.forEach { controller ->
                         val packageName = controller.packageName
                         val metadata = controller.metadata
                         val playbackState = controller.playbackState
-                        val rawTitle = metadata
-                            ?.getString(android.media.MediaMetadata.METADATA_KEY_TITLE)
+                        val snapshot = if (metadata != null) {
+                            buildSnapshot(packageName, metadata)
+                        } else {
+                            MediaMetadataSnapshot(packageName = packageName)
+                        }
                         val durationMs = metadata
                             ?.getLong(android.media.MediaMetadata.METADATA_KEY_DURATION) ?: -1L
                         val state = playbackState?.state ?: -1
                         val positionMs = playbackState?.position ?: -1L
-                        logSessionIfDebug(packageName, rawTitle, state, positionMs, durationMs)
-                        if (metadata == null || playbackState == null || rawTitle == null) return@forEach
-                        val snapshot = buildSnapshot(packageName, metadata)
+                        if (!publishedDiagnostics) {
+                            publishObservedSession(snapshot, state, positionMs, durationMs)
+                            publishedDiagnostics = true
+                        }
+                        logSessionIfDebug(snapshot, state, positionMs, durationMs)
+                        val key = snapshot.sessionKey() ?: return@forEach
+                        liveKeys.add(key)
+                        if (metadata == null || playbackState == null) return@forEach
                         val progress = computeProgress(playbackState, metadata)
-                        if (progress != null) recordProgress(rawTitle, progress)
+                        if (progress != null) recordProgress(key, snapshot, progress)
                         when (playbackState.state) {
-                            PlaybackState.STATE_PLAYING -> processPlayingMedia(snapshot, rawTitle, progress)
-                            PlaybackState.STATE_PAUSED -> handleScrobblePause(rawTitle, progress)
+                            PlaybackState.STATE_PLAYING -> processPlayingMedia(snapshot, key, progress)
+                            PlaybackState.STATE_PAUSED -> handleScrobblePause(snapshot, key, progress)
                             PlaybackState.STATE_STOPPED,
-                            PlaybackState.STATE_NONE -> handleScrobbleStop(rawTitle, progress)
+                            PlaybackState.STATE_NONE -> handleScrobbleStop(snapshot, key, progress)
                             else -> {}
                         }
                     }
+                    reconcileVanished(liveKeys)
                 } catch (e: Exception) {
                     Log.w(TAG, "Session polling error", e)
                 }
                 delay(30_000)
             }
         }
+    }
+
+    /**
+     * Stable identity for a media session across polls. Uses the first non-blank
+     * field from [MediaMetadataSnapshot.candidateStrings] so sessions where
+     * `METADATA_KEY_TITLE` is null (Plex ships the show in `ALBUM_ARTIST`,
+     * Jellyfin in `ALBUM`) still get a durable key instead of being dropped.
+     * Returns null when every string field is blank — caller skips scrobble but
+     * still publishes the snapshot to [lastObservedSession] for diagnostics.
+     */
+    internal fun MediaMetadataSnapshot.sessionKey(): String? =
+        candidateStrings().firstOrNull()?.let { "$packageName:$it" }
+
+    internal fun sessionKey(candidate: ScrobbleCandidate): String =
+        "${candidate.packageName}:${candidate.mediaTitle}"
+
+    internal fun publishObservedSession(
+        snapshot: MediaMetadataSnapshot,
+        playbackState: Int,
+        positionMs: Long,
+        durationMs: Long,
+    ) {
+        _lastObservedSession.value = LastObservedSession(
+            snapshot = snapshot,
+            playbackState = playbackState,
+            positionMs = positionMs,
+            durationMs = durationMs,
+            observedAtMs = System.currentTimeMillis(),
+        )
     }
 
     /**
@@ -164,51 +236,77 @@ class MediaSessionScrobbler @Inject constructor(
         album = metadata.getString(android.media.MediaMetadata.METADATA_KEY_ALBUM),
     )
 
-    internal fun recordProgress(title: String, progress: Float) {
-        lastProgressByTitle[title] = progress
+    internal fun recordProgress(sessionKey: String, snapshot: MediaMetadataSnapshot?, progress: Float) {
+        lastProgressBySessionKey[sessionKey] = LastKnownProgress(snapshot, progress)
     }
 
+    internal fun recordProgress(sessionKey: String, progress: Float) {
+        recordProgress(sessionKey, null, progress)
+    }
+
+    /**
+     * Writes a breadcrumb listing every non-null `MediaMetadata` string field
+     * the streaming app published, plus playback state / position / duration.
+     * Previous versions only logged `title`, which hid the fact that Plex /
+     * Jellyfin / some Netflix skins ship the show in other fields and leave
+     * `METADATA_KEY_TITLE` null — the "Debug: log every media session" toggle
+     * needs to surface the full picture so the user can see which field
+     * actually carries signal.
+     */
     internal fun logSessionIfDebug(
-        packageName: String,
-        title: String?,
+        snapshot: MediaMetadataSnapshot,
         state: Int,
         positionMs: Long,
         durationMs: Long,
     ) {
         if (!debugLogMediaSession) return
-        DiagnosticLog.event(
-            TAG,
-            "session pkg=$packageName title='${title ?: "(null)"}' state=$state " +
-                "pos=${positionMs}ms dur=${durationMs}ms",
-        )
+        val head = "session pkg=${snapshot.packageName} state=$state " +
+            "pos=${positionMs}ms dur=${durationMs}ms"
+        val fields = buildList {
+            add("title" to snapshot.title)
+            add("displayTitle" to snapshot.displayTitle)
+            add("displaySubtitle" to snapshot.displaySubtitle)
+            add("displayDescription" to snapshot.displayDescription)
+            add("artist" to snapshot.artist)
+            add("albumArtist" to snapshot.albumArtist)
+            add("album" to snapshot.album)
+        }
+        val tail = fields.joinToString(" ") { (name, value) ->
+            "$name='${value ?: "(null)"}'"
+        }
+        DiagnosticLog.event(TAG, "$head $tail")
     }
 
     /**
      * Detect the case where a streaming app destroys its MediaSession instead of
      * transitioning through STATE_STOPPED (common on YouTube and some Fire TV skins —
-     * issue #402). Without this reconciliation `currentlyScrobbling` would stay pinned
-     * to the last episode forever, silently blocking every future scrobble of the same
-     * title inside [processPlayingMedia]'s dedup guard.
+     * issue #402). Without this reconciliation `currentlySessionKey` would stay
+     * pinned to the last episode forever, silently blocking every future scrobble
+     * of the same session inside [processPlayingMedia]'s dedup guard.
      *
-     * When the previously-tracked title is no longer in the live session set, dispatch
+     * When the previously-tracked session key is no longer in the live set, dispatch
      * an implicit stop with the last observed progress (best-effort — we don't know the
      * real endpoint) and clear local state so the next playback can scrobble again.
+     * Uses the last-known [MediaMetadataSnapshot] so the match goes through the full
+     * multi-field cascade — falling back to title-only matching on the key suffix
+     * (`packageName:title`) only when no snapshot was stashed (direct test calls).
      */
-    internal suspend fun reconcileVanished(liveTitles: Set<String>) {
-        val stale = currentlyScrobbling ?: return
-        if (stale in liveTitles) return
-        val lastProgress = lastProgressByTitle.remove(stale)
-        currentlyScrobbling = null
-        if (lastProgress == null) {
+    internal suspend fun reconcileVanished(liveKeys: Set<String>) {
+        val stale = currentlySessionKey ?: return
+        if (stale in liveKeys) return
+        val last = lastProgressBySessionKey.remove(stale)
+        currentlySessionKey = null
+        if (last == null) {
             DiagnosticLog.warn(TAG, "Session vanished without captured progress — cleared '$stale'")
             return
         }
         try {
-            val candidate = matchTitle("", stale)
+            val candidate = last.snapshot?.let { matchSnapshot(it) }
+                ?: matchTitle("", stale.substringAfter(':', missingDelimiterValue = stale))
             val show = candidate?.matchedShow
             val episode = candidate?.matchedEpisode
             if (show != null && episode != null) {
-                scrobbleDispatcher.dispatchStop(show, episode, lastProgress)
+                scrobbleDispatcher.dispatchStop(show, episode, last.progress)
                 Log.i(TAG, "Session vanished — implicit stop: ${show.title} S${episode.season}E${episode.number}")
             } else {
                 DiagnosticLog.warn(TAG, "Session vanished — no match for '$stale', dispatch skipped")
@@ -222,25 +320,26 @@ class MediaSessionScrobbler @Inject constructor(
         pollingJob?.cancel()
         scope.cancel()
         _isListening.value = false
-        currentlyScrobbling = null
-        lastProgressByTitle.clear()
+        currentlySessionKey = null
+        lastProgressBySessionKey.clear()
+        _lastObservedSession.value = null
     }
 
     private suspend fun processPlayingMedia(
         snapshot: MediaMetadataSnapshot,
-        rawTitle: String,
+        sessionKey: String,
         progress: Float?,
     ) {
-        if (rawTitle == currentlyScrobbling) return
+        if (sessionKey == currentlySessionKey) return
         val candidate = matchSnapshot(snapshot)
         if (candidate == null) {
             if (debugLogMediaSession) {
-                DiagnosticLog.debug(TAG, "no match for '$rawTitle' — best confidence null")
+                DiagnosticLog.debug(TAG, "no match for '$sessionKey' — best confidence null")
             }
             return
         }
         if (candidate.confidence >= AUTO_SCROBBLE_THRESHOLD) {
-            autoScrobble(candidate, progress)
+            autoScrobble(candidate, progress, sessionKey)
             _lastCandidate.value = LastCandidate(candidate, System.currentTimeMillis(), autoScrobbled = true)
         } else if (candidate.confidence >= OVERLAY_THRESHOLD) {
             _pendingConfirmation.emit(candidate)
@@ -248,7 +347,7 @@ class MediaSessionScrobbler @Inject constructor(
         } else if (debugLogMediaSession) {
             DiagnosticLog.debug(
                 TAG,
-                "no match for '$rawTitle' — best confidence ${candidate.confidence}",
+                "no match for '$sessionKey' — best confidence ${candidate.confidence}",
             )
         }
     }
@@ -519,35 +618,47 @@ class MediaSessionScrobbler @Inject constructor(
 
     // ── Scrobble API ──────────────────────────────────────────────────────────
 
-    suspend fun autoScrobble(candidate: ScrobbleCandidate, progress: Float? = null) {
+    suspend fun autoScrobble(
+        candidate: ScrobbleCandidate,
+        progress: Float? = null,
+        sessionKey: String? = null,
+    ) {
         val show = candidate.matchedShow ?: return
         val episode = candidate.matchedEpisode ?: return
         scrobbleDispatcher.dispatchStart(show, episode, progress ?: 0f)
-        currentlyScrobbling = candidate.mediaTitle
+        currentlySessionKey = sessionKey ?: this.sessionKey(candidate)
         Log.i(TAG, "Scrobble started: ${show.title} S${episode.season}E${episode.number}")
     }
 
-    internal suspend fun handleScrobblePause(rawTitle: String, progress: Float? = null) {
-        if (rawTitle != currentlyScrobbling) return
-        val candidate = matchTitle("", rawTitle) ?: return
+    internal suspend fun handleScrobblePause(
+        snapshot: MediaMetadataSnapshot,
+        sessionKey: String,
+        progress: Float? = null,
+    ) {
+        if (sessionKey != currentlySessionKey) return
+        val candidate = matchSnapshot(snapshot) ?: return
         val show = candidate.matchedShow ?: return
         val episode = candidate.matchedEpisode ?: return
         scrobbleDispatcher.dispatchPause(show, episode, progress ?: 50f)
         Log.i(TAG, "Scrobble paused: ${show.title}")
     }
 
-    internal suspend fun handleScrobbleStop(rawTitle: String, progress: Float? = null) {
-        if (rawTitle != currentlyScrobbling) return
+    internal suspend fun handleScrobbleStop(
+        snapshot: MediaMetadataSnapshot,
+        sessionKey: String,
+        progress: Float? = null,
+    ) {
+        if (sessionKey != currentlySessionKey) return
         if (progress == null) {
-            Log.w(TAG, "Scrobble stop skipped — playback position/duration unavailable for '$rawTitle'")
-            currentlyScrobbling = null
+            Log.w(TAG, "Scrobble stop skipped — playback position/duration unavailable for '$sessionKey'")
+            currentlySessionKey = null
             return
         }
-        val candidate = matchTitle("", rawTitle) ?: return
+        val candidate = matchSnapshot(snapshot) ?: return
         val show = candidate.matchedShow ?: return
         val episode = candidate.matchedEpisode ?: return
         scrobbleDispatcher.dispatchStop(show, episode, progress)
-        currentlyScrobbling = null
+        currentlySessionKey = null
         Log.i(TAG, "Scrobble stopped: ${show.title} S${episode.season}E${episode.number}")
     }
 }

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerDebugLogTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerDebugLogTest.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.core.scrobbler
 import android.content.Context
 import android.media.session.MediaSessionManager
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import io.mockk.every
 import io.mockk.mockk
@@ -41,8 +42,10 @@ class MediaSessionScrobblerDebugLogTest {
         scrobbler.debugLogMediaSession = false
 
         scrobbler.logSessionIfDebug(
-            packageName = "com.netflix.ninja",
-            title = "Breaking Bad S01E01",
+            snapshot = MediaMetadataSnapshot(
+                packageName = "com.netflix.ninja",
+                title = "Breaking Bad S01E01",
+            ),
             state = 3,
             positionMs = 1234L,
             durationMs = 2600000L,
@@ -58,8 +61,10 @@ class MediaSessionScrobblerDebugLogTest {
         scrobbler.debugLogMediaSession = true
 
         scrobbler.logSessionIfDebug(
-            packageName = "com.netflix.ninja",
-            title = "Breaking Bad S01E01",
+            snapshot = MediaMetadataSnapshot(
+                packageName = "com.netflix.ninja",
+                title = "Breaking Bad S01E01",
+            ),
             state = 3,
             positionMs = 1234L,
             durationMs = 2600000L,
@@ -82,8 +87,7 @@ class MediaSessionScrobblerDebugLogTest {
         scrobbler.debugLogMediaSession = true
 
         scrobbler.logSessionIfDebug(
-            packageName = "com.netflix.ninja",
-            title = null,
+            snapshot = MediaMetadataSnapshot(packageName = "com.netflix.ninja"),
             state = -1,
             positionMs = -1L,
             durationMs = -1L,
@@ -92,5 +96,33 @@ class MediaSessionScrobblerDebugLogTest {
         val entry = DiagnosticLog.snapshot()
             .single { it.message.startsWith("session pkg=") }
         assertTrue(entry.message.contains("title='(null)'"))
+    }
+
+    @Test
+    fun `breadcrumb includes every non-null MediaMetadata field`() {
+        scrobbler.debugLogMediaSession = true
+
+        scrobbler.logSessionIfDebug(
+            snapshot = MediaMetadataSnapshot(
+                packageName = "com.plexapp.android",
+                title = null,
+                displayTitle = "Pilot",
+                displaySubtitle = "S01E01",
+                albumArtist = "Breaking Bad",
+                album = null,
+            ),
+            state = 3,
+            positionMs = 100L,
+            durationMs = 2000L,
+        )
+
+        val entry = DiagnosticLog.snapshot()
+            .single { it.message.startsWith("session pkg=") }
+        assertTrue(entry.message.contains("pkg=com.plexapp.android"))
+        assertTrue(entry.message.contains("title='(null)'"))
+        assertTrue(entry.message.contains("displayTitle='Pilot'"))
+        assertTrue(entry.message.contains("displaySubtitle='S01E01'"))
+        assertTrue(entry.message.contains("albumArtist='Breaking Bad'"))
+        assertTrue(entry.message.contains("album='(null)'"))
     }
 }

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerLifecycleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerLifecycleTest.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.core.scrobbler
 import android.content.ComponentName
 import android.content.Context
 import android.media.session.MediaSessionManager
+import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
 import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktIds
@@ -31,6 +32,16 @@ class MediaSessionScrobblerLifecycleTest {
     private val testCandidate = ScrobbleCandidate(
         "com.netflix", "Breaking Bad S01E01", 0.95f, testShow, testEpisode
     )
+    private val testSnapshot = MediaMetadataSnapshot(
+        packageName = "com.netflix",
+        title = "Breaking Bad S01E01",
+    )
+    private val testSessionKey = "com.netflix:Breaking Bad S01E01"
+    private val otherSnapshot = MediaMetadataSnapshot(
+        packageName = "com.netflix",
+        title = "Other Show",
+    )
+    private val otherSessionKey = "com.netflix:Other Show"
 
     @BeforeEach
     fun setUp() {
@@ -146,7 +157,7 @@ class MediaSessionScrobblerLifecycleTest {
             coEvery { scrobbleDispatcher.dispatchPause(any(), any(), any()) } just runs
             primeScrobbling()
 
-            scrobbler.handleScrobblePause("Breaking Bad S01E01", progress = 42f)
+            scrobbler.handleScrobblePause(testSnapshot, testSessionKey, progress = 42f)
 
             coVerify { scrobbleDispatcher.dispatchPause(any(), any(), 42f) }
         }
@@ -156,14 +167,14 @@ class MediaSessionScrobblerLifecycleTest {
             coEvery { scrobbleDispatcher.dispatchPause(any(), any(), any()) } just runs
             primeScrobbling()
 
-            scrobbler.handleScrobblePause("Breaking Bad S01E01", progress = null)
+            scrobbler.handleScrobblePause(testSnapshot, testSessionKey, progress = null)
 
             coVerify { scrobbleDispatcher.dispatchPause(any(), any(), 50f) }
         }
 
         @Test
-        fun `skips when title does not match currently scrobbling`() = runTest {
-            scrobbler.handleScrobblePause("Other Show", progress = 50f)
+        fun `skips when session key does not match currently scrobbling`() = runTest {
+            scrobbler.handleScrobblePause(otherSnapshot, otherSessionKey, progress = 50f)
 
             coVerify(exactly = 0) { scrobbleDispatcher.dispatchPause(any(), any(), any()) }
         }
@@ -188,7 +199,7 @@ class MediaSessionScrobblerLifecycleTest {
             coEvery { scrobbleDispatcher.dispatchStop(any(), any(), any()) } just runs
             primeScrobbling()
 
-            scrobbler.handleScrobbleStop("Breaking Bad S01E01", progress = 80f)
+            scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = 80f)
 
             coVerify { scrobbleDispatcher.dispatchStop(any(), any(), 80f) }
         }
@@ -197,14 +208,14 @@ class MediaSessionScrobblerLifecycleTest {
         fun `skips stop when progress is null`() = runTest {
             primeScrobbling()
 
-            scrobbler.handleScrobbleStop("Breaking Bad S01E01", progress = null)
+            scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = null)
 
             coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
         }
 
         @Test
-        fun `skips when title does not match currently scrobbling`() = runTest {
-            scrobbler.handleScrobbleStop("Other Show", progress = 90f)
+        fun `skips when session key does not match currently scrobbling`() = runTest {
+            scrobbler.handleScrobbleStop(otherSnapshot, otherSessionKey, progress = 90f)
 
             coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
         }

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerNullTitleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerNullTitleTest.kt
@@ -1,0 +1,217 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import android.content.Context
+import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
+import com.justb81.watchbuddy.core.model.ScrobbleCandidate
+import com.justb81.watchbuddy.core.model.TraktEpisode
+import com.justb81.watchbuddy.core.model.TraktIds
+import com.justb81.watchbuddy.core.model.TraktShow
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.tmdb.TmdbApiService
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for the null-`METADATA_KEY_TITLE` scrobble cascade. Previously
+ * the polling loop early-returned when TITLE was null, dropping every Plex,
+ * Jellyfin, and Netflix-skin session that ships the show in another field. The
+ * fix identifies sessions by the first non-blank `candidateStrings()` entry
+ * instead of raw title, so pause/stop dedup + vanished-stop reconciliation keep
+ * working when TITLE is unavailable.
+ *
+ * Also covers the `lastObservedSession` diagnostics StateFlow that surfaces the
+ * full `MediaMetadataSnapshot` in the TV diagnostics view regardless of whether
+ * a scrobble fired — so the user can see exactly what each streaming app is
+ * publishing, rather than just a single "title='(null)'" row.
+ */
+@DisplayName("MediaSessionScrobbler — null TITLE cascade + lastObservedSession")
+class MediaSessionScrobblerNullTitleTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val tmdbApiService: TmdbApiService = mockk()
+    private val watchedShowSource: WatchedShowSource = mockk()
+    private val scrobbleDispatcher: ScrobbleDispatcher = mockk()
+    private lateinit var scrobbler: MediaSessionScrobbler
+
+    private val breakingBadShow = TraktShow(
+        title = "Breaking Bad",
+        year = 2008,
+        ids = TraktIds(trakt = 1, tmdb = 1396),
+    )
+    private val breakingBadEntry = TraktWatchedEntry(show = breakingBadShow)
+
+    // Plex: TITLE = episode name, ALBUM_ARTIST = show, DISPLAY_SUBTITLE = S##E##
+    private val plexPlayingSnapshot = MediaMetadataSnapshot(
+        packageName = "com.plexapp.android",
+        title = null,
+        albumArtist = "Breaking Bad",
+        displaySubtitle = "S01E01",
+    )
+    // sessionKey = "${packageName}:${candidateStrings().first()}"
+    // candidateStrings priority: albumArtist > album > artist > displayTitle > displaySubtitle > title > displayDescription
+    private val plexSessionKey = "com.plexapp.android:Breaking Bad"
+
+    @BeforeEach
+    fun setUp() {
+        scrobbler = MediaSessionScrobbler(
+            context, tmdbApiService, watchedShowSource, scrobbleDispatcher, NoOpTitleExtractor,
+        )
+        coEvery { watchedShowSource.getTmdbApiKey() } returns null
+        coEvery { watchedShowSource.getShowHint(any()) } returns null
+        coEvery { scrobbleDispatcher.dispatchStart(any(), any(), any()) } just runs
+        coEvery { scrobbleDispatcher.dispatchPause(any(), any(), any()) } just runs
+        coEvery { scrobbleDispatcher.dispatchStop(any(), any(), any()) } just runs
+    }
+
+    // ── lastObservedSession (diagnostics exposure) ────────────────────────────
+
+    @Test
+    fun `publishObservedSession populates lastObservedSession StateFlow`() {
+        assertNull(scrobbler.lastObservedSession.value)
+
+        scrobbler.publishObservedSession(
+            snapshot = plexPlayingSnapshot,
+            playbackState = 3,
+            positionMs = 123L,
+            durationMs = 2600000L,
+        )
+
+        val observed = scrobbler.lastObservedSession.value
+        assertNotNull(observed)
+        assertEquals(plexPlayingSnapshot, observed!!.snapshot)
+        assertEquals(3, observed.playbackState)
+        assertEquals(123L, observed.positionMs)
+        assertEquals(2600000L, observed.durationMs)
+        assertTrue(observed.observedAtMs > 0L)
+    }
+
+    @Test
+    fun `publishObservedSession populates even when every string field is null`() {
+        val emptySnapshot = MediaMetadataSnapshot(packageName = "com.example.splash")
+
+        scrobbler.publishObservedSession(
+            snapshot = emptySnapshot,
+            playbackState = -1,
+            positionMs = -1L,
+            durationMs = -1L,
+        )
+
+        val observed = scrobbler.lastObservedSession.value
+        assertNotNull(observed)
+        assertEquals(emptySnapshot, observed!!.snapshot)
+        assertTrue(emptySnapshot.candidateStrings().isEmpty())
+    }
+
+    @Test
+    fun `stopListening clears lastObservedSession`() {
+        scrobbler.publishObservedSession(plexPlayingSnapshot, 3, 0L, 0L)
+        assertNotNull(scrobbler.lastObservedSession.value)
+
+        scrobbler.stopListening()
+
+        assertNull(scrobbler.lastObservedSession.value)
+    }
+
+    // ── Pause/stop dedup keyed by sessionKey, not raw title ───────────────────
+
+    @Test
+    fun `Plex-shape pause deduped by session key when TITLE is null`() = runTest {
+        coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
+        val candidate = scrobbler.matchSnapshot(plexPlayingSnapshot)
+        assertNotNull(candidate)
+        scrobbler.autoScrobble(candidate!!, progress = 10f, sessionKey = plexSessionKey)
+        clearMocks(scrobbleDispatcher, answers = false)
+        coEvery { scrobbleDispatcher.dispatchPause(any(), any(), any()) } just runs
+
+        // Same session key → dispatchPause fires.
+        scrobbler.handleScrobblePause(plexPlayingSnapshot, plexSessionKey, progress = 42f)
+
+        coVerify { scrobbleDispatcher.dispatchPause(breakingBadShow, any(), 42f) }
+    }
+
+    @Test
+    fun `Plex-shape stop deduped by session key when TITLE is null`() = runTest {
+        coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
+        val candidate = scrobbler.matchSnapshot(plexPlayingSnapshot)
+        assertNotNull(candidate)
+        scrobbler.autoScrobble(candidate!!, progress = 10f, sessionKey = plexSessionKey)
+        clearMocks(scrobbleDispatcher, answers = false)
+        coEvery { scrobbleDispatcher.dispatchStop(any(), any(), any()) } just runs
+
+        scrobbler.handleScrobbleStop(plexPlayingSnapshot, plexSessionKey, progress = 88f)
+
+        coVerify { scrobbleDispatcher.dispatchStop(breakingBadShow, any(), 88f) }
+    }
+
+    @Test
+    fun `pause with different session key does not fire even if snapshot matches cache`() = runTest {
+        coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
+        val candidate = scrobbler.matchSnapshot(plexPlayingSnapshot)
+        assertNotNull(candidate)
+        scrobbler.autoScrobble(candidate!!, progress = 10f, sessionKey = plexSessionKey)
+
+        scrobbler.handleScrobblePause(
+            plexPlayingSnapshot,
+            "some.other.app:Different Show",
+            progress = 42f,
+        )
+
+        coVerify(exactly = 0) { scrobbleDispatcher.dispatchPause(any(), any(), any()) }
+    }
+
+    // ── Vanished-stop uses the stashed snapshot (multi-field cascade) ──────────
+
+    @Test
+    fun `vanished session with stashed snapshot dispatches stop via matchSnapshot`() = runTest {
+        coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
+        val candidate = ScrobbleCandidate(
+            packageName = plexPlayingSnapshot.packageName,
+            mediaTitle = "Breaking Bad",
+            confidence = 0.95f,
+            matchedShow = breakingBadShow,
+            matchedEpisode = TraktEpisode(season = 1, number = 1),
+        )
+        scrobbler.autoScrobble(candidate, progress = 10f, sessionKey = plexSessionKey)
+        // Poll once — stash the snapshot alongside the progress so vanish can re-match.
+        scrobbler.recordProgress(plexSessionKey, plexPlayingSnapshot, 55f)
+
+        scrobbler.reconcileVanished(liveKeys = emptySet())
+
+        coVerify { scrobbleDispatcher.dispatchStop(breakingBadShow, any(), 55f) }
+    }
+
+    // ── sessionKey identity derivation ────────────────────────────────────────
+
+    @Test
+    fun `sessionKey for snapshot with empty candidate strings is null`() {
+        val emptySnapshot = MediaMetadataSnapshot(packageName = "com.example.splash")
+        with(scrobbler) {
+            assertNull(emptySnapshot.sessionKey())
+        }
+    }
+
+    @Test
+    fun `sessionKey derives from highest-priority non-blank field`() {
+        val plexSnapshot = MediaMetadataSnapshot(
+            packageName = "com.plexapp.android",
+            title = "Pilot",
+            albumArtist = "Breaking Bad",
+        )
+        // candidateStrings order: albumArtist > album > artist > displayTitle > displaySubtitle > title > displayDescription
+        with(scrobbler) {
+            assertEquals("com.plexapp.android:Breaking Bad", plexSnapshot.sessionKey())
+        }
+    }
+}

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerNullTitleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerNullTitleTest.kt
@@ -53,14 +53,15 @@ class MediaSessionScrobblerNullTitleTest {
     private val breakingBadEntry = TraktWatchedEntry(show = breakingBadShow)
 
     // Plex: TITLE = episode name, ALBUM_ARTIST = show, DISPLAY_SUBTITLE = S##E##
+    // sessionKey = "${packageName}:${candidateStrings().first()}" — priority order
+    // is: albumArtist > album > artist > displayTitle > displaySubtitle > title >
+    // displayDescription, so the Plex snapshot below keys on "Breaking Bad".
     private val plexPlayingSnapshot = MediaMetadataSnapshot(
         packageName = "com.plexapp.android",
         title = null,
         albumArtist = "Breaking Bad",
         displaySubtitle = "S01E01",
     )
-    // sessionKey = "${packageName}:${candidateStrings().first()}"
-    // candidateStrings priority: albumArtist > album > artist > displayTitle > displaySubtitle > title > displayDescription
     private val plexSessionKey = "com.plexapp.android:Breaking Bad"
 
     @BeforeEach

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerVanishTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerVanishTest.kt
@@ -22,10 +22,10 @@ import org.junit.jupiter.api.Test
  * Regression tests for issue #402: some streaming apps destroy their MediaSession
  * entirely when playback ends instead of transitioning through STATE_STOPPED.
  * When that happens `getActiveSessions` just stops returning the session — no
- * STATE_STOPPED is ever observed — so the dedup key `currentlyScrobbling` used
- * to stay pinned forever, silently blocking every future scrobble of the same title.
+ * STATE_STOPPED is ever observed — so the dedup key `currentlySessionKey` used
+ * to stay pinned forever, silently blocking every future scrobble of the same session.
  *
- * The fix reconciles `currentlyScrobbling` against the set of titles currently
+ * The fix reconciles `currentlySessionKey` against the set of session keys currently
  * reported as live on each poll, dispatches an implicit stop with the last
  * captured progress, and clears local state so the next play can scrobble again.
  */
@@ -44,6 +44,7 @@ class MediaSessionScrobblerVanishTest {
     private val testCandidate = ScrobbleCandidate(
         "com.netflix", testTitle, 0.95f, testShow, testEpisode
     )
+    private val testSessionKey = "com.netflix:$testTitle"
 
     @BeforeEach
     fun setUp() {
@@ -59,9 +60,9 @@ class MediaSessionScrobblerVanishTest {
     @Test
     fun `vanished session dispatches stop with last captured progress`() = runTest {
         scrobbler.autoScrobble(testCandidate)
-        scrobbler.recordProgress(testTitle, 42f)
+        scrobbler.recordProgress(testSessionKey, 42f)
 
-        scrobbler.reconcileVanished(liveTitles = emptySet())
+        scrobbler.reconcileVanished(liveKeys = emptySet())
 
         coVerify { scrobbleDispatcher.dispatchStop(testShow, testEpisode, 42f) }
     }
@@ -69,8 +70,8 @@ class MediaSessionScrobblerVanishTest {
     @Test
     fun `subsequent scrobble of same title proceeds after reconciliation`() = runTest {
         scrobbler.autoScrobble(testCandidate)
-        scrobbler.recordProgress(testTitle, 42f)
-        scrobbler.reconcileVanished(liveTitles = emptySet())
+        scrobbler.recordProgress(testSessionKey, 42f)
+        scrobbler.reconcileVanished(liveKeys = emptySet())
         clearMocks(scrobbleDispatcher, answers = false)
 
         scrobbler.autoScrobble(testCandidate)
@@ -81,16 +82,16 @@ class MediaSessionScrobblerVanishTest {
     @Test
     fun `live title still present does not trigger implicit stop`() = runTest {
         scrobbler.autoScrobble(testCandidate)
-        scrobbler.recordProgress(testTitle, 42f)
+        scrobbler.recordProgress(testSessionKey, 42f)
 
-        scrobbler.reconcileVanished(liveTitles = setOf(testTitle))
+        scrobbler.reconcileVanished(liveKeys = setOf(testSessionKey))
 
         coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
     }
 
     @Test
     fun `no-op when nothing is currently scrobbling`() = runTest {
-        scrobbler.reconcileVanished(liveTitles = emptySet())
+        scrobbler.reconcileVanished(liveKeys = emptySet())
 
         coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
     }
@@ -100,7 +101,7 @@ class MediaSessionScrobblerVanishTest {
         scrobbler.autoScrobble(testCandidate)
         // Intentionally no recordProgress() — stream ended before any progress-bearing poll.
 
-        scrobbler.reconcileVanished(liveTitles = emptySet())
+        scrobbler.reconcileVanished(liveKeys = emptySet())
 
         coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
         // Follow-up start must no longer be blocked by the dedup guard.
@@ -112,12 +113,12 @@ class MediaSessionScrobblerVanishTest {
     @Test
     fun `stopListening clears scrobble state`() = runTest {
         scrobbler.autoScrobble(testCandidate)
-        scrobbler.recordProgress(testTitle, 42f)
+        scrobbler.recordProgress(testSessionKey, 42f)
 
         scrobbler.stopListening()
 
         // After stop, reconciliation is a no-op because state is cleared.
-        scrobbler.reconcileVanished(liveTitles = emptySet())
+        scrobbler.reconcileVanished(liveKeys = emptySet())
         coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
     }
 }


### PR DESCRIPTION
## Summary

The TV diagnostics view's "Last candidate" row used to collapse the full `MediaMetadataSnapshot` down to a single string derived from `candidate.mediaTitle`, and the polling loop in `MediaSessionScrobbler.kt` early-returned when `METADATA_KEY_TITLE` was null. So Plex (show in `ALBUM_ARTIST`), Jellyfin (show in `ALBUM`), and some Netflix skins (episode + `SxxExx` in `DISPLAY_SUBTITLE`) both showed up as "—" in diagnostics **and** silently failed to scrobble — even though `matchSnapshot` can already resolve shows from any candidate string.

This change:

- **Identifies sessions by a `sessionKey`** derived from the first non-blank entry in `MediaMetadataSnapshot.candidateStrings()` (`packageName:first-field`) instead of raw TITLE. `currentlySessionKey` + `lastProgressBySessionKey` replace the title-keyed state so dedup, pause/stop, and vanish reconciliation keep working when TITLE is null.
- **Upgrades `handleScrobblePause` / `handleScrobbleStop`** to take the snapshot and run the full `matchSnapshot` cascade instead of title-only `matchTitle` — so pause/stop benefit from the same multi-field matching as PLAYING.
- **Exposes `lastObservedSession: StateFlow<LastObservedSession?>`** that captures every polled session regardless of match outcome. `TvDiagnosticsViewModel` surfaces it as a new **"Last media session"** card in the diagnostics screen listing every MediaMetadata field plus playback state / position / duration. `"(null)"` rows are rendered explicitly so the user can tell "Netflix published nothing here" apart from "no session yet".
- **Rewrites `logSessionIfDebug`** to emit every non-null MediaMetadata field in the "Debug: log every media session" breadcrumb, not just the title.
- **New `MediaSessionScrobblerNullTitleTest`** covers `sessionKey` derivation, `lastObservedSession` publish + `stopListening` clear, Plex-shape pause/stop dedup with null TITLE, and vanished-stop routing through `matchSnapshot`. Existing Vanish / Lifecycle / DebugLog tests updated for the new signatures.
- **Localized strings** in en / de / fr / es for the new card title and each field label.

## Test plan

- [ ] CI: `Test & Build` green (includes unit tests, detekt, Android Lint)
- [ ] CI: `Backend Tests` green / skipped (no backend changes)
- [ ] Local gradle skipped — sandboxed environment had no Android SDK; CI is the real gate per `scripts/precommit.sh` guidance
- [ ] Netflix (TITLE populated): "Last media session" card shows every published field; "Last candidate" still fires; Trakt records the episode.
- [ ] **Plex** (TITLE null, ALBUM_ARTIST set): "Last media session" card shows `title='(null)'` dimmed but `albumArtist` populated; "Last candidate" now fires (was empty before); Trakt records the episode — this is the core cascade-fix proof point.
- [ ] **Jellyfin** (ALBUM populated): same as Plex.
- [ ] All-null session: card shows every field "(null)" with WARN status; no scrobble dispatched; app does not crash.
- [ ] Pause Plex mid-episode → scrobble pause fires to phone.
- [ ] Close streaming app mid-episode → next 30 s poll's `reconcileVanished` dispatches implicit stop with last-known progress.
- [ ] With "Debug: log every media session" ON in TV settings → "Recent events" card shows breadcrumbs with every non-null MediaMetadata field, not just `title='(null)'`.
- [ ] `stopListening` → "Last media session" card shows "—"s (state cleared).

https://claude.ai/code/session_01SeViAgdxLEkizrk2hV5sx5

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeViAgdxLEkizrk2hV5sx5)_