### PR TITLE
fix(tv): track real notification access in MediaSessionScrobbler per poll tick

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/TvDiscoveryService.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/TvDiscoveryService.kt
@@ -8,7 +8,11 @@ import android.app.Service
 import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.ServiceInfo
+import android.database.ContentObserver
+import android.os.Handler
 import android.os.IBinder
+import android.os.Looper
+import android.provider.Settings
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.justb81.watchbuddy.R
@@ -44,6 +48,7 @@ class TvDiscoveryService : Service() {
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     private var observerJob: Job? = null
+    private var notificationAccessObserver: ContentObserver? = null
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -75,6 +80,7 @@ class TvDiscoveryService : Service() {
                     if (discovery) {
                         phoneDiscovery.setEnabled(true)
                         startScrobblerIfPermitted()
+                        registerNotificationAccessObserver()
                     } else {
                         DiagnosticLog.event(TAG, "phone discovery disabled — stopping self")
                         scrobbler.stopListening()
@@ -116,8 +122,45 @@ class TvDiscoveryService : Service() {
         super.onDestroy()
         DiagnosticLog.event(TAG, "service destroyed")
         scrobbler.stopListening()
+        notificationAccessObserver?.let { contentResolver.unregisterContentObserver(it) }
+        notificationAccessObserver = null
         observerJob?.cancel()
         scope.cancel()
+    }
+
+    /**
+     * Registers a [ContentObserver] on [Settings.Secure.ENABLED_NOTIFICATION_LISTENERS]
+     * so the service can react to permission changes without requiring the user to
+     * toggle Phone discovery. Idempotent — subsequent calls while already registered
+     * are no-ops.
+     */
+    private fun registerNotificationAccessObserver() {
+        if (notificationAccessObserver != null) return
+        val uri = Settings.Secure.getUriFor(Settings.Secure.ENABLED_NOTIFICATION_LISTENERS)
+        notificationAccessObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
+            override fun onChange(selfChange: Boolean) {
+                onNotificationAccessChanged()
+            }
+        }
+        contentResolver.registerContentObserver(uri, false, notificationAccessObserver!!)
+    }
+
+    /**
+     * Called whenever the system notification-listener allowlist changes.
+     * Starts the scrobbler if access was just granted and it isn't running yet;
+     * stops it immediately when access is revoked so [isListening] reflects reality
+     * before the next per-tick poll in [MediaSessionScrobbler].
+     */
+    private fun onNotificationAccessChanged() {
+        val granted = NotificationManagerCompat.getEnabledListenerPackages(this)
+            .contains(packageName)
+        if (granted && !scrobbler.isListening.value) {
+            DiagnosticLog.warn(TAG, "notification access granted — starting scrobbler")
+            startScrobblerIfPermitted()
+        } else if (!granted && scrobbler.isListening.value) {
+            DiagnosticLog.warn(TAG, "notification access revoked — stopping scrobbler")
+            scrobbler.stopListening()
+        }
     }
 
     private fun ensureNotificationChannel() {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/TvDiscoveryService.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/TvDiscoveryService.kt
@@ -129,14 +129,14 @@ class TvDiscoveryService : Service() {
     }
 
     /**
-     * Registers a [ContentObserver] on [Settings.Secure.ENABLED_NOTIFICATION_LISTENERS]
-     * so the service can react to permission changes without requiring the user to
-     * toggle Phone discovery. Idempotent — subsequent calls while already registered
-     * are no-ops.
+     * Registers a [ContentObserver] on `enabled_notification_listeners` in
+     * [Settings.Secure] so the service can react to permission changes without
+     * requiring the user to toggle Phone discovery. Idempotent — subsequent calls
+     * while already registered are no-ops.
      */
     private fun registerNotificationAccessObserver() {
         if (notificationAccessObserver != null) return
-        val uri = Settings.Secure.getUriFor(Settings.Secure.ENABLED_NOTIFICATION_LISTENERS)
+        val uri = Settings.Secure.getUriFor("enabled_notification_listeners")
         notificationAccessObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
             override fun onChange(selfChange: Boolean) {
                 onNotificationAccessChanged()

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -116,11 +116,7 @@ fun TvDiagnosticsScreen(
                         DiagRow(
                             stringResource(R.string.tv_diagnostics_row_scrobbler_listening),
                             yesNoStr(uiState.scrobblerListening),
-                            when {
-                                uiState.scrobblerListening -> Status.OK
-                                uiState.notificationAccessGranted -> Status.WARN
-                                else -> Status.NEUTRAL
-                            },
+                            if (uiState.scrobblerListening) Status.OK else Status.FAIL,
                         ),
                         DiagRow(
                             stringResource(R.string.tv_diagnostics_row_last_candidate),

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModelTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -93,5 +94,40 @@ class TvDiagnosticsViewModelTest {
         assertEquals(100, events.size)
         assertEquals("msg 149", events[0].message)
         assertEquals("msg 50", events[99].message)
+    }
+
+    @Test
+    fun `scrobblerListening reflects true when scrobbler isListening emits true`() = runTest {
+        val isListeningFlow = MutableStateFlow(false)
+        every { scrobbler.isListening } returns isListeningFlow
+        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo)
+        advanceUntilIdle()
+
+        isListeningFlow.value = true
+        advanceUntilIdle()
+
+        assertTrue(vm.uiState.value.scrobblerListening)
+    }
+
+    @Test
+    fun `scrobblerListening reflects false when scrobbler isListening emits false`() = runTest {
+        val isListeningFlow = MutableStateFlow(true)
+        every { scrobbler.isListening } returns isListeningFlow
+        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo)
+        advanceUntilIdle()
+
+        isListeningFlow.value = false
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.scrobblerListening)
+    }
+
+    @Test
+    fun `scrobblerListening starts as false when scrobbler is not listening`() = runTest {
+        every { scrobbler.isListening } returns MutableStateFlow(false)
+        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo)
+        advanceUntilIdle()
+
+        assertFalse(vm.uiState.value.scrobblerListening)
     }
 }

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -154,8 +154,11 @@ class MediaSessionScrobbler @Inject constructor(
                 val wasListening = _isListening.value
                 _isListening.value = granted
                 if (wasListening != granted) {
-                    if (granted) DiagnosticLog.event(TAG, "notification access granted — scrobbler resumed")
-                    else DiagnosticLog.warn(TAG, "notification access revoked — scrobbler paused")
+                    if (granted) {
+                        DiagnosticLog.event(TAG, "notification access granted — scrobbler resumed")
+                    } else {
+                        DiagnosticLog.warn(TAG, "notification access revoked — scrobbler paused")
+                    }
                 }
                 if (!granted) {
                     delay(30_000)

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.media.session.MediaSessionManager
 import android.media.session.PlaybackState
 import android.util.Log
+import androidx.core.app.NotificationManagerCompat
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
 import com.justb81.watchbuddy.core.model.ScrobbleCandidate
@@ -115,6 +116,14 @@ class MediaSessionScrobbler @Inject constructor(
     private var currentlySessionKey: String? = null
 
     /**
+     * Returns true when this app currently holds notification-listener access.
+     * Overridable in tests to avoid a real Android framework call.
+     */
+    internal var notificationAccessChecker: () -> Boolean = {
+        NotificationManagerCompat.getEnabledListenerPackages(context).contains(context.packageName)
+    }
+
+    /**
      * Debug firehose toggle. When true, every poll tick writes a per-session breadcrumb
      * to [DiagnosticLog] (package, title, state, position, duration) regardless of
      * confidence, plus a near-miss line when a title fails to clear [OVERLAY_THRESHOLD].
@@ -136,12 +145,22 @@ class MediaSessionScrobbler @Inject constructor(
 
     fun startListening(notificationListenerComponent: ComponentName) {
         scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-        _isListening.value = true
         val sessionManager = context.getSystemService(Context.MEDIA_SESSION_SERVICE)
                 as MediaSessionManager
 
         pollingJob = scope.launch {
             while (isActive) {
+                val granted = notificationAccessChecker()
+                val wasListening = _isListening.value
+                _isListening.value = granted
+                if (wasListening != granted) {
+                    if (granted) DiagnosticLog.event(TAG, "notification access granted — scrobbler resumed")
+                    else DiagnosticLog.warn(TAG, "notification access revoked — scrobbler paused")
+                }
+                if (!granted) {
+                    delay(30_000)
+                    continue
+                }
                 try {
                     val sessions = sessionManager.getActiveSessions(notificationListenerComponent)
                     val liveKeys = mutableSetOf<String>()

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -143,6 +143,25 @@ class MediaSessionScrobbler @Inject constructor(
      */
     private val lastProgressBySessionKey = ConcurrentHashMap<String, LastKnownProgress>()
 
+    /**
+     * Checks notification-listener access on every poll tick, updates [_isListening],
+     * and emits a breadcrumb when the state flips. Returns true when access is granted
+     * and session polling should proceed.
+     */
+    private fun updateListeningState(): Boolean {
+        val granted = notificationAccessChecker()
+        val wasListening = _isListening.value
+        _isListening.value = granted
+        if (wasListening != granted) {
+            if (granted) {
+                DiagnosticLog.event(TAG, "notification access granted — scrobbler resumed")
+            } else {
+                DiagnosticLog.warn(TAG, "notification access revoked — scrobbler paused")
+            }
+        }
+        return granted
+    }
+
     fun startListening(notificationListenerComponent: ComponentName) {
         scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
         val sessionManager = context.getSystemService(Context.MEDIA_SESSION_SERVICE)
@@ -150,17 +169,7 @@ class MediaSessionScrobbler @Inject constructor(
 
         pollingJob = scope.launch {
             while (isActive) {
-                val granted = notificationAccessChecker()
-                val wasListening = _isListening.value
-                _isListening.value = granted
-                if (wasListening != granted) {
-                    if (granted) {
-                        DiagnosticLog.event(TAG, "notification access granted — scrobbler resumed")
-                    } else {
-                        DiagnosticLog.warn(TAG, "notification access revoked — scrobbler paused")
-                    }
-                }
-                if (!granted) {
+                if (!updateListeningState()) {
                     delay(30_000)
                     continue
                 }

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerLifecycleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerLifecycleTest.kt
@@ -79,14 +79,39 @@ class MediaSessionScrobblerLifecycleTest {
         }
 
         @Test
-        fun `isListening reflects start and stop transitions`() {
+        fun `isListening is false before startListening and after stopListening`() {
             val component = mockk<ComponentName>()
             assertFalse(scrobbler.isListening.value)
+            scrobbler.notificationAccessChecker = { true }
             scrobbler.startListening(component)
+            // isListening is set by the polling coroutine on the first tick, not synchronously
+            scrobbler.stopListening()
+            assertFalse(scrobbler.isListening.value)
+        }
+
+        @Test
+        fun `isListening becomes true after first poll tick when access is granted`() {
+            val component = mockk<ComponentName>()
+            scrobbler.notificationAccessChecker = { true }
+            assertFalse(scrobbler.isListening.value)
+            scrobbler.startListening(component)
+            // First tick runs immediately on IO dispatcher; 200 ms is ample
+            Thread.sleep(200)
             assertTrue(scrobbler.isListening.value)
             scrobbler.stopListening()
             assertFalse(scrobbler.isListening.value)
         }
+
+        @Test
+        fun `isListening stays false when notification access is not granted`() {
+            val component = mockk<ComponentName>()
+            scrobbler.notificationAccessChecker = { false }
+            scrobbler.startListening(component)
+            Thread.sleep(200)
+            assertFalse(scrobbler.isListening.value)
+            scrobbler.stopListening()
+        }
+
     }
 
     // ── autoScrobble() ───────────────────────────────────────────────────────

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerLifecycleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerLifecycleTest.kt
@@ -111,7 +111,6 @@ class MediaSessionScrobblerLifecycleTest {
             assertFalse(scrobbler.isListening.value)
             scrobbler.stopListening()
         }
-
     }
 
     // ── autoScrobble() ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes two failure modes where TV Diagnostics showed a misleading "Scrobbler listening: Yes" (green) despite no sessions being observable:

- **Access revoked mid-session**: `startListening` unconditionally set `_isListening = true`; revoking notification access left the flag stuck and `getActiveSessions` silently returned empty.
- **Access granted after service start**: The one-shot check in `startScrobblerIfPermitted` never re-ran, requiring the user to toggle Phone discovery to start the scrobbler.

## Changes

- **`MediaSessionScrobbler`**: removes the unconditional `_isListening.value = true` from `startListening`; checks `notificationAccessChecker()` on every 30 s poll tick, sets `_isListening` to match reality, skips session polling when access is missing, and emits `DiagnosticLog.warn/event` breadcrumbs on state flips. An internal `notificationAccessChecker: () -> Boolean` var (defaulting to the real `NotificationManagerCompat` call) keeps the class unit-testable without Android-framework dependencies.
- **`TvDiscoveryService`**: registers a `ContentObserver` on `Settings.Secure.ENABLED_NOTIFICATION_LISTENERS` when phone discovery is enabled. Calls `startScrobblerIfPermitted()` immediately when access is granted post-start; calls `scrobbler.stopListening()` immediately on revocation. Observer is unregistered in `onDestroy`.
- **`TvDiagnosticsScreen`**: scrobbler-listening row now shows FAIL (red) in both the "access missing" and "access granted but polling idle" states instead of NEUTRAL/WARN.
- **Tests**: updates `isListening reflects start and stop transitions` to match the new async semantics; adds three new lifecycle tests for granted/denied first-tick behavior; adds three `TvDiagnosticsViewModelTest` cases for `scrobblerListening` flow propagation.

## Test plan

- [ ] Run `./gradlew :app-tv:testDebugUnitTest :core:test` — all tests pass
- [ ] Manual: grant notification access → TV Diagnostics shows `Scrobbler listening: Yes` (green) within one 30 s poll
- [ ] Manual: revoke access via system settings → Diagnostics flips to `No` (red) without toggling Phone discovery
- [ ] Manual: grant access after the service is already running (no phone-discovery toggle needed) → scrobbler starts via ContentObserver

> **Note:** Gradle checks were skipped locally (no Android SDK in this environment). CI (`build-android.yml`) is the real gate.

Closes #404

https://claude.ai/code/session_01BdUm6f7wPasgd2TAsaUJYY

---
_Generated by [Claude Code](https://claude.ai/code/session_01BdUm6f7wPasgd2TAsaUJYY)_