### PR TITLE
test(phone): restore LiteRtLlmProvider unit tests (closes #469)

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LiteRtLlmProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LiteRtLlmProvider.kt
@@ -46,9 +46,13 @@ class LiteRtLlmProvider internal constructor(
      * LiteRT-LM [Engine] plus a per-call [com.google.ai.edge.litertlm.Conversation].
      * Unit tests supply a pure-Kotlin fake so the JNI-backed LiteRT-LM classes
      * never have to load in the JVM test classpath.
+     *
+     * Parameters are plain Kotlin types (no LiteRT-LM imports) so the seam is
+     * safe to reference from JVM-only unit tests without risking native-library
+     * class-load failures during JUnit discovery.
      */
     internal fun interface EngineFactory {
-        fun create(config: EngineConfig): EngineHandle
+        fun create(modelPath: String, useGpu: Boolean): EngineHandle
     }
 
     /** Opaque handle over an initialized LiteRT-LM engine. */
@@ -96,11 +100,8 @@ class LiteRtLlmProvider internal constructor(
         return newHandle
     }
 
-    private fun createHandle(modelPath: String, useGpu: Boolean): EngineHandle {
-        val backend = if (useGpu) Backend.GPU() else Backend.CPU()
-        val config = EngineConfig(modelPath = modelPath, backend = backend)
-        return engineFactory.create(config)
-    }
+    private fun createHandle(modelPath: String, useGpu: Boolean): EngineHandle =
+        engineFactory.create(modelPath, useGpu)
 
     private fun resolveModelPath(): String {
         val modelDir = File(context.filesDir, "llm_models")
@@ -123,7 +124,9 @@ class LiteRtLlmProvider internal constructor(
     }
 
     private object DefaultEngineFactory : EngineFactory {
-        override fun create(config: EngineConfig): EngineHandle {
+        override fun create(modelPath: String, useGpu: Boolean): EngineHandle {
+            val backend = if (useGpu) Backend.GPU() else Backend.CPU()
+            val config = EngineConfig(modelPath = modelPath, backend = backend)
             val engine = Engine(config).also { it.initialize() }
             return RealEngineHandle(engine)
         }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LiteRtLlmProviderTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LiteRtLlmProviderTest.kt
@@ -84,7 +84,7 @@ class LiteRtLlmProviderTest {
             val factory = LiteRtLlmProvider.EngineFactory { _, useGpu ->
                 callCount++
                 if (useGpu) {
-                    throw IllegalStateException("GPU init failed")
+                    error("GPU init failed")
                 } else {
                     fakeHandle("CPU response")
                 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LiteRtLlmProviderTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LiteRtLlmProviderTest.kt
@@ -1,0 +1,171 @@
+package com.justb81.watchbuddy.phone.llm
+
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+@DisplayName("LiteRtLlmProvider")
+class LiteRtLlmProviderTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val context: Context = mockk(relaxed = true)
+
+    @BeforeEach
+    fun setUp() {
+        LiteRtLlmProvider.resetGpuKnownBadForTesting()
+        every { context.filesDir } returns File(tempDir, "files")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        LiteRtLlmProvider.resetGpuKnownBadForTesting()
+    }
+
+    private fun createModelFile() {
+        val modelDir = File(File(tempDir, "files"), "llm_models")
+        modelDir.mkdirs()
+        File(modelDir, LlmOrchestrator.ModelVariant.GEMMA4_E2B.fileName).createNewFile()
+    }
+
+    private fun fakeHandle(response: String = "Generated recap"): LiteRtLlmProvider.EngineHandle =
+        object : LiteRtLlmProvider.EngineHandle {
+            override fun sendMessage(prompt: String): String = response
+        }
+
+    private fun throwingHandle(message: String = "Engine failure"): LiteRtLlmProvider.EngineHandle =
+        object : LiteRtLlmProvider.EngineHandle {
+            override fun sendMessage(prompt: String): String = throw RuntimeException(message)
+        }
+
+    private fun provider(factory: LiteRtLlmProvider.EngineFactory): LiteRtLlmProvider =
+        LiteRtLlmProvider(context, LlmOrchestrator.ModelVariant.GEMMA4_E2B, factory)
+
+    @Nested
+    @DisplayName("GPU to CPU fallback — sendMessage failure")
+    inner class SendMessageFallback {
+
+        @Test
+        fun `GPU sendMessage throws then CPU retry succeeds`() = runTest {
+            createModelFile()
+            var callCount = 0
+            val factory = LiteRtLlmProvider.EngineFactory { _, useGpu ->
+                callCount++
+                if (useGpu) throwingHandle("OpenCL unavailable") else fakeHandle("CPU response")
+            }
+            val result = provider(factory).generate("test prompt")
+            assertEquals("CPU response", result)
+            assertEquals(2, callCount)
+            assertTrue(LiteRtLlmProvider.isGpuKnownBadForTesting())
+        }
+    }
+
+    @Nested
+    @DisplayName("GPU to CPU fallback — init failure")
+    inner class InitFallback {
+
+        @Test
+        fun `GPU engine init throws then CPU fallback succeeds`() = runTest {
+            createModelFile()
+            var callCount = 0
+            val factory = LiteRtLlmProvider.EngineFactory { _, useGpu ->
+                callCount++
+                if (useGpu) throw RuntimeException("GPU init failed")
+                else fakeHandle("CPU response")
+            }
+            val result = provider(factory).generate("test prompt")
+            assertEquals("CPU response", result)
+            assertEquals(2, callCount)
+            assertTrue(LiteRtLlmProvider.isGpuKnownBadForTesting())
+        }
+    }
+
+    @Nested
+    @DisplayName("gpuKnownBad latch")
+    inner class GpuKnownBadLatch {
+
+        @Test
+        fun `second provider instance skips GPU when latch is set`() = runTest {
+            createModelFile()
+            val factory1 = LiteRtLlmProvider.EngineFactory { _, useGpu ->
+                if (useGpu) throwingHandle("OpenCL unavailable") else fakeHandle("CPU response")
+            }
+            provider(factory1).generate("first prompt")
+            assertTrue(LiteRtLlmProvider.isGpuKnownBadForTesting())
+
+            var gpuRequested = false
+            val factory2 = LiteRtLlmProvider.EngineFactory { _, useGpu ->
+                if (useGpu) gpuRequested = true
+                fakeHandle("CPU direct")
+            }
+            val result = provider(factory2).generate("second prompt")
+            assertEquals("CPU direct", result)
+            assertFalse(gpuRequested)
+        }
+    }
+
+    @Nested
+    @DisplayName("Both backends fail")
+    inner class BothBackendsFail {
+
+        @Test
+        fun `exception propagates when GPU and CPU both fail`() = runTest {
+            createModelFile()
+            val factory = LiteRtLlmProvider.EngineFactory { _, _ -> throwingHandle("all failed") }
+            assertThrows<RuntimeException> {
+                provider(factory).generate("test prompt")
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Model file missing")
+    inner class ModelFileMissing {
+
+        @Test
+        fun `throws IllegalStateException and never invokes factory`() = runTest {
+            var factoryInvoked = false
+            val factory = LiteRtLlmProvider.EngineFactory { _, _ ->
+                factoryInvoked = true
+                fakeHandle()
+            }
+            assertThrows<IllegalStateException> {
+                provider(factory).generate("test prompt")
+            }
+            assertFalse(factoryInvoked)
+        }
+    }
+
+    @Nested
+    @DisplayName("Blank response handling")
+    inner class BlankResponseHandling {
+
+        @Test
+        fun `blank GPU response throws ISE without latching gpuKnownBad`() = runTest {
+            createModelFile()
+            var callCount = 0
+            val factory = LiteRtLlmProvider.EngineFactory { _, _ ->
+                callCount++
+                fakeHandle("")
+            }
+            assertThrows<IllegalStateException> {
+                provider(factory).generate("test prompt")
+            }
+            assertFalse(LiteRtLlmProvider.isGpuKnownBadForTesting())
+            assertEquals(1, callCount)
+        }
+    }
+}

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LiteRtLlmProviderTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LiteRtLlmProviderTest.kt
@@ -48,7 +48,7 @@ class LiteRtLlmProviderTest {
 
     private fun throwingHandle(message: String = "Engine failure"): LiteRtLlmProvider.EngineHandle =
         object : LiteRtLlmProvider.EngineHandle {
-            override fun sendMessage(prompt: String): String = throw RuntimeException(message)
+            override fun sendMessage(prompt: String): String = throw IllegalStateException(message)
         }
 
     private fun provider(factory: LiteRtLlmProvider.EngineFactory): LiteRtLlmProvider =
@@ -83,8 +83,11 @@ class LiteRtLlmProviderTest {
             var callCount = 0
             val factory = LiteRtLlmProvider.EngineFactory { _, useGpu ->
                 callCount++
-                if (useGpu) throw RuntimeException("GPU init failed")
-                else fakeHandle("CPU response")
+                if (useGpu) {
+                    throw IllegalStateException("GPU init failed")
+                } else {
+                    fakeHandle("CPU response")
+                }
             }
             val result = provider(factory).generate("test prompt")
             assertEquals("CPU response", result)
@@ -125,7 +128,7 @@ class LiteRtLlmProviderTest {
         fun `exception propagates when GPU and CPU both fail`() = runTest {
             createModelFile()
             val factory = LiteRtLlmProvider.EngineFactory { _, _ -> throwingHandle("all failed") }
-            assertThrows<RuntimeException> {
+            assertThrows<IllegalStateException> {
                 provider(factory).generate("test prompt")
             }
         }


### PR DESCRIPTION
## Summary

- Decouples `EngineFactory.create()` from LiteRT-LM's `EngineConfig` type: the interface now takes `(modelPath: String, useGpu: Boolean)` — plain Kotlin types — while `DefaultEngineFactory` constructs `EngineConfig` internally. This eliminates any LiteRT-LM class reference from the test seam, removing the likely root cause of the `DiscoveryIssueException` reported in #469 (JUnit Platform loading the test class forced loading of `EngineConfig`, which could trigger native-library class-load failures in the JVM-only test runner).
- Restores the six test cases from #469:
  1. GPU `sendMessage` throws → CPU retry succeeds
  2. GPU engine init throws → CPU fallback at init
  3. `gpuKnownBad` latch: second provider instance skips GPU directly
  4. Both GPU and CPU fail → exception propagates to the cascade
  5. Model file missing → `IllegalStateException`, factory never invoked
  6. Blank GPU response does **not** latch `gpuKnownBad` (treated as a content error, not a backend failure)

## Test plan

- [ ] CI `Test & Build` passes with all six new `LiteRtLlmProviderTest` cases green
- [ ] No detekt or Lint regressions in `app-phone`
- [ ] Existing `LlmOrchestratorTest` and `LlmProviderFactoryTest` still pass (they don't reference `EngineFactory` directly)

## Note on Gradle skipped locally

This session runs in a web sandbox without the Android SDK, so `./scripts/precommit.sh` skipped the Gradle scope with a yellow warning (expected per CLAUDE.md). CI (`build-android.yml`) is the real gate.

Closes #469

https://claude.ai/code/session_01E4o1dntPkE52GTwSE9qMcM

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4o1dntPkE52GTwSE9qMcM)_