### PR TITLE
fix(core): assume 100% progress when duration/position unavailable on scrobble stop

### DIFF
--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -650,16 +650,18 @@ class MediaSessionScrobbler @Inject constructor(
         progress: Float? = null,
     ) {
         if (sessionKey != currentlySessionKey) return
-        if (progress == null) {
-            Log.w(TAG, "Scrobble stop skipped — playback position/duration unavailable for '$sessionKey'")
-            currentlySessionKey = null
-            return
+        val effectiveProgress = progress ?: run {
+            DiagnosticLog.warn(
+                TAG,
+                "scrobble stop: duration/position unavailable for '$sessionKey' — assuming 100% (watched)"
+            )
+            100f
         }
         val candidate = matchSnapshot(snapshot)
         val show = candidate?.matchedShow
         val episode = candidate?.matchedEpisode
         if (show == null || episode == null) return
-        scrobbleDispatcher.dispatchStop(show, episode, progress)
+        scrobbleDispatcher.dispatchStop(show, episode, effectiveProgress)
         currentlySessionKey = null
         Log.i(TAG, "Scrobble stopped: ${show.title} S${episode.season}E${episode.number}")
     }

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerLifecycleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerLifecycleTest.kt
@@ -205,12 +205,13 @@ class MediaSessionScrobblerLifecycleTest {
         }
 
         @Test
-        fun `skips stop when progress is null`() = runTest {
+        fun `defaults to 100f when progress is null — assumes watched`() = runTest {
+            coEvery { scrobbleDispatcher.dispatchStop(any(), any(), any()) } just runs
             primeScrobbling()
 
             scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = null)
 
-            coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
+            coVerify { scrobbleDispatcher.dispatchStop(any(), any(), 100f) }
         }
 
         @Test

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerStopTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerStopTest.kt
@@ -1,0 +1,153 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import android.content.Context
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
+import com.justb81.watchbuddy.core.model.ScrobbleCandidate
+import com.justb81.watchbuddy.core.model.TraktEpisode
+import com.justb81.watchbuddy.core.model.TraktIds
+import com.justb81.watchbuddy.core.model.TraktShow
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.tmdb.TmdbApiService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression tests for issue #403: handleScrobbleStop silently dropped stop events when
+ * duration/position was unavailable (e.g. streaming apps that report duration=0 on the
+ * last tick during credits or livestream segmentation).
+ *
+ * The fix treats a missing progress as "watched" and sends progress=100f, matching
+ * the lenient fallback already used by handleScrobblePause (which defaults to 50f).
+ */
+@DisplayName("MediaSessionScrobbler — Stop with unavailable progress (#403)")
+class MediaSessionScrobblerStopTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val tmdbApiService: TmdbApiService = mockk()
+    private val watchedShowSource: WatchedShowSource = mockk()
+    private val scrobbleDispatcher: ScrobbleDispatcher = mockk()
+    private lateinit var scrobbler: MediaSessionScrobbler
+
+    private val testShow = TraktShow("Breaking Bad", 2008, TraktIds(trakt = 1))
+    private val testEpisode = TraktEpisode(season = 1, number = 1)
+    private val testCandidate = ScrobbleCandidate(
+        "com.netflix", "Breaking Bad S01E01", 0.95f, testShow, testEpisode
+    )
+    private val testSnapshot = MediaMetadataSnapshot(
+        packageName = "com.netflix",
+        title = "Breaking Bad S01E01",
+    )
+    private val testSessionKey = "com.netflix:Breaking Bad S01E01"
+
+    @BeforeEach
+    fun setUp() {
+        scrobbler = MediaSessionScrobbler(
+            context, tmdbApiService, watchedShowSource, scrobbleDispatcher, NoOpTitleExtractor
+        )
+        coEvery { scrobbleDispatcher.dispatchStart(any(), any(), any()) } just runs
+        coEvery { scrobbleDispatcher.dispatchStop(any(), any(), any()) } just runs
+        coEvery { watchedShowSource.getCachedShows() } returns
+            listOf(TraktWatchedEntry(show = testShow))
+        coEvery { watchedShowSource.getTmdbApiKey() } returns null
+    }
+
+    private suspend fun primeScrobbling() {
+        scrobbler.autoScrobble(testCandidate)
+    }
+
+    @Test
+    fun `dispatches stop with 100f when progress is null — duration=0 on last tick`() = runTest {
+        primeScrobbling()
+
+        scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = null)
+
+        coVerify { scrobbleDispatcher.dispatchStop(testShow, testEpisode, 100f) }
+    }
+
+    @Test
+    fun `clears currentlyScrobbling after null-progress stop so next play can scrobble`() = runTest {
+        primeScrobbling()
+
+        scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = null)
+
+        // autoScrobble must succeed for the same session key after the stop cleared state
+        scrobbler.autoScrobble(testCandidate)
+        coVerify { scrobbleDispatcher.dispatchStart(testShow, testEpisode, any()) }
+    }
+
+    @Test
+    fun `dispatches stop with explicit progress when available`() = runTest {
+        primeScrobbling()
+
+        scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = 85f)
+
+        coVerify { scrobbleDispatcher.dispatchStop(testShow, testEpisode, 85f) }
+    }
+
+    @Test
+    fun `null-progress stop emits DiagnosticLog WARN with session key`() = runTest {
+        primeScrobbling()
+        val beforeMs = System.currentTimeMillis()
+
+        scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = null)
+
+        val warnEntries = DiagnosticLog.snapshot().filter { entry ->
+            entry.level == DiagnosticLog.Level.WARN &&
+                entry.message.contains(testSessionKey) &&
+                entry.message.contains("100%") &&
+                entry.timestampMs >= beforeMs
+        }
+        assertTrue(warnEntries.isNotEmpty(), "Expected a WARN breadcrumb mentioning the session key and 100%")
+    }
+
+    @Test
+    fun `no dispatch when session key does not match currently scrobbling`() = runTest {
+        primeScrobbling()
+        val otherKey = "com.netflix:Other Show"
+        val otherSnapshot = MediaMetadataSnapshot(packageName = "com.netflix", title = "Other Show")
+
+        scrobbler.handleScrobbleStop(otherSnapshot, otherKey, progress = null)
+
+        coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
+    }
+
+    @Test
+    fun `null-progress stop still skips dispatch when no library match`() = runTest {
+        coEvery { watchedShowSource.getCachedShows() } returns emptyList()
+        primeScrobbling()
+
+        scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = null)
+
+        coVerify(exactly = 0) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
+    }
+
+    @Test
+    fun `progress of 0 is not treated as null — dispatches with 0f`() = runTest {
+        primeScrobbling()
+
+        scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = 0f)
+
+        coVerify { scrobbleDispatcher.dispatchStop(testShow, testEpisode, 0f) }
+    }
+
+    @Test
+    fun `null-progress stop does not double-dispatch when called twice`() = runTest {
+        primeScrobbling()
+
+        scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = null)
+        // Second call — currentlySessionKey is already null, so it should be a no-op
+        scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = null)
+
+        coVerify(exactly = 1) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }
+    }
+}

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerStopTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerStopTest.kt
@@ -15,7 +15,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName


### PR DESCRIPTION
## Summary

- **Root cause:** `handleScrobbleStop` bailed out without calling `dispatchStop` when `computeProgress` returned `null` (triggered when `durationMs <= 0` or `positionMs < 0`). Some streaming apps report `duration = 0` on the last tick before `STATE_STOPPED` (credits roll, livestream segmentation, app-side bugs), so Trakt never received `/scrobble/stop` and the episode was never marked as watched.
- **Fix:** Treat missing progress at `STATE_STOPPED` as "watched" — fall back to `progress = 100f` and emit a `DiagnosticLog.warn` breadcrumb. This mirrors the lenient fallback already in `handleScrobblePause` (which defaults to `50f`).
- **Rationale from issue:** If the user had bailed out early, the session would have transitioned through `STATE_PAUSED` first (dispatching the 50% pause). Reaching `STATE_STOPPED` without a prior pause really does mean "playback ended."

## Changes

- `core/…/scrobbler/MediaSessionScrobbler.kt` — replaced the silent skip with a `100f` fallback + `DiagnosticLog.warn`
- `core/…/scrobbler/MediaSessionScrobblerLifecycleTest.kt` — updated the existing `skips stop when progress is null` test to assert the new behaviour (`dispatchStop` called with `100f`)
- `core/…/scrobbler/MediaSessionScrobblerStopTest.kt` *(new)* — dedicated regression suite for #403: null-progress dispatches `100f`, clears session key, emits the WARN breadcrumb, does not double-dispatch, `0f` explicit progress still passes through unchanged

## Test plan

- [ ] `./gradlew :core:test` passes with the new `MediaSessionScrobblerStopTest` and updated `MediaSessionScrobblerLifecycleTest`
- [ ] CI `Test & Build` check is green

> **Note:** Gradle checks were skipped locally (no Android SDK in sandbox). CI is the real gate.

Closes #403

https://claude.ai/code/session_01QPbi3voZhd1ghs3ULMQWTX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QPbi3voZhd1ghs3ULMQWTX)_