### PR TITLE
chore(phone): align card surfaces with M3 Expressive shape & tonal tokens

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
@@ -50,6 +50,7 @@ import com.justb81.watchbuddy.phone.permissions.BluetoothAdvertisePermission
 import com.justb81.watchbuddy.phone.permissions.NotificationPermission
 import com.justb81.watchbuddy.phone.permissions.rememberBluetoothAdvertisePermissionRequest
 import com.justb81.watchbuddy.phone.permissions.rememberNotificationPermissionRequest
+import com.justb81.watchbuddy.phone.ui.theme.watchBuddyShapes
 import com.justb81.watchbuddy.phone.ui.util.relativeDate
 import com.justb81.watchbuddy.phone.ui.util.relativeTime
 
@@ -57,7 +58,6 @@ private val NewSeasonBorderWidth = 1.5.dp
 private val NewSeasonBadgeCorner = 10.dp
 private val NewSeasonBadgePadding = 4.dp
 private val NewSeasonBadgeIconSize = 12.dp
-private val ShowCardCorner = 12.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -408,7 +408,7 @@ private fun DiagnosticsBanner(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 8.dp),
-        shape = RoundedCornerShape(12.dp),
+        shape = MaterialTheme.watchBuddyShapes.banner,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.errorContainer
         )
@@ -463,7 +463,7 @@ private fun WatchingTvToggle(
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
+        shape = MaterialTheme.watchBuddyShapes.card,
         colors = CardDefaults.cardColors(
             containerColor = if (isWatching)
                 MaterialTheme.colorScheme.primaryContainer
@@ -525,7 +525,7 @@ private fun NowWatchingCard(event: ScrobbleDisplayEvent) {
 
     Card(
         modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
+        shape = MaterialTheme.watchBuddyShapes.card,
         colors = CardDefaults.cardColors(
             containerColor = MaterialTheme.colorScheme.tertiaryContainer
         )
@@ -578,7 +578,7 @@ private fun ShowRowCard(
 ) {
     val entry = enriched.entry
     val posterUrl = TmdbImageHelper.poster(enriched.posterPath, 300)
-    val cardShape = RoundedCornerShape(ShowCardCorner)
+    val cardShape = MaterialTheme.watchBuddyShapes.banner
 
     Card(
         modifier = Modifier
@@ -593,7 +593,7 @@ private fun ShowRowCard(
             .clickable { entry.show.ids.trakt?.let(onShowClick) },
         shape    = cardShape,
         colors   = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceVariant
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
         )
     ) {
         Row(
@@ -608,13 +608,13 @@ private fun ShowRowCard(
                     contentScale = ContentScale.Crop,
                     modifier = Modifier
                         .size(56.dp, 80.dp)
-                        .clip(RoundedCornerShape(8.dp))
+                        .clip(MaterialTheme.watchBuddyShapes.thumbnail)
                 )
             } else {
                 Box(
                     modifier = Modifier
                         .size(56.dp, 80.dp)
-                        .clip(RoundedCornerShape(8.dp))
+                        .clip(MaterialTheme.watchBuddyShapes.thumbnail)
                         .background(MaterialTheme.colorScheme.outline)
                 )
             }
@@ -654,14 +654,15 @@ private fun ShelfCard(
     val entry = enriched.entry
     val posterUrl = TmdbImageHelper.poster(enriched.posterPath, 500)
 
+    val shelfShape = MaterialTheme.watchBuddyShapes.banner
     Box(
         modifier = Modifier
             .width(180.dp)
             .aspectRatio(2f / 3f)
-            .clip(RoundedCornerShape(12.dp))
+            .clip(shelfShape)
             .then(
                 if (hasNewSeason) {
-                    Modifier.border(NewSeasonBorderWidth, MaterialTheme.colorScheme.primary, RoundedCornerShape(ShowCardCorner))
+                    Modifier.border(NewSeasonBorderWidth, MaterialTheme.colorScheme.primary, shelfShape)
                 } else {
                     Modifier
                 }
@@ -877,7 +878,7 @@ private fun BadgePill(
 ) {
     Row(
         modifier = Modifier
-            .clip(RoundedCornerShape(12.dp))
+            .clip(MaterialTheme.watchBuddyShapes.pill)
             .background(container)
             .padding(horizontal = 8.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/theme/Shapes.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/theme/Shapes.kt
@@ -1,0 +1,24 @@
+package com.justb81.watchbuddy.phone.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Shape
+
+internal data class WatchBuddyShapes(
+    /** Large interactive cards (WatchingTvToggle, NowWatchingCard) — M3 shapes.large */
+    val card: Shape,
+    /** Standard surface panels (DiagnosticsBanner, ShowRowCard, ShelfCard) — M3 shapes.medium */
+    val banner: Shape,
+    /** Compact badge pills (BadgePill) — M3 shapes.medium */
+    val pill: Shape,
+    /** Image thumbnails (poster crops) — M3 shapes.small */
+    val thumbnail: Shape,
+)
+
+internal val MaterialTheme.watchBuddyShapes: WatchBuddyShapes
+    @Composable get() = WatchBuddyShapes(
+        card      = shapes.large,
+        banner    = shapes.medium,
+        pill      = shapes.medium,
+        thumbnail = shapes.small,
+    )

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/theme/WatchBuddyShapes.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/theme/WatchBuddyShapes.kt
@@ -17,8 +17,8 @@ internal data class WatchBuddyShapes(
 
 internal val MaterialTheme.watchBuddyShapes: WatchBuddyShapes
     @Composable get() = WatchBuddyShapes(
-        card      = shapes.large,
-        banner    = shapes.medium,
-        pill      = shapes.medium,
+        card = shapes.large,
+        banner = shapes.medium,
+        pill = shapes.medium,
         thumbnail = shapes.small,
     )

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/theme/WatchBuddyShapesTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/theme/WatchBuddyShapesTest.kt
@@ -1,0 +1,61 @@
+package com.justb81.watchbuddy.phone.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("WatchBuddyShapes")
+class WatchBuddyShapesTest {
+
+    private val shapes = WatchBuddyShapes(
+        card      = RoundedCornerShape(16.dp),
+        banner    = RoundedCornerShape(12.dp),
+        pill      = RoundedCornerShape(12.dp),
+        thumbnail = RoundedCornerShape(8.dp),
+    )
+
+    @Test
+    fun `data class equality holds for identical instances`() {
+        val copy = shapes.copy()
+        assertEquals(shapes, copy)
+    }
+
+    @Test
+    fun `copy with different card shape produces distinct instance`() {
+        val modified = shapes.copy(card = RoundedCornerShape(8.dp))
+        assertNotEquals(shapes, modified)
+    }
+
+    @Test
+    fun `banner and pill use the same shape`() {
+        assertEquals(shapes.banner, shapes.pill)
+    }
+
+    @Test
+    fun `card shape differs from banner shape`() {
+        assertNotEquals(shapes.card, shapes.banner)
+    }
+
+    @Test
+    fun `thumbnail shape differs from banner shape`() {
+        assertNotEquals(shapes.thumbnail, shapes.banner)
+    }
+
+    @Test
+    fun `card shape is RoundedCornerShape 16dp`() {
+        assertEquals(RoundedCornerShape(16.dp), shapes.card)
+    }
+
+    @Test
+    fun `banner shape is RoundedCornerShape 12dp`() {
+        assertEquals(RoundedCornerShape(12.dp), shapes.banner)
+    }
+
+    @Test
+    fun `thumbnail shape is RoundedCornerShape 8dp`() {
+        assertEquals(RoundedCornerShape(8.dp), shapes.thumbnail)
+    }
+}

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/theme/WatchBuddyShapesTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/theme/WatchBuddyShapesTest.kt
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.Test
 class WatchBuddyShapesTest {
 
     private val shapes = WatchBuddyShapes(
-        card      = RoundedCornerShape(16.dp),
-        banner    = RoundedCornerShape(12.dp),
-        pill      = RoundedCornerShape(12.dp),
+        card = RoundedCornerShape(16.dp),
+        banner = RoundedCornerShape(12.dp),
+        pill = RoundedCornerShape(12.dp),
         thumbnail = RoundedCornerShape(8.dp),
     )
 


### PR DESCRIPTION
## Summary

- Introduces `WatchBuddyShapes` data class and `MaterialTheme.watchBuddyShapes` composable extension property in `app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/theme/Shapes.kt`, backed by `MaterialTheme.shapes.{large,medium,small}` so all card corner radii derive from the theme shape contract rather than scattered `RoundedCornerShape(N.dp)` literals.
- Replaces all six call sites in `HomeScreen.kt` — `DiagnosticsBanner`, `WatchingTvToggle`, `NowWatchingCard`, `ShowRowCard` (card + poster crops), `ShelfCard`, `BadgePill` — with the corresponding `WatchBuddyShapes.*` token.
- Updates `ShowRowCard` container color from `surfaceVariant` → `surfaceContainerHigh` for automatic elevation-based tonal shift; semantic containers (`errorContainer`, `primaryContainer`, `tertiaryContainer`) are unchanged.
- Removes the now-redundant `ShowCardCorner` private constant.
- Adds `WatchBuddyShapesTest` (8 JUnit 5 tests) covering data-class equality, copy semantics, and expected radius relationships.

Scope is cosmetic only — no behaviour, copy, or string changes. TV app untouched.

## Test plan

- [ ] `WatchBuddyShapesTest` passes (`./gradlew :app-phone:test`)
- [ ] `./gradlew :app-phone:assembleDebug` succeeds
- [ ] `./gradlew detektAll :app-phone:lintDebug` — no new findings
- [ ] Install phone APK and visually verify HomeScreen:
  - Diagnostics banner still reads as an error surface
  - "I am watching TV" toggle changes colour when active
  - "Now Watching" card stands out from neutral show rows
  - Show row cards look consistent in light and dark themes

> **Note:** Gradle scope was skipped locally (no Android SDK in this sandboxed environment). CI (`build-android.yml`) is the real gate.

Closes #336

https://claude.ai/code/session_012W4iGAH2SWL4E86qxTp7y3

---
_Generated by [Claude Code](https://claude.ai/code/session_012W4iGAH2SWL4E86qxTp7y3)_