### PR TITLE
feat(tv): retry dropped scrobbles when phones become reachable again

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
@@ -7,12 +7,16 @@ import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher
 import com.justb81.watchbuddy.tv.discovery.DiscoveryConstants
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
-import com.justb81.watchbuddy.tv.discovery.PhoneApiService
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import com.justb81.watchbuddy.tv.discovery.PhoneScrobbleRequest
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import retrofit2.HttpException
 import java.io.IOException
 import javax.inject.Inject
@@ -24,41 +28,90 @@ import javax.inject.Singleton
  * Fans scrobble events in parallel to every available connected phone's HTTP API.
  * Each phone records the episode on its own Trakt account. A failure for one phone
  * does not block scrobbling for the others.
+ *
+ * When no phones are reachable at dispatch time, the event is held in a bounded
+ * in-memory queue (max [QUEUE_MAX_SIZE] entries, drop-oldest). The queue is drained
+ * automatically on the next [PhoneDiscoveryManager.discoveredPhones] emission that
+ * contains at least one reachable phone, provided the event is still within
+ * [QUEUE_TTL_MS].
  */
 @Singleton
-class TvScrobbleDispatcher @Inject constructor(
+class TvScrobbleDispatcher(
     private val phoneDiscovery: PhoneDiscoveryManager,
-    private val phoneApiClientFactory: PhoneApiClientFactory
+    private val phoneApiClientFactory: PhoneApiClientFactory,
+    private val replayScope: CoroutineScope,
+    private val clock: () -> Long,
 ) : ScrobbleDispatcher {
+
+    @Inject
+    constructor(
+        phoneDiscovery: PhoneDiscoveryManager,
+        phoneApiClientFactory: PhoneApiClientFactory,
+    ) : this(
+        phoneDiscovery,
+        phoneApiClientFactory,
+        CoroutineScope(SupervisorJob() + Dispatchers.Default),
+        System::currentTimeMillis,
+    )
 
     companion object {
         private const val TAG = "TvScrobbleDispatcher"
+        internal const val QUEUE_MAX_SIZE = 16
+        internal const val QUEUE_TTL_MS = 5 * 60 * 1_000L
     }
 
     internal enum class ScrobbleAction { START, PAUSE, STOP }
 
+    internal data class QueuedScrobble(
+        val action: ScrobbleAction,
+        val show: TraktShow,
+        val episode: TraktEpisode,
+        val progress: Float,
+        val capturedAtMs: Long,
+    )
+
+    private val queueMutex = Mutex()
+    private val pendingQueue = ArrayDeque<QueuedScrobble>()
+
+    init {
+        replayScope.launch {
+            phoneDiscovery.discoveredPhones.collect { _ ->
+                if (availablePhones().isNotEmpty()) {
+                    drainQueue()
+                }
+            }
+        }
+    }
+
     private fun availablePhones(): List<PhoneDiscoveryManager.DiscoveredPhone> {
-        val now = System.currentTimeMillis()
+        val now = clock()
         return phoneDiscovery.discoveredPhones.value
             .filter { it.capability?.isAvailable == true }
             .filter { now - it.lastSuccessfulCheck < DiscoveryConstants.PRESENCE_STALENESS_MS }
     }
 
-    private suspend fun dispatch(
+    private suspend fun drainQueue() {
+        val now = clock()
+        val toReplay = queueMutex.withLock {
+            val fresh = pendingQueue.filter { now - it.capturedAtMs <= QUEUE_TTL_MS }
+            pendingQueue.clear()
+            fresh
+        }
+        if (toReplay.isEmpty()) return
+        toReplay.forEach { q ->
+            dispatchToPhones(q.action, q.show, q.episode, q.progress)
+        }
+        DiagnosticLog.event(TAG, "replayed ${toReplay.size} queued scrobbles")
+    }
+
+    private suspend fun dispatchToPhones(
         action: ScrobbleAction,
         show: TraktShow,
         episode: TraktEpisode,
         progress: Float,
     ) {
         val phones = availablePhones()
-        if (phones.isEmpty()) {
-            Log.w(TAG, "No phones available — scrobble ${action.name.lowercase()} skipped")
-            DiagnosticLog.warn(
-                TAG,
-                "scrobble ${action.name.lowercase()} dropped — no phones reachable",
-            )
-            return
-        }
+        if (phones.isEmpty()) return
         val request = PhoneScrobbleRequest(show = show, episode = episode, progress = progress)
         coroutineScope {
             phones.forEach { phone ->
@@ -89,6 +142,30 @@ class TvScrobbleDispatcher @Inject constructor(
                 }
             }
         }
+    }
+
+    private suspend fun dispatch(
+        action: ScrobbleAction,
+        show: TraktShow,
+        episode: TraktEpisode,
+        progress: Float,
+    ) {
+        val phones = availablePhones()
+        if (phones.isEmpty()) {
+            DiagnosticLog.warn(
+                TAG,
+                "scrobble ${action.name.lowercase()} dropped — no phones reachable",
+            )
+            val queued = QueuedScrobble(action, show, episode, progress, clock())
+            queueMutex.withLock {
+                if (pendingQueue.size >= QUEUE_MAX_SIZE) {
+                    pendingQueue.removeFirst()
+                }
+                pendingQueue.addLast(queued)
+            }
+            return
+        }
+        dispatchToPhones(action, show, episode, progress)
     }
 
     override suspend fun dispatchStart(show: TraktShow, episode: TraktEpisode, progress: Float) =

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
@@ -11,6 +11,7 @@ import com.justb81.watchbuddy.tv.discovery.PhoneScrobbleRequest
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
@@ -69,7 +70,7 @@ class TvScrobbleDispatcherTest {
     inner class StalenessFilteringTest {
 
         @Test
-        fun `dispatches to a fresh phone`() = runTest {
+        fun `dispatches to a fresh phone`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val phone = makePhone()
             phonesFlow.value = listOf(phone)
@@ -86,7 +87,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `skips a stale phone whose lastSuccessfulCheck exceeds PRESENCE_STALENESS_MS`() = runTest {
+        fun `skips a stale phone whose lastSuccessfulCheck exceeds PRESENCE_STALENESS_MS`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val staleTime = fakeNow - DiscoveryConstants.PRESENCE_STALENESS_MS - 1_000L
             val phone = makePhone(lastSuccessfulCheck = staleTime)
@@ -102,7 +103,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `includes a phone whose lastSuccessfulCheck is exactly at the staleness boundary`() = runTest {
+        fun `includes a phone whose lastSuccessfulCheck is exactly at the staleness boundary`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             // A check that happened exactly at the boundary should still be considered fresh.
             val boundaryTime = fakeNow - DiscoveryConstants.PRESENCE_STALENESS_MS + 100L
@@ -121,7 +122,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `skips a phone marked as unavailable even when fresh`() = runTest {
+        fun `skips a phone marked as unavailable even when fresh`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val phone = makePhone(isAvailable = false)
             phonesFlow.value = listOf(phone)
@@ -136,7 +137,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `skips dispatch when phone list is empty`() = runTest {
+        fun `skips dispatch when phone list is empty`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             phonesFlow.value = emptyList()
 
@@ -150,7 +151,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `dispatches to all fresh phones in parallel`() = runTest {
+        fun `dispatches to all fresh phones in parallel`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val apiService1: PhoneApiService = mockk()
             val apiService2: PhoneApiService = mockk()
@@ -173,7 +174,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `IOException on one phone does not prevent dispatch to others`() = runTest {
+        fun `IOException on one phone does not prevent dispatch to others`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val apiService1: PhoneApiService = mockk()
             val apiService2: PhoneApiService = mockk()
@@ -203,7 +204,7 @@ class TvScrobbleDispatcherTest {
     inner class ActionRoutingTest {
 
         @Test
-        fun `dispatchPause calls scrobblePause on available phones`() = runTest {
+        fun `dispatchPause calls scrobblePause on available phones`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val phone = makePhone()
             phonesFlow.value = listOf(phone)
@@ -222,7 +223,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `dispatchStop calls scrobbleStop on available phones`() = runTest {
+        fun `dispatchStop calls scrobbleStop on available phones`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val phone = makePhone()
             phonesFlow.value = listOf(phone)
@@ -241,7 +242,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `dispatchPause skips dispatch when phone list is empty`() = runTest {
+        fun `dispatchPause skips dispatch when phone list is empty`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             phonesFlow.value = emptyList()
 
@@ -255,7 +256,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `dispatchStop skips dispatch when phone list is empty`() = runTest {
+        fun `dispatchStop skips dispatch when phone list is empty`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             phonesFlow.value = emptyList()
 
@@ -269,7 +270,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `dispatchStart calls scrobbleStart not pause or stop`() = runTest {
+        fun `dispatchStart calls scrobbleStart not pause or stop`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val phone = makePhone()
             phonesFlow.value = listOf(phone)
@@ -295,7 +296,7 @@ class TvScrobbleDispatcherTest {
     inner class RetryQueueTest {
 
         @Test
-        fun `dropped START is dispatched when a phone later appears on discoveredPhones`() = runTest {
+        fun `dropped START is dispatched when a phone later appears on discoveredPhones`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             coEvery { phoneApiService.scrobbleStart(any()) } returns mockk()
@@ -312,7 +313,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `dropped PAUSE is replayed on the next phone emission`() = runTest {
+        fun `dropped PAUSE is replayed on the next phone emission`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             coEvery { phoneApiService.scrobblePause(any()) } returns mockk()
@@ -327,7 +328,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `dropped STOP is replayed on the next phone emission`() = runTest {
+        fun `dropped STOP is replayed on the next phone emission`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             coEvery { phoneApiService.scrobbleStop(any()) } returns mockk()
@@ -342,7 +343,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `queue is drained in FIFO order`() = runTest {
+        fun `queue is drained in FIFO order`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             val callOrder = mutableListOf<String>()
@@ -361,7 +362,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `stale queued events older than QUEUE_TTL_MS are discarded on drain`() = runTest {
+        fun `stale queued events older than QUEUE_TTL_MS are discarded on drain`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             coEvery { phoneApiService.scrobbleStart(any()) } returns mockk()
@@ -379,7 +380,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `queue caps at QUEUE_MAX_SIZE and drops the oldest entry`() = runTest {
+        fun `queue caps at QUEUE_MAX_SIZE and drops the oldest entry`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             val dispatchedProgress = mutableListOf<Float>()
@@ -402,7 +403,7 @@ class TvScrobbleDispatcherTest {
         }
 
         @Test
-        fun `queue is empty after successful drain so second phone emission dispatches nothing`() = runTest {
+        fun `queue is empty after successful drain so second phone emission dispatches nothing`() = runTest(UnconfinedTestDispatcher()) {
             dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             coEvery { phoneApiService.scrobbleStart(any()) } returns mockk()

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
@@ -7,8 +7,11 @@ import com.justb81.watchbuddy.tv.discovery.DiscoveryConstants
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneApiService
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import com.justb81.watchbuddy.tv.discovery.PhoneScrobbleRequest
 import io.mockk.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -17,6 +20,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.io.IOException
 
+@OptIn(ExperimentalCoroutinesApi::class)
 @DisplayName("TvScrobbleDispatcher")
 class TvScrobbleDispatcherTest {
 
@@ -26,17 +30,18 @@ class TvScrobbleDispatcherTest {
     private lateinit var dispatcher: TvScrobbleDispatcher
 
     private val phonesFlow = MutableStateFlow<List<PhoneDiscoveryManager.DiscoveredPhone>>(emptyList())
+    private var fakeNow = System.currentTimeMillis()
 
     @BeforeEach
     fun setUp() {
         every { phoneDiscovery.discoveredPhones } returns phonesFlow
-        dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory)
+        fakeNow = System.currentTimeMillis()
     }
 
     private fun makePhone(
         baseUrl: String = "http://192.168.1.1:8765/",
         isAvailable: Boolean = true,
-        lastSuccessfulCheck: Long = System.currentTimeMillis(),
+        lastSuccessfulCheck: Long = fakeNow,
         name: String = "test-phone"
     ): PhoneDiscoveryManager.DiscoveredPhone {
         val serviceInfo = mockk<NsdServiceInfo>()
@@ -65,6 +70,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatches to a fresh phone`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
             val phone = makePhone()
             phonesFlow.value = listOf(phone)
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
@@ -81,7 +87,8 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `skips a stale phone whose lastSuccessfulCheck exceeds PRESENCE_STALENESS_MS`() = runTest {
-            val staleTime = System.currentTimeMillis() - DiscoveryConstants.PRESENCE_STALENESS_MS - 1_000L
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            val staleTime = fakeNow - DiscoveryConstants.PRESENCE_STALENESS_MS - 1_000L
             val phone = makePhone(lastSuccessfulCheck = staleTime)
             phonesFlow.value = listOf(phone)
 
@@ -96,8 +103,9 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `includes a phone whose lastSuccessfulCheck is exactly at the staleness boundary`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
             // A check that happened exactly at the boundary should still be considered fresh.
-            val boundaryTime = System.currentTimeMillis() - DiscoveryConstants.PRESENCE_STALENESS_MS + 100L
+            val boundaryTime = fakeNow - DiscoveryConstants.PRESENCE_STALENESS_MS + 100L
             val phone = makePhone(lastSuccessfulCheck = boundaryTime)
             phonesFlow.value = listOf(phone)
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
@@ -114,6 +122,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `skips a phone marked as unavailable even when fresh`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
             val phone = makePhone(isAvailable = false)
             phonesFlow.value = listOf(phone)
 
@@ -128,6 +137,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `skips dispatch when phone list is empty`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
             phonesFlow.value = emptyList()
 
             dispatcher.dispatchStart(
@@ -141,6 +151,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatches to all fresh phones in parallel`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
             val apiService1: PhoneApiService = mockk()
             val apiService2: PhoneApiService = mockk()
             val phone1 = makePhone(baseUrl = "http://phone1:8765/", name = "phone1")
@@ -163,6 +174,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `IOException on one phone does not prevent dispatch to others`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
             val apiService1: PhoneApiService = mockk()
             val apiService2: PhoneApiService = mockk()
             val phone1 = makePhone(baseUrl = "http://phone1:8765/", name = "phone1")
@@ -192,6 +204,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatchPause calls scrobblePause on available phones`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
             val phone = makePhone()
             phonesFlow.value = listOf(phone)
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
@@ -210,6 +223,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatchStop calls scrobbleStop on available phones`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
             val phone = makePhone()
             phonesFlow.value = listOf(phone)
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
@@ -228,6 +242,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatchPause skips dispatch when phone list is empty`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
             phonesFlow.value = emptyList()
 
             dispatcher.dispatchPause(
@@ -241,6 +256,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatchStop skips dispatch when phone list is empty`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
             phonesFlow.value = emptyList()
 
             dispatcher.dispatchStop(
@@ -254,6 +270,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatchStart calls scrobbleStart not pause or stop`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
             val phone = makePhone()
             phonesFlow.value = listOf(phone)
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
@@ -268,6 +285,141 @@ class TvScrobbleDispatcherTest {
             coVerify { phoneApiService.scrobbleStart(any()) }
             coVerify(exactly = 0) { phoneApiService.scrobblePause(any()) }
             coVerify(exactly = 0) { phoneApiService.scrobbleStop(any()) }
+        }
+    }
+
+    // ── retry queue ────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("retry queue")
+    inner class RetryQueueTest {
+
+        @Test
+        fun `dropped START is dispatched when a phone later appears on discoveredPhones`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobbleStart(any()) } returns mockk()
+
+            // No phones → event is queued, not dispatched.
+            dispatcher.dispatchStart(TestFixtures.traktShow(), TestFixtures.traktEpisode(), 10f)
+            coVerify(exactly = 0) { phoneApiService.scrobbleStart(any()) }
+
+            // Phone appears → drain loop fires and replays the queued START.
+            phonesFlow.value = listOf(makePhone())
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { phoneApiService.scrobbleStart(any()) }
+        }
+
+        @Test
+        fun `dropped PAUSE is replayed on the next phone emission`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobblePause(any()) } returns mockk()
+
+            dispatcher.dispatchPause(TestFixtures.traktShow(), TestFixtures.traktEpisode(), 50f)
+            coVerify(exactly = 0) { phoneApiService.scrobblePause(any()) }
+
+            phonesFlow.value = listOf(makePhone())
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { phoneApiService.scrobblePause(any()) }
+        }
+
+        @Test
+        fun `dropped STOP is replayed on the next phone emission`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobbleStop(any()) } returns mockk()
+
+            dispatcher.dispatchStop(TestFixtures.traktShow(), TestFixtures.traktEpisode(), 90f)
+            coVerify(exactly = 0) { phoneApiService.scrobbleStop(any()) }
+
+            phonesFlow.value = listOf(makePhone())
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { phoneApiService.scrobbleStop(any()) }
+        }
+
+        @Test
+        fun `queue is drained in FIFO order`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            val callOrder = mutableListOf<String>()
+            coEvery { phoneApiService.scrobbleStart(any()) } answers { callOrder += "start"; mockk() }
+            coEvery { phoneApiService.scrobblePause(any()) } answers { callOrder += "pause"; mockk() }
+            coEvery { phoneApiService.scrobbleStop(any()) } answers { callOrder += "stop"; mockk() }
+
+            dispatcher.dispatchStart(TestFixtures.traktShow(), TestFixtures.traktEpisode(), 10f)
+            dispatcher.dispatchPause(TestFixtures.traktShow(), TestFixtures.traktEpisode(), 50f)
+            dispatcher.dispatchStop(TestFixtures.traktShow(), TestFixtures.traktEpisode(), 90f)
+
+            phonesFlow.value = listOf(makePhone())
+            advanceUntilIdle()
+
+            assertEquals(listOf("start", "pause", "stop"), callOrder)
+        }
+
+        @Test
+        fun `stale queued events older than QUEUE_TTL_MS are discarded on drain`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobbleStart(any()) } returns mockk()
+
+            // Enqueue a START at the current fake time.
+            dispatcher.dispatchStart(TestFixtures.traktShow(), TestFixtures.traktEpisode(), 10f)
+
+            // Advance the fake clock past the TTL — the entry is now expired.
+            fakeNow += TvScrobbleDispatcher.QUEUE_TTL_MS + 1_000L
+
+            phonesFlow.value = listOf(makePhone(lastSuccessfulCheck = fakeNow))
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { phoneApiService.scrobbleStart(any()) }
+        }
+
+        @Test
+        fun `queue caps at QUEUE_MAX_SIZE and drops the oldest entry`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            val dispatchedProgress = mutableListOf<Float>()
+            coEvery { phoneApiService.scrobbleStart(any()) } answers {
+                dispatchedProgress += firstArg<PhoneScrobbleRequest>().progress
+                mockk()
+            }
+
+            // Enqueue QUEUE_MAX_SIZE + 1 events; the first (progress=0f) should be dropped.
+            repeat(TvScrobbleDispatcher.QUEUE_MAX_SIZE + 1) { i ->
+                dispatcher.dispatchStart(TestFixtures.traktShow(), TestFixtures.traktEpisode(), i.toFloat())
+            }
+
+            phonesFlow.value = listOf(makePhone())
+            advanceUntilIdle()
+
+            assertEquals(TvScrobbleDispatcher.QUEUE_MAX_SIZE, dispatchedProgress.size)
+            assertFalse(dispatchedProgress.contains(0f), "oldest entry (progress=0) should have been dropped")
+            assertTrue(dispatchedProgress.contains(1f), "second entry should survive")
+        }
+
+        @Test
+        fun `queue is empty after successful drain so second phone emission dispatches nothing`() = runTest {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobbleStart(any()) } returns mockk()
+
+            dispatcher.dispatchStart(TestFixtures.traktShow(), TestFixtures.traktEpisode(), 10f)
+
+            // First phone appearance drains the queue.
+            phonesFlow.value = listOf(makePhone())
+            advanceUntilIdle()
+            coVerify(exactly = 1) { phoneApiService.scrobbleStart(any()) }
+
+            // Second phone appearance → queue is already empty, nothing more dispatched.
+            phonesFlow.value = emptyList()
+            phonesFlow.value = listOf(makePhone())
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { phoneApiService.scrobbleStart(any()) }
         }
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
@@ -70,7 +70,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatches to a fresh phone`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val phone = makePhone()
             phonesFlow.value = listOf(phone)
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
@@ -87,7 +87,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `skips a stale phone whose lastSuccessfulCheck exceeds PRESENCE_STALENESS_MS`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val staleTime = fakeNow - DiscoveryConstants.PRESENCE_STALENESS_MS - 1_000L
             val phone = makePhone(lastSuccessfulCheck = staleTime)
             phonesFlow.value = listOf(phone)
@@ -103,7 +103,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `includes a phone whose lastSuccessfulCheck is exactly at the staleness boundary`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             // A check that happened exactly at the boundary should still be considered fresh.
             val boundaryTime = fakeNow - DiscoveryConstants.PRESENCE_STALENESS_MS + 100L
             val phone = makePhone(lastSuccessfulCheck = boundaryTime)
@@ -122,7 +122,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `skips a phone marked as unavailable even when fresh`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val phone = makePhone(isAvailable = false)
             phonesFlow.value = listOf(phone)
 
@@ -137,7 +137,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `skips dispatch when phone list is empty`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             phonesFlow.value = emptyList()
 
             dispatcher.dispatchStart(
@@ -151,7 +151,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatches to all fresh phones in parallel`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val apiService1: PhoneApiService = mockk()
             val apiService2: PhoneApiService = mockk()
             val phone1 = makePhone(baseUrl = "http://phone1:8765/", name = "phone1")
@@ -174,7 +174,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `IOException on one phone does not prevent dispatch to others`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val apiService1: PhoneApiService = mockk()
             val apiService2: PhoneApiService = mockk()
             val phone1 = makePhone(baseUrl = "http://phone1:8765/", name = "phone1")
@@ -204,7 +204,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatchPause calls scrobblePause on available phones`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val phone = makePhone()
             phonesFlow.value = listOf(phone)
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
@@ -223,7 +223,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatchStop calls scrobbleStop on available phones`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val phone = makePhone()
             phonesFlow.value = listOf(phone)
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
@@ -242,7 +242,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatchPause skips dispatch when phone list is empty`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             phonesFlow.value = emptyList()
 
             dispatcher.dispatchPause(
@@ -256,7 +256,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatchStop skips dispatch when phone list is empty`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             phonesFlow.value = emptyList()
 
             dispatcher.dispatchStop(
@@ -270,7 +270,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dispatchStart calls scrobbleStart not pause or stop`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             val phone = makePhone()
             phonesFlow.value = listOf(phone)
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
@@ -296,7 +296,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dropped START is dispatched when a phone later appears on discoveredPhones`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             coEvery { phoneApiService.scrobbleStart(any()) } returns mockk()
 
@@ -313,7 +313,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dropped PAUSE is replayed on the next phone emission`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             coEvery { phoneApiService.scrobblePause(any()) } returns mockk()
 
@@ -328,7 +328,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `dropped STOP is replayed on the next phone emission`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             coEvery { phoneApiService.scrobbleStop(any()) } returns mockk()
 
@@ -343,7 +343,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `queue is drained in FIFO order`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             val callOrder = mutableListOf<String>()
             coEvery { phoneApiService.scrobbleStart(any()) } answers { callOrder += "start"; mockk() }
@@ -362,7 +362,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `stale queued events older than QUEUE_TTL_MS are discarded on drain`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             coEvery { phoneApiService.scrobbleStart(any()) } returns mockk()
 
@@ -380,7 +380,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `queue caps at QUEUE_MAX_SIZE and drops the oldest entry`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             val dispatchedProgress = mutableListOf<Float>()
             coEvery { phoneApiService.scrobbleStart(any()) } answers {
@@ -403,7 +403,7 @@ class TvScrobbleDispatcherTest {
 
         @Test
         fun `queue is empty after successful drain so second phone emission dispatches nothing`() = runTest {
-            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, this) { fakeNow }
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
             coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
             coEvery { phoneApiService.scrobbleStart(any()) } returns mockk()
 


### PR DESCRIPTION
## Summary

- Adds a bounded in-memory retry queue (cap 16, drop-oldest, 5-minute TTL) to `TvScrobbleDispatcher`
- Scrobbles dropped because no phone was reachable are now held in the queue and automatically replayed on the next `discoveredPhones` emission that contains at least one available phone
- Replaces the bare `Log.w` with `DiagnosticLog.warn` (already present) and emits a `DiagnosticLog.event` breadcrumb after successful replay
- Injects a `clock: () -> Long` lambda and a `CoroutineScope` through the primary constructor for full unit-test determinism; Hilt uses the secondary `@Inject` constructor with real defaults

## Test plan

- [x] 6 new unit tests: dropped-START/PAUSE/STOP replay on phone appearance, FIFO drain order, TTL expiry discards stale entries, queue cap drops oldest entry, queue empty after drain
- [ ] Run `./gradlew :app-tv:testDebugUnitTest` — all tests pass
- [ ] Manual: disconnect Wi-Fi on phone briefly during playback; expect DiagnosticLog WARN on drop and INFO breadcrumb on replay when connectivity returns

> **Note:** Gradle checks were skipped locally (no Android SDK in this environment). CI (`build-android.yml`) is the real gate.

Closes #405

https://claude.ai/code/session_01XEMWyxAct5LoRKmkdvh6rM

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEMWyxAct5LoRKmkdvh6rM)_