### PR TITLE
refactor(core): collapse MediaMetadataSnapshot to text blob; add PlaybackTick, MetadataEnricher, NowPlayingSection

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.phone.di
 import android.content.Context
 import androidx.work.WorkManager
 import com.justb81.watchbuddy.BuildConfig
+import com.justb81.watchbuddy.core.scrobbler.MetadataEnricher
 import com.justb81.watchbuddy.core.scrobbler.NoOpTitleExtractor
 import com.justb81.watchbuddy.core.scrobbler.TitleExtractor
 import dagger.Module
@@ -78,4 +79,9 @@ object AppModule {
     @Provides
     @Singleton
     fun provideTitleExtractor(): TitleExtractor = NoOpTitleExtractor
+
+    /** No enrichers registered in the phone app yet; populated per-app via Hilt. */
+    @Provides
+    @Singleton
+    fun provideMetadataEnrichers(): List<MetadataEnricher> = emptyList()
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmTitleExtractor.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmTitleExtractor.kt
@@ -147,23 +147,15 @@ class LlmTitleExtractor @Inject constructor(
             }
             "{${parts.joinToString(",")}}"
         }
-        val snapshotLines = buildString {
-            appendLine("packageName: ${snapshot.packageName}")
-            snapshot.title?.let { appendLine("TITLE: $it") }
-            snapshot.displayTitle?.let { appendLine("DISPLAY_TITLE: $it") }
-            snapshot.displaySubtitle?.let { appendLine("DISPLAY_SUBTITLE: $it") }
-            snapshot.displayDescription?.let { appendLine("DISPLAY_DESCRIPTION: $it") }
-            snapshot.artist?.let { appendLine("ARTIST: $it") }
-            snapshot.albumArtist?.let { appendLine("ALBUM_ARTIST: $it") }
-            snapshot.album?.let { appendLine("ALBUM: $it") }
-        }
         return """
 You extract TV-show metadata from Android MediaSession fields published by
 streaming apps (Netflix, Prime Video, Disney+, Plex, Jellyfin, YouTube, etc.).
 Different apps put the show name, season, and episode in different fields.
+Each input line has the format "sourceTag: value".
 
-Input fields from the currently-playing session:
-$snapshotLines
+Input evidence from the currently-playing session (package: ${snapshot.packageName}):
+${snapshot.text}
+
 Shows the user already watches (prefer matching one of these if plausible):
 [
 $hintsJson

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -284,6 +284,14 @@ internal fun Application.configureCompanionRoutes(
             } catch (_: Exception) {
                 return@post call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid request body"))
             }
+            // Old TV clients that pre-date the text-blob migration send the snapshot
+            // with named fields and no `text` field; WatchBuddyJson ignores unknown
+            // keys and defaults `text` to "". Detect this and return confidence=0
+            // gracefully instead of running inference on empty evidence.
+            if (body.snapshot.text.isBlank()) {
+                DiagnosticLog.warn(TAG, "extract: empty snapshot text — likely old-format client, returning confidence=0")
+                return@post call.respond(TitleExtractionResponse(confidence = 0f))
+            }
             try {
                 val response = titleExtractor.extract(body.snapshot, body.libraryHints)
                     ?: TitleExtractionResponse(confidence = 0f)

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LlmTitleExtractorTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LlmTitleExtractorTest.kt
@@ -139,8 +139,9 @@ class LlmTitleExtractorTest {
         assertNull(result!!.showTitle)
     }
 
-    private fun sampleSnapshot() = MediaMetadataSnapshot(
-        packageName = "com.netflix.ninja",
-        title = "Pilot",
-    )
+    private fun sampleSnapshot(): MediaMetadataSnapshot {
+        val builder = com.justb81.watchbuddy.core.scrobbler.MediaSnapshotBuilder("com.netflix.ninja")
+        builder.add("mediaSession.title", "Pilot")
+        return builder.build()
+    }
 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -812,11 +812,21 @@ class CompanionHttpServerTest {
             {
               "snapshot": {
                 "packageName": "com.netflix.ninja",
-                "title": "Pilot"
+                "text": "mediaSession.title: Pilot"
               },
               "libraryHints": [
                 {"traktId": 1, "tmdbId": 100, "title": "Breaking Bad", "year": 2008}
               ]
+            }
+        """.trimIndent()
+
+        private val oldFormatRequestBody = """
+            {
+              "snapshot": {
+                "packageName": "com.netflix.ninja",
+                "title": "Pilot"
+              },
+              "libraryHints": []
             }
         """.trimIndent()
 
@@ -880,6 +890,17 @@ class CompanionHttpServerTest {
                 setBody(extractRequestBody)
             }
             assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+        }
+
+        @Test
+        fun `returns 200 with confidence=0 for old-format client that omits text field`() = testApp {
+            val response = client.post("/scrobble/extract") {
+                contentType(ContentType.Application.Json)
+                setBody(oldFormatRequestBody)
+            }
+            assertEquals(HttpStatusCode.OK, response.status)
+            val body = response.bodyAsText()
+            assertEquals("{}", body)
         }
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.tv.di
 
+import com.justb81.watchbuddy.core.scrobbler.MetadataEnricher
 import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher
 import com.justb81.watchbuddy.core.scrobbler.TitleExtractor
 import com.justb81.watchbuddy.core.scrobbler.WatchedShowSource
@@ -46,5 +47,10 @@ abstract class AppModule {
         @Singleton
         @Named("traktClientId")
         fun provideTraktClientId(): String = ""
+
+        /** No enrichers registered in the TV app yet; populated per-app via Hilt. */
+        @Provides
+        @Singleton
+        fun provideMetadataEnrichers(): List<MetadataEnricher> = emptyList()
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneTitleExtractionClient.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneTitleExtractionClient.kt
@@ -51,6 +51,7 @@ class PhoneTitleExtractionClient @Inject constructor(
 
     companion object {
         private const val TAG = "PhoneTitleExtractor"
+        private const val DEDUP_KEY_HEX_LENGTH = 32
         internal const val MAX_HINTS = 50
         internal const val CLIENT_TIMEOUT_SECONDS = 90L
         internal const val CALL_TIMEOUT_SECONDS = 95L
@@ -153,7 +154,7 @@ class PhoneTitleExtractionClient @Inject constructor(
     private fun dedupKey(snapshot: MediaMetadataSnapshot): String {
         val digest = java.security.MessageDigest.getInstance("SHA-256")
             .digest(snapshot.text.toByteArray(Charsets.UTF_8))
-        val hex = digest.joinToString("") { "%02x".format(it) }.take(32)
+        val hex = digest.joinToString("") { "%02x".format(it) }.take(DEDUP_KEY_HEX_LENGTH)
         return "${snapshot.packageName}:$hex"
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneTitleExtractionClient.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneTitleExtractionClient.kt
@@ -145,11 +145,15 @@ class PhoneTitleExtractionClient @Inject constructor(
     }
 
     /**
-     * Dedup key — same raw `packageName + TITLE` should hit one inference even
-     * if the rest of the MediaMetadata drifts slightly between polls. Using
-     * [MediaMetadataSnapshot.title] keeps the key stable across richer-field
-     * additions in subsequent polls.
+     * Dedup key — same evidence text should hit one inference even if minor
+     * positional drift occurs between polls. Hashes [MediaMetadataSnapshot.text]
+     * so the key is stable regardless of field additions or source-tag changes,
+     * and position/duration data never influences the dedup window.
      */
-    private fun dedupKey(snapshot: MediaMetadataSnapshot): String =
-        "${snapshot.packageName}:${snapshot.title.orEmpty()}"
+    private fun dedupKey(snapshot: MediaMetadataSnapshot): String {
+        val digest = java.security.MessageDigest.getInstance("SHA-256")
+            .digest(snapshot.text.toByteArray(Charsets.UTF_8))
+        val hex = digest.joinToString("") { "%02x".format(it) }.take(32)
+        return "${snapshot.packageName}:$hex"
+    }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.tv.material3.*
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.core.model.PlaybackTick
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 
@@ -125,6 +126,10 @@ fun TvDiagnosticsScreen(
                         ),
                     ),
                 )
+            }
+
+            item {
+                NowPlayingSection(uiState.lastObservedSession)
             }
 
             item {
@@ -473,6 +478,59 @@ private fun formatLastCandidate(last: MediaSessionScrobbler.LastCandidate?): Str
     val pct = (last.candidate.confidence * 100).toInt()
     val marker = if (last.autoScrobbled) "auto" else "overlay"
     return "$title @ ${pct}% · $marker · ${formatAge(last.observedAtMs)}"
+}
+
+private fun tickStateName(state: Int): String = when (state) {
+    PlaybackTick.STATE_PLAYING -> "Playing"
+    PlaybackTick.STATE_PAUSED -> "Paused"
+    PlaybackTick.STATE_STOPPED -> "Stopped"
+    PlaybackTick.STATE_NONE -> "None"
+    -1 -> "—"
+    else -> state.toString()
+}
+
+@Composable
+private fun NowPlayingSection(last: MediaSessionScrobbler.LastObservedSession?) {
+    val tick = last?.tick
+    val isActive = tick != null && tick.isPlaying
+    val headerStatus = when {
+        last == null -> Status.NEUTRAL
+        isActive -> Status.OK
+        else -> Status.WARN
+    }
+    val firstTitle = last?.snapshot?.text?.lines()
+        ?.firstOrNull { it.isNotBlank() }
+        ?.substringAfter(": ", "")
+        ?.trim()
+        ?.takeIf { it.isNotBlank() }
+    val progressStr = if (tick != null && tick.durationMs > 0) {
+        "${(tick.progress * 100).toInt()}%"
+    } else {
+        "—"
+    }
+    val rows = listOf(
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_now_playing_package),
+            last?.snapshot?.packageName ?: "—",
+            headerStatus,
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_now_playing_title),
+            firstTitle ?: "—",
+            if (firstTitle != null) Status.OK else Status.NEUTRAL,
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_now_playing_state),
+            tickStateName(tick?.state ?: -1),
+            if (isActive) Status.OK else Status.NEUTRAL,
+        ),
+        DiagRow(
+            stringResource(R.string.tv_diagnostics_row_now_playing_progress),
+            progressStr,
+            Status.NEUTRAL,
+        ),
+    )
+    DiagnosticsSection(title = stringResource(R.string.tv_diagnostics_section_now_playing), rows = rows)
 }
 
 @Composable

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -477,79 +477,46 @@ private fun formatLastCandidate(last: MediaSessionScrobbler.LastCandidate?): Str
 
 @Composable
 private fun MediaSessionSection(last: MediaSessionScrobbler.LastObservedSession?) {
-    val title = stringResource(R.string.tv_diagnostics_section_media_session)
     val snapshot = last?.snapshot
+    val hasEvidence = snapshot != null && snapshot.text.isNotBlank()
     val headerStatus = when {
         last == null -> Status.NEUTRAL
-        snapshot != null && snapshot.candidateStrings().isNotEmpty() -> Status.OK
+        hasEvidence -> Status.OK
         else -> Status.WARN
     }
-    val rows = buildMediaSessionRows(last, headerStatus)
-    DiagnosticsSection(title = title, rows = rows)
-}
-
-@Composable
-private fun buildMediaSessionRows(
-    last: MediaSessionScrobbler.LastObservedSession?,
-    headerStatus: Status,
-): List<DiagRow> {
-    val em = "—"
-    val snapshot = last?.snapshot
-    return listOf(
-        DiagRow(
+    val rows = buildList {
+        add(DiagRow(
             stringResource(R.string.tv_diagnostics_row_media_session_package),
-            snapshot?.packageName ?: em,
+            snapshot?.packageName ?: "—",
             headerStatus,
-        ),
-        stringRow(R.string.tv_diagnostics_row_media_session_title, snapshot, snapshot?.title),
-        stringRow(R.string.tv_diagnostics_row_media_session_display_title, snapshot, snapshot?.displayTitle),
-        stringRow(R.string.tv_diagnostics_row_media_session_display_subtitle, snapshot, snapshot?.displaySubtitle),
-        stringRow(
-            R.string.tv_diagnostics_row_media_session_display_description,
-            snapshot,
-            snapshot?.displayDescription,
-        ),
-        stringRow(R.string.tv_diagnostics_row_media_session_artist, snapshot, snapshot?.artist),
-        stringRow(R.string.tv_diagnostics_row_media_session_album_artist, snapshot, snapshot?.albumArtist),
-        stringRow(R.string.tv_diagnostics_row_media_session_album, snapshot, snapshot?.album),
-        DiagRow(
+        ))
+        if (snapshot != null && snapshot.text.isNotBlank()) {
+            snapshot.text.lines().filter { it.isNotBlank() }.forEach { line ->
+                val tag = line.substringBefore(": ", "")
+                val value = line.substringAfter(": ", line)
+                add(DiagRow(tag, value, Status.OK))
+            }
+        }
+        add(DiagRow(
             stringResource(R.string.tv_diagnostics_row_media_session_playback_state),
-            last?.playbackState?.toString() ?: em,
+            last?.playbackState?.toString() ?: "—",
             Status.NEUTRAL,
-        ),
-        DiagRow(
+        ))
+        add(DiagRow(
             stringResource(R.string.tv_diagnostics_row_media_session_position),
-            last?.positionMs?.let { "${it}ms" } ?: em,
+            last?.positionMs?.let { "${it}ms" } ?: "—",
             Status.NEUTRAL,
-        ),
-        DiagRow(
+        ))
+        add(DiagRow(
             stringResource(R.string.tv_diagnostics_row_media_session_duration),
-            last?.durationMs?.let { "${it}ms" } ?: em,
+            last?.durationMs?.let { "${it}ms" } ?: "—",
             Status.NEUTRAL,
-        ),
-        DiagRow(
+        ))
+        add(DiagRow(
             stringResource(R.string.tv_diagnostics_row_media_session_observed_age),
             formatAge(last?.observedAtMs ?: 0L),
             Status.NEUTRAL,
-        ),
-    )
-}
-
-@Composable
-private fun stringRow(
-    labelRes: Int,
-    snapshot: com.justb81.watchbuddy.core.model.MediaMetadataSnapshot?,
-    value: String?,
-): DiagRow {
-    val display = when {
-        value != null -> value
-        snapshot == null -> "—"
-        else -> stringResource(R.string.tv_diagnostics_value_null)
+        ))
     }
-    val status = when {
-        snapshot == null -> Status.NEUTRAL
-        value.isNullOrBlank() -> Status.WARN
-        else -> Status.OK
-    }
-    return DiagRow(stringResource(labelRes), display, status)
+    DiagnosticsSection(title = stringResource(R.string.tv_diagnostics_section_media_session), rows = rows)
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -499,17 +499,17 @@ private fun MediaSessionSection(last: MediaSessionScrobbler.LastObservedSession?
         }
         add(DiagRow(
             stringResource(R.string.tv_diagnostics_row_media_session_playback_state),
-            last?.playbackState?.toString() ?: "—",
+            last?.tick?.state?.toString() ?: "—",
             Status.NEUTRAL,
         ))
         add(DiagRow(
             stringResource(R.string.tv_diagnostics_row_media_session_position),
-            last?.positionMs?.let { "${it}ms" } ?: "—",
+            last?.tick?.positionMs?.let { "${it}ms" } ?: "—",
             Status.NEUTRAL,
         ))
         add(DiagRow(
             stringResource(R.string.tv_diagnostics_row_media_session_duration),
-            last?.durationMs?.let { "${it}ms" } ?: "—",
+            last?.tick?.durationMs?.let { "${it}ms" } ?: "—",
             Status.NEUTRAL,
         ))
         add(DiagRow(

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -134,6 +134,11 @@
     <string name="tv_diagnostics_value_no_phones">Noch keine Telefone gefunden.</string>
     <string name="tv_diagnostics_section_recent_events">Letzte Ereignisse</string>
     <string name="tv_diagnostics_value_no_events">Noch keine Ereignisse</string>
+    <string name="tv_diagnostics_section_now_playing">Jetzt läuft</string>
+    <string name="tv_diagnostics_row_now_playing_package">App</string>
+    <string name="tv_diagnostics_row_now_playing_title">Titel</string>
+    <string name="tv_diagnostics_row_now_playing_state">Status</string>
+    <string name="tv_diagnostics_row_now_playing_progress">Fortschritt</string>
     <string name="tv_diagnostics_section_media_session">Letzte Mediensitzung</string>
     <string name="tv_diagnostics_row_media_session_package">Paket</string>
     <string name="tv_diagnostics_row_media_session_title">Titel</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -138,6 +138,11 @@
     <string name="tv_diagnostics_value_no_phones">No se han encontrado teléfonos.</string>
     <string name="tv_diagnostics_section_recent_events">Eventos recientes</string>
     <string name="tv_diagnostics_value_no_events">Sin eventos aún</string>
+    <string name="tv_diagnostics_section_now_playing">Reproduciendo</string>
+    <string name="tv_diagnostics_row_now_playing_package">App</string>
+    <string name="tv_diagnostics_row_now_playing_title">Título</string>
+    <string name="tv_diagnostics_row_now_playing_state">Estado</string>
+    <string name="tv_diagnostics_row_now_playing_progress">Progreso</string>
     <string name="tv_diagnostics_section_media_session">Última sesión multimedia</string>
     <string name="tv_diagnostics_row_media_session_package">Paquete</string>
     <string name="tv_diagnostics_row_media_session_title">Título</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -138,6 +138,11 @@
     <string name="tv_diagnostics_value_no_phones">Aucun téléphone détecté.</string>
     <string name="tv_diagnostics_section_recent_events">Événements récents</string>
     <string name="tv_diagnostics_value_no_events">Aucun événement</string>
+    <string name="tv_diagnostics_section_now_playing">En lecture</string>
+    <string name="tv_diagnostics_row_now_playing_package">App</string>
+    <string name="tv_diagnostics_row_now_playing_title">Titre</string>
+    <string name="tv_diagnostics_row_now_playing_state">État</string>
+    <string name="tv_diagnostics_row_now_playing_progress">Progression</string>
     <string name="tv_diagnostics_section_media_session">Dernière session média</string>
     <string name="tv_diagnostics_row_media_session_package">Paquet</string>
     <string name="tv_diagnostics_row_media_session_title">Titre</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -134,6 +134,11 @@
     <string name="tv_diagnostics_value_no_phones">No phones discovered yet.</string>
     <string name="tv_diagnostics_section_recent_events">Recent events</string>
     <string name="tv_diagnostics_value_no_events">No events yet</string>
+    <string name="tv_diagnostics_section_now_playing">Now Playing</string>
+    <string name="tv_diagnostics_row_now_playing_package">App</string>
+    <string name="tv_diagnostics_row_now_playing_title">Title</string>
+    <string name="tv_diagnostics_row_now_playing_state">State</string>
+    <string name="tv_diagnostics_row_now_playing_progress">Progress</string>
     <string name="tv_diagnostics_section_media_session">Last media session</string>
     <string name="tv_diagnostics_row_media_session_package">Package</string>
     <string name="tv_diagnostics_row_media_session_title">Title</string>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneTitleExtractionClientTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneTitleExtractionClientTest.kt
@@ -3,8 +3,8 @@ package com.justb81.watchbuddy.tv.discovery
 import android.net.nsd.NsdServiceInfo
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.model.LlmBackend
-import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.scrobbler.MediaSnapshotBuilder
 import com.justb81.watchbuddy.core.scrobbler.WatchedShowSource
 import io.mockk.coEvery
 import io.mockk.every
@@ -63,7 +63,7 @@ class PhoneTitleExtractionClientTest {
         )
 
         val result = client.extract(
-            MediaMetadataSnapshot(packageName = "com.netflix.ninja", title = "Pilot")
+            snapshotOf("com.netflix.ninja", "title" to "Pilot")
         )
 
         assertNull(result)
@@ -95,7 +95,7 @@ class PhoneTitleExtractionClientTest {
         )
 
         val result = client.extract(
-            MediaMetadataSnapshot(packageName = "com.netflix.ninja", title = "Pilot")
+            snapshotOf("com.netflix.ninja", "title" to "Pilot")
         )
 
         assertNotNull(result)
@@ -129,7 +129,7 @@ class PhoneTitleExtractionClientTest {
             )
         )
 
-        val snapshot = MediaMetadataSnapshot(packageName = "com.netflix.ninja", title = "Pilot")
+        val snapshot = snapshotOf("com.netflix.ninja", "title" to "Pilot")
         val results = (1..3)
             .map { async(Dispatchers.IO) { client.extract(snapshot) } }
             .awaitAll()
@@ -153,8 +153,8 @@ class PhoneTitleExtractionClientTest {
             )
         )
 
-        val s1 = MediaMetadataSnapshot(packageName = "com.netflix.ninja", title = "Pilot")
-        val s2 = MediaMetadataSnapshot(packageName = "com.netflix.ninja", title = "System")
+        val s1 = snapshotOf("com.netflix.ninja", "title" to "Pilot")
+        val s2 = snapshotOf("com.netflix.ninja", "title" to "System")
         val r1 = async(Dispatchers.IO) { client.extract(s1) }
         val r2 = async(Dispatchers.IO) { client.extract(s2) }
         val (a, b) = listOf(r1.await(), r2.await())
@@ -178,11 +178,17 @@ class PhoneTitleExtractionClientTest {
         )
 
         val result = client.extract(
-            MediaMetadataSnapshot(packageName = "com.netflix.ninja", title = "Pilot")
+            snapshotOf("com.netflix.ninja", "title" to "Pilot")
         )
 
         assertNull(result)
     }
+
+    private fun snapshotOf(packageName: String, vararg fields: Pair<String, String>) =
+        MediaSnapshotBuilder(packageName).also { b ->
+            listOf("albumArtist", "album", "artist", "displayTitle", "displaySubtitle", "title", "displayDescription")
+                .forEach { key -> fields.toMap()[key]?.let { b.add("mediaSession.$key", it) } }
+        }.build()
 
     private fun makeDiscoveredPhone(
         baseUrl: String,

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -151,6 +151,36 @@ enum class AvatarSource { TRAKT, GENERATED, CUSTOM }
 
 // ── Scrobble / Session ────────────────────────────────────────────────────────
 
+/**
+ * Fast-changing playback state sampled once per poll tick, kept separate from
+ * [MediaMetadataSnapshot] which is invariant for the duration of an episode.
+ *
+ * [state] mirrors Android's `PlaybackState.STATE_*` integer constants.
+ * [positionMs] and [durationMs] are -1 when the streaming app does not report them.
+ */
+@Serializable
+data class PlaybackTick(
+    val state: Int,
+    val positionMs: Long,
+    val durationMs: Long,
+    val capturedAtMs: Long,
+) {
+    val progress: Float
+        get() = if (durationMs > 0 && positionMs >= 0)
+            (positionMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f
+
+    val isPlaying: Boolean get() = state == STATE_PLAYING
+    val isStopped: Boolean get() = state == STATE_STOPPED || state == STATE_NONE
+
+    companion object {
+        const val STATE_NONE = 0
+        const val STATE_STOPPED = 1
+        const val STATE_PAUSED = 2
+        const val STATE_PLAYING = 3
+        val UNKNOWN = PlaybackTick(state = -1, positionMs = -1L, durationMs = -1L, capturedAtMs = 0L)
+    }
+}
+
 @Serializable
 data class ScrobbleCandidate(
     val packageName: String,

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -191,36 +191,26 @@ data class ScrobbleCandidate(
 )
 
 /**
- * Structured view of the MediaMetadata fields a streaming app publishes for the
- * currently-playing session. Streaming apps distribute signal across several
- * fields (Plex puts the show in ALBUM_ARTIST, Jellyfin in ALBUM, some Netflix
- * skins use DISPLAY_SUBTITLE for SxxExx) so the scrobbler tries them all before
- * falling back to the LLM extractor.
+ * One stable string of evidence per session tick, plus the package name.
+ *
+ * [text] is a newline-joined sequence of `"<sourceTag>: <value>"` lines written
+ * in priority order by [com.justb81.watchbuddy.core.scrobbler.MediaSnapshotBuilder].
+ * For the MediaSession-only case the tag prefix is `mediaSession.*`. Additional
+ * enrichers (#471, #472) append their own prefixed lines without changing the schema.
+ *
+ * Wire-format note: [text] defaults to an empty string so that a TV client built
+ * against the old schema (which sent 8 named fields instead of [text]) is
+ * deserialized gracefully by a new phone — [WatchBuddyJson] ignores unknown keys,
+ * and an empty [text] naturally yields confidence 0 from the extraction cascade.
+ *
+ * [sources] records which enrichers contributed; used for diagnostics only.
  */
 @Serializable
 data class MediaMetadataSnapshot(
     val packageName: String,
-    val title: String? = null,
-    val displayTitle: String? = null,
-    val displaySubtitle: String? = null,
-    val displayDescription: String? = null,
-    val artist: String? = null,
-    val albumArtist: String? = null,
-    val album: String? = null,
-) {
-    /**
-     * Candidate strings to try for SxxExx parsing + fuzzy matching, ordered by
-     * how likely they are to hold the show title: `ALBUM_ARTIST` > `ALBUM` >
-     * `ARTIST` > `DISPLAY_TITLE` > `DISPLAY_SUBTITLE` > `TITLE` >
-     * `DISPLAY_DESCRIPTION`. Empty / blank values are filtered; duplicates are
-     * collapsed so the fuzzy cascade doesn't redo the same scoring twice.
-     */
-    fun candidateStrings(): List<String> =
-        listOfNotNull(albumArtist, album, artist, displayTitle, displaySubtitle, title, displayDescription)
-            .map { it.trim() }
-            .filter { it.isNotBlank() }
-            .distinct()
-}
+    val text: String = "",
+    val sources: Set<String> = emptySet(),
+)
 
 /**
  * Minimal show reference shipped to the LLM extractor so it can prefer a library

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -166,8 +166,11 @@ data class PlaybackTick(
     val capturedAtMs: Long,
 ) {
     val progress: Float
-        get() = if (durationMs > 0 && positionMs >= 0)
-            (positionMs.toFloat() / durationMs).coerceIn(0f, 1f) else 0f
+        get() = if (durationMs > 0 && positionMs >= 0) {
+            (positionMs.toFloat() / durationMs).coerceIn(0f, 1f)
+        } else {
+            0f
+        }
 
     val isPlaying: Boolean get() = state == STATE_PLAYING
     val isStopped: Boolean get() = state == STATE_STOPPED || state == STATE_NONE

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -45,6 +45,8 @@ class MediaSessionScrobbler @Inject constructor(
     private val watchedShowSource: WatchedShowSource,
     private val scrobbleDispatcher: ScrobbleDispatcher,
     private val titleExtractor: TitleExtractor,
+    /** Enrichers append additional evidence lines; populated per-app via Hilt. */
+    private val metadataEnrichers: List<MetadataEnricher> = emptyList(),
 ) {
     companion object {
         private const val TAG = "MediaSessionScrobbler"
@@ -65,14 +67,22 @@ class MediaSessionScrobbler @Inject constructor(
      * view so the user can see exactly which evidence lines the streaming app
      * published — `METADATA_KEY_TITLE` is frequently null on Plex, Jellyfin,
      * and some Netflix skins, so surfacing only the title row hides everything.
+     *
+     * [observedAtMs] is kept separately from [tick.capturedAtMs] because it drives
+     * the staleness check for implicit-stop reconciliation (5-minute presence timeout).
      */
     data class LastObservedSession(
         val snapshot: MediaMetadataSnapshot,
-        val playbackState: Int,
-        val positionMs: Long,
-        val durationMs: Long,
+        val tick: PlaybackTick,
         val observedAtMs: Long,
-    )
+    ) {
+        @Deprecated("Use tick.state", ReplaceWith("tick.state"))
+        val playbackState: Int get() = tick.state
+        @Deprecated("Use tick.positionMs", ReplaceWith("tick.positionMs"))
+        val positionMs: Long get() = tick.positionMs
+        @Deprecated("Use tick.durationMs", ReplaceWith("tick.durationMs"))
+        val durationMs: Long get() = tick.durationMs
+    }
 
     /** Strips the `"<tag>: "` prefix from a text-blob line and returns the bare value. */
     private fun String.stripTag(): String = substringAfter(": ", missingDelimiterValue = this).trim()
@@ -184,27 +194,24 @@ class MediaSessionScrobbler @Inject constructor(
                         val packageName = controller.packageName
                         val metadata = controller.metadata
                         val playbackState = controller.playbackState
+                        val tick = buildTick(playbackState, metadata)
                         val snapshot = if (metadata != null) {
-                            buildSnapshot(packageName, metadata)
+                            buildSnapshotWithEnrichers(packageName, metadata, tick)
                         } else {
                             MediaMetadataSnapshot(packageName = packageName)
                         }
-                        val durationMs = metadata
-                            ?.getLong(android.media.MediaMetadata.METADATA_KEY_DURATION) ?: -1L
-                        val state = playbackState?.state ?: -1
-                        val positionMs = playbackState?.position ?: -1L
                         if (!publishedDiagnostics) {
-                            publishObservedSession(snapshot, state, positionMs, durationMs)
+                            publishObservedSession(snapshot, tick)
                             publishedDiagnostics = true
                         }
-                        logSessionIfDebug(snapshot, state, positionMs, durationMs)
+                        logSessionIfDebug(snapshot, tick.state, tick.positionMs, tick.durationMs)
                         val key = snapshot.sessionKey() ?: return@forEach
                         liveKeys.add(key)
                         if (metadata == null || playbackState == null) return@forEach
                         val progress = computeProgress(playbackState, metadata)
                         if (progress != null) recordProgress(key, snapshot, progress)
                         when (playbackState.state) {
-                            PlaybackState.STATE_PLAYING -> processPlayingMedia(snapshot, key, progress)
+                            PlaybackState.STATE_PLAYING -> processPlayingMedia(snapshot, key, progress, tick)
                             PlaybackState.STATE_PAUSED -> handleScrobblePause(snapshot, key, progress)
                             PlaybackState.STATE_STOPPED,
                             PlaybackState.STATE_NONE -> handleScrobbleStop(snapshot, key, progress)
@@ -242,16 +249,30 @@ class MediaSessionScrobbler @Inject constructor(
 
     internal fun publishObservedSession(
         snapshot: MediaMetadataSnapshot,
+        tick: PlaybackTick,
+    ) {
+        _lastObservedSession.value = LastObservedSession(
+            snapshot = snapshot,
+            tick = tick,
+            observedAtMs = System.currentTimeMillis(),
+        )
+    }
+
+    /** Compat overload used by tests that still pass raw state/position/duration ints. */
+    internal fun publishObservedSession(
+        snapshot: MediaMetadataSnapshot,
         playbackState: Int,
         positionMs: Long,
         durationMs: Long,
     ) {
-        _lastObservedSession.value = LastObservedSession(
-            snapshot = snapshot,
-            playbackState = playbackState,
-            positionMs = positionMs,
-            durationMs = durationMs,
-            observedAtMs = System.currentTimeMillis(),
+        publishObservedSession(
+            snapshot,
+            PlaybackTick(
+                state = playbackState,
+                positionMs = positionMs,
+                durationMs = durationMs,
+                capturedAtMs = System.currentTimeMillis(),
+            ),
         )
     }
 
@@ -276,6 +297,40 @@ class MediaSessionScrobbler @Inject constructor(
         builder.add("mediaSession.displaySubtitle", metadata.getString(android.media.MediaMetadata.METADATA_KEY_DISPLAY_SUBTITLE))
         builder.add("mediaSession.title", metadata.getString(android.media.MediaMetadata.METADATA_KEY_TITLE))
         builder.add("mediaSession.displayDescription", metadata.getString(android.media.MediaMetadata.METADATA_KEY_DISPLAY_DESCRIPTION))
+        return builder.build()
+    }
+
+    /** Samples the Android [PlaybackState] and metadata duration into a [PlaybackTick]. */
+    private fun buildTick(
+        playbackState: android.media.session.PlaybackState?,
+        metadata: android.media.MediaMetadata?,
+    ) = PlaybackTick(
+        state = playbackState?.state ?: -1,
+        positionMs = playbackState?.position ?: -1L,
+        durationMs = metadata?.getLong(android.media.MediaMetadata.METADATA_KEY_DURATION) ?: -1L,
+        capturedAtMs = System.currentTimeMillis(),
+    )
+
+    /**
+     * Calls [buildSnapshot] then lets every registered [MetadataEnricher] append
+     * additional evidence lines. Enrichers should short-circuit when [tick] is
+     * not actively playing to avoid querying providers for stale sessions.
+     */
+    private suspend fun buildSnapshotWithEnrichers(
+        packageName: String,
+        metadata: android.media.MediaMetadata,
+        tick: PlaybackTick,
+    ): MediaMetadataSnapshot {
+        if (metadataEnrichers.isEmpty()) return buildSnapshot(packageName, metadata)
+        val builder = MediaSnapshotBuilder(packageName)
+        builder.add("mediaSession.albumArtist", metadata.getString(android.media.MediaMetadata.METADATA_KEY_ALBUM_ARTIST))
+        builder.add("mediaSession.album", metadata.getString(android.media.MediaMetadata.METADATA_KEY_ALBUM))
+        builder.add("mediaSession.artist", metadata.getString(android.media.MediaMetadata.METADATA_KEY_ARTIST))
+        builder.add("mediaSession.displayTitle", metadata.getString(android.media.MediaMetadata.METADATA_KEY_DISPLAY_TITLE))
+        builder.add("mediaSession.displaySubtitle", metadata.getString(android.media.MediaMetadata.METADATA_KEY_DISPLAY_SUBTITLE))
+        builder.add("mediaSession.title", metadata.getString(android.media.MediaMetadata.METADATA_KEY_TITLE))
+        builder.add("mediaSession.displayDescription", metadata.getString(android.media.MediaMetadata.METADATA_KEY_DISPLAY_DESCRIPTION))
+        metadataEnrichers.forEach { it.enrich(packageName, tick, builder) }
         return builder.build()
     }
 
@@ -360,9 +415,10 @@ class MediaSessionScrobbler @Inject constructor(
         snapshot: MediaMetadataSnapshot,
         sessionKey: String,
         progress: Float?,
+        tick: PlaybackTick = PlaybackTick.UNKNOWN,
     ) {
         if (sessionKey == currentlySessionKey) return
-        val candidate = matchSnapshot(snapshot)
+        val candidate = matchSnapshot(snapshot, tick)
         if (candidate == null) {
             if (debugLogMediaSession) {
                 DiagnosticLog.debug(TAG, "no match for '$sessionKey' — best confidence null")
@@ -419,7 +475,15 @@ class MediaSessionScrobbler @Inject constructor(
      *      with the best-scoring candidate (cheap-path best or extractor
      *      output).
      */
-    internal suspend fun matchSnapshot(snapshot: MediaMetadataSnapshot): ScrobbleCandidate? {
+    /**
+     * [tick] is threaded through for future consumers (#474 duration tiebreaker,
+     * #471/#472 freshness gates inside enrichers) but does not influence Phase 1/2/3
+     * scoring in this issue.
+     */
+    internal suspend fun matchSnapshot(
+        snapshot: MediaMetadataSnapshot,
+        tick: PlaybackTick = PlaybackTick.UNKNOWN,
+    ): ScrobbleCandidate? {
         val candidates = snapshot.text.lines().map { it.stripTag() }.filter { it.isNotBlank() }.distinct()
         if (candidates.isEmpty()) return null
         val mediaTitle = candidates.first()

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -47,7 +47,7 @@ class MediaSessionScrobbler @Inject constructor(
     private val scrobbleDispatcher: ScrobbleDispatcher,
     private val titleExtractor: TitleExtractor,
     /** Enrichers append additional evidence lines; populated per-app via Hilt. */
-    private val metadataEnrichers: List<MetadataEnricher> = emptyList(),
+    private val metadataEnrichers: List<@JvmSuppressWildcards MetadataEnricher> = emptyList(),
 ) {
     companion object {
         private const val TAG = "MediaSessionScrobbler"

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import androidx.core.app.NotificationManagerCompat
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
+import com.justb81.watchbuddy.core.model.PlaybackTick
 import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 import com.justb81.watchbuddy.core.model.TitleExtractionResponse
 import com.justb81.watchbuddy.core.model.TraktEpisode

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -79,8 +79,10 @@ class MediaSessionScrobbler @Inject constructor(
     ) {
         @Deprecated("Use tick.state", ReplaceWith("tick.state"))
         val playbackState: Int get() = tick.state
+
         @Deprecated("Use tick.positionMs", ReplaceWith("tick.positionMs"))
         val positionMs: Long get() = tick.positionMs
+
         @Deprecated("Use tick.durationMs", ReplaceWith("tick.durationMs"))
         val durationMs: Long get() = tick.durationMs
     }
@@ -481,6 +483,7 @@ class MediaSessionScrobbler @Inject constructor(
      * #471/#472 freshness gates inside enrichers) but does not influence Phase 1/2/3
      * scoring in this issue.
      */
+    @Suppress("UnusedParameter")
     internal suspend fun matchSnapshot(
         snapshot: MediaMetadataSnapshot,
         tick: PlaybackTick = PlaybackTick.UNKNOWN,

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -62,8 +62,8 @@ class MediaSessionScrobbler @Inject constructor(
     /**
      * Full dump of the most recent `MediaSession` the scrobbler polled, regardless
      * of whether it produced a scrobble candidate. Intended for the TV diagnostics
-     * view so the user can see exactly which `MediaMetadata` fields the streaming
-     * app published — `METADATA_KEY_TITLE` is frequently null on Plex, Jellyfin,
+     * view so the user can see exactly which evidence lines the streaming app
+     * published — `METADATA_KEY_TITLE` is frequently null on Plex, Jellyfin,
      * and some Netflix skins, so surfacing only the title row hides everything.
      */
     data class LastObservedSession(
@@ -73,6 +73,9 @@ class MediaSessionScrobbler @Inject constructor(
         val durationMs: Long,
         val observedAtMs: Long,
     )
+
+    /** Strips the `"<tag>: "` prefix from a text-blob line and returns the bare value. */
+    private fun String.stripTag(): String = substringAfter(": ", missingDelimiterValue = this).trim()
 
     /**
      * Per-session progress snapshot kept around so `reconcileVanished` can dispatch
@@ -218,15 +221,21 @@ class MediaSessionScrobbler @Inject constructor(
     }
 
     /**
-     * Stable identity for a media session across polls. Uses the first non-blank
-     * field from [MediaMetadataSnapshot.candidateStrings] so sessions where
-     * `METADATA_KEY_TITLE` is null (Plex ships the show in `ALBUM_ARTIST`,
-     * Jellyfin in `ALBUM`) still get a durable key instead of being dropped.
-     * Returns null when every string field is blank — caller skips scrobble but
-     * still publishes the snapshot to [lastObservedSession] for diagnostics.
+     * Stable identity for a media session across polls. Reads the first non-blank
+     * line of [MediaMetadataSnapshot.text] (stripping the `tag: ` prefix) so
+     * sessions where `METADATA_KEY_TITLE` is null (Plex ships the show in
+     * `ALBUM_ARTIST`, Jellyfin in `ALBUM`) still get a durable key. The builder
+     * writes lines in the same priority order as the old `candidateStrings()` so
+     * behaviour is identical for the MediaSession-only case.
+     * Returns null when [text] is blank — caller skips scrobble but still
+     * publishes the snapshot to [lastObservedSession] for diagnostics.
      */
     internal fun MediaMetadataSnapshot.sessionKey(): String? =
-        candidateStrings().firstOrNull()?.let { "$packageName:$it" }
+        text.lineSequence()
+            .firstOrNull { it.isNotBlank() }
+            ?.stripTag()
+            ?.takeIf { it.isNotBlank() }
+            ?.let { "$packageName:$it" }
 
     internal fun sessionKey(candidate: ScrobbleCandidate): String =
         "${candidate.packageName}:${candidate.mediaTitle}"
@@ -248,25 +257,27 @@ class MediaSessionScrobbler @Inject constructor(
 
     /**
      * Reads every MediaMetadata field a streaming app might use to ship the show
-     * name or `S##E##` marker. Netflix/Prime/Disney+ ship only the episode title
-     * in `METADATA_KEY_TITLE`; Plex publishes the show in `ALBUM_ARTIST`;
-     * Jellyfin uses `ALBUM`; some Netflix skins use `DISPLAY_SUBTITLE`. Pulling
-     * all of them up front lets the match cascade score each candidate and keep
-     * the best one without round-tripping back to the controller.
+     * name or `S##E##` marker and emits them as prioritised `"tag: value"` lines.
+     * Netflix/Prime/Disney+ ship only the episode title in `METADATA_KEY_TITLE`;
+     * Plex publishes the show in `ALBUM_ARTIST`; Jellyfin uses `ALBUM`; some
+     * Netflix skins use `DISPLAY_SUBTITLE`. The builder insertion order is the
+     * field-priority ranking (albumArtist first), preserved through to the
+     * cascade that strips tag prefixes and tries each line as a candidate title.
      */
     internal fun buildSnapshot(
         packageName: String,
         metadata: android.media.MediaMetadata,
-    ): MediaMetadataSnapshot = MediaMetadataSnapshot(
-        packageName = packageName,
-        title = metadata.getString(android.media.MediaMetadata.METADATA_KEY_TITLE),
-        displayTitle = metadata.getString(android.media.MediaMetadata.METADATA_KEY_DISPLAY_TITLE),
-        displaySubtitle = metadata.getString(android.media.MediaMetadata.METADATA_KEY_DISPLAY_SUBTITLE),
-        displayDescription = metadata.getString(android.media.MediaMetadata.METADATA_KEY_DISPLAY_DESCRIPTION),
-        artist = metadata.getString(android.media.MediaMetadata.METADATA_KEY_ARTIST),
-        albumArtist = metadata.getString(android.media.MediaMetadata.METADATA_KEY_ALBUM_ARTIST),
-        album = metadata.getString(android.media.MediaMetadata.METADATA_KEY_ALBUM),
-    )
+    ): MediaMetadataSnapshot {
+        val builder = MediaSnapshotBuilder(packageName)
+        builder.add("mediaSession.albumArtist", metadata.getString(android.media.MediaMetadata.METADATA_KEY_ALBUM_ARTIST))
+        builder.add("mediaSession.album", metadata.getString(android.media.MediaMetadata.METADATA_KEY_ALBUM))
+        builder.add("mediaSession.artist", metadata.getString(android.media.MediaMetadata.METADATA_KEY_ARTIST))
+        builder.add("mediaSession.displayTitle", metadata.getString(android.media.MediaMetadata.METADATA_KEY_DISPLAY_TITLE))
+        builder.add("mediaSession.displaySubtitle", metadata.getString(android.media.MediaMetadata.METADATA_KEY_DISPLAY_SUBTITLE))
+        builder.add("mediaSession.title", metadata.getString(android.media.MediaMetadata.METADATA_KEY_TITLE))
+        builder.add("mediaSession.displayDescription", metadata.getString(android.media.MediaMetadata.METADATA_KEY_DISPLAY_DESCRIPTION))
+        return builder.build()
+    }
 
     internal fun recordProgress(sessionKey: String, snapshot: MediaMetadataSnapshot?, progress: Float) {
         lastProgressBySessionKey[sessionKey] = LastKnownProgress(snapshot, progress)
@@ -277,13 +288,11 @@ class MediaSessionScrobbler @Inject constructor(
     }
 
     /**
-     * Writes a breadcrumb listing every non-null `MediaMetadata` string field
-     * the streaming app published, plus playback state / position / duration.
-     * Previous versions only logged `title`, which hid the fact that Plex /
-     * Jellyfin / some Netflix skins ship the show in other fields and leave
-     * `METADATA_KEY_TITLE` null — the "Debug: log every media session" toggle
-     * needs to surface the full picture so the user can see which field
-     * actually carries signal.
+     * Writes a breadcrumb listing the full evidence text blob the streaming app
+     * published, plus playback state / position / duration. The text lines show
+     * which field actually carries signal (Plex/Jellyfin/Netflix-skin metadata
+     * shapes differ widely), making the "Debug: log every media session" toggle
+     * useful for diagnosing missed scrobbles.
      */
     internal fun logSessionIfDebug(
         snapshot: MediaMetadataSnapshot,
@@ -292,21 +301,11 @@ class MediaSessionScrobbler @Inject constructor(
         durationMs: Long,
     ) {
         if (!debugLogMediaSession) return
-        val head = "session pkg=${snapshot.packageName} state=$state " +
-            "pos=${positionMs}ms dur=${durationMs}ms"
-        val fields = buildList {
-            add("title" to snapshot.title)
-            add("displayTitle" to snapshot.displayTitle)
-            add("displaySubtitle" to snapshot.displaySubtitle)
-            add("displayDescription" to snapshot.displayDescription)
-            add("artist" to snapshot.artist)
-            add("albumArtist" to snapshot.albumArtist)
-            add("album" to snapshot.album)
-        }
-        val tail = fields.joinToString(" ") { (name, value) ->
-            "$name='${value ?: "(null)"}'"
-        }
-        DiagnosticLog.event(TAG, "$head $tail")
+        val evidence = if (snapshot.text.isBlank()) "(no evidence)" else snapshot.text.replace("\n", " | ")
+        DiagnosticLog.event(
+            TAG,
+            "session pkg=${snapshot.packageName} state=$state pos=${positionMs}ms dur=${durationMs}ms $evidence",
+        )
     }
 
     /**
@@ -402,8 +401,11 @@ class MediaSessionScrobbler @Inject constructor(
      * runs through [matchSnapshot] — always prefer that entry point when the
      * full `MediaMetadata` is available.
      */
-    internal suspend fun matchTitle(packageName: String, rawTitle: String): ScrobbleCandidate? =
-        matchSnapshot(MediaMetadataSnapshot(packageName = packageName, title = rawTitle))
+    internal suspend fun matchTitle(packageName: String, rawTitle: String): ScrobbleCandidate? {
+        val builder = MediaSnapshotBuilder(packageName)
+        builder.add("mediaSession.title", rawTitle)
+        return matchSnapshot(builder.build())
+    }
 
     /**
      * Full match cascade:
@@ -418,9 +420,9 @@ class MediaSessionScrobbler @Inject constructor(
      *      output).
      */
     internal suspend fun matchSnapshot(snapshot: MediaMetadataSnapshot): ScrobbleCandidate? {
-        val candidates = snapshot.candidateStrings()
+        val candidates = snapshot.text.lines().map { it.stripTag() }.filter { it.isNotBlank() }.distinct()
         if (candidates.isEmpty()) return null
-        val mediaTitle = snapshot.title ?: candidates.first()
+        val mediaTitle = candidates.first()
 
         val (globalSeason, globalEpisode) = findGlobalEpisodeMarker(candidates)
         val cachedShows = watchedShowSource.getCachedShows()
@@ -573,7 +575,8 @@ class MediaSessionScrobbler @Inject constructor(
         )
         DiagnosticLog.event(
             TAG,
-            "LLM fallback resolved '${snapshot.title}' → '${bestCacheMatch.show.title}' " +
+            "LLM fallback resolved '${snapshot.text.lines().firstOrNull()?.stripTag()}' " +
+                "→ '${bestCacheMatch.show.title}' " +
                 "S${matchedEpisode?.season}E${matchedEpisode?.number} score=$score",
         )
         return ScrobbleCandidate(

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSnapshotBuilder.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSnapshotBuilder.kt
@@ -1,0 +1,30 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
+
+/**
+ * Builds a [MediaMetadataSnapshot] as an ordered list of `"<tag>: <value>"` lines.
+ *
+ * Lines are appended in priority order — the first line carries the highest-signal
+ * field. Blank or null values are silently skipped; newline characters inside
+ * values are stripped to keep each line a single logical unit.
+ *
+ * [packageName] is the streaming-app package name (e.g. `com.plexapp.android`).
+ */
+class MediaSnapshotBuilder(val packageName: String) {
+    private val lines = mutableListOf<String>()
+    private val sources = mutableSetOf<String>()
+
+    fun add(tag: String, value: String?) {
+        val v = value?.replace('\n', ' ')?.replace('\r', ' ')?.trim() ?: return
+        if (v.isBlank()) return
+        lines += "$tag: $v"
+    }
+
+    fun addSource(source: String) {
+        sources += source
+    }
+
+    fun build(): MediaMetadataSnapshot =
+        MediaMetadataSnapshot(packageName, lines.joinToString("\n"), sources)
+}

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MetadataEnricher.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MetadataEnricher.kt
@@ -1,0 +1,19 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import com.justb81.watchbuddy.core.model.PlaybackTick
+
+/**
+ * Extension point for plugging additional evidence sources into the scrobble
+ * cascade without reopening [MediaSessionScrobbler] for each addition.
+ *
+ * Implementations append `"<tag>: <value>"` lines to [builder] for [packageName].
+ * Short-circuit when [tick] is not actively playing so slow sources (content
+ * provider queries, notification reads) are skipped for stale sessions.
+ *
+ * Registered via the [MediaSessionScrobbler] constructor. The TV app will
+ * populate this list in #471 (WatchNextMetadataSource) and #472
+ * (NotificationMetadataSource). The phone app and tests use an empty list.
+ */
+fun interface MetadataEnricher {
+    suspend fun enrich(packageName: String, tick: PlaybackTick, builder: MediaSnapshotBuilder)
+}

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerDebugLogTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerDebugLogTest.kt
@@ -42,10 +42,7 @@ class MediaSessionScrobblerDebugLogTest {
         scrobbler.debugLogMediaSession = false
 
         scrobbler.logSessionIfDebug(
-            snapshot = MediaMetadataSnapshot(
-                packageName = "com.netflix.ninja",
-                title = "Breaking Bad S01E01",
-            ),
+            snapshot = snapshotOf("com.netflix.ninja", "title" to "Breaking Bad S01E01"),
             state = 3,
             positionMs = 1234L,
             durationMs = 2600000L,
@@ -61,10 +58,7 @@ class MediaSessionScrobblerDebugLogTest {
         scrobbler.debugLogMediaSession = true
 
         scrobbler.logSessionIfDebug(
-            snapshot = MediaMetadataSnapshot(
-                packageName = "com.netflix.ninja",
-                title = "Breaking Bad S01E01",
-            ),
+            snapshot = snapshotOf("com.netflix.ninja", "title" to "Breaking Bad S01E01"),
             state = 3,
             positionMs = 1234L,
             durationMs = 2600000L,
@@ -76,14 +70,14 @@ class MediaSessionScrobblerDebugLogTest {
         val entry = sessionEntries.single()
         assertEquals(DiagnosticLog.Level.INFO, entry.level)
         assertTrue(entry.message.contains("pkg=com.netflix.ninja"))
-        assertTrue(entry.message.contains("title='Breaking Bad S01E01'"))
+        assertTrue(entry.message.contains("Breaking Bad S01E01"))
         assertTrue(entry.message.contains("state=3"))
         assertTrue(entry.message.contains("pos=1234ms"))
         assertTrue(entry.message.contains("dur=2600000ms"))
     }
 
     @Test
-    fun `renders null title as literal placeholder`() {
+    fun `renders blank snapshot as no-evidence placeholder`() {
         scrobbler.debugLogMediaSession = true
 
         scrobbler.logSessionIfDebug(
@@ -95,21 +89,19 @@ class MediaSessionScrobblerDebugLogTest {
 
         val entry = DiagnosticLog.snapshot()
             .single { it.message.startsWith("session pkg=") }
-        assertTrue(entry.message.contains("title='(null)'"))
+        assertTrue(entry.message.contains("(no evidence)"))
     }
 
     @Test
-    fun `breadcrumb includes every non-null MediaMetadata field`() {
+    fun `breadcrumb includes all evidence lines joined with pipe`() {
         scrobbler.debugLogMediaSession = true
 
         scrobbler.logSessionIfDebug(
-            snapshot = MediaMetadataSnapshot(
-                packageName = "com.plexapp.android",
-                title = null,
-                displayTitle = "Pilot",
-                displaySubtitle = "S01E01",
-                albumArtist = "Breaking Bad",
-                album = null,
+            snapshot = snapshotOf(
+                "com.plexapp.android",
+                "albumArtist" to "Breaking Bad",
+                "displaySubtitle" to "S01E01",
+                "displayTitle" to "Pilot",
             ),
             state = 3,
             positionMs = 100L,
@@ -119,10 +111,8 @@ class MediaSessionScrobblerDebugLogTest {
         val entry = DiagnosticLog.snapshot()
             .single { it.message.startsWith("session pkg=") }
         assertTrue(entry.message.contains("pkg=com.plexapp.android"))
-        assertTrue(entry.message.contains("title='(null)'"))
-        assertTrue(entry.message.contains("displayTitle='Pilot'"))
-        assertTrue(entry.message.contains("displaySubtitle='S01E01'"))
-        assertTrue(entry.message.contains("albumArtist='Breaking Bad'"))
-        assertTrue(entry.message.contains("album='(null)'"))
+        assertTrue(entry.message.contains("Breaking Bad"))
+        assertTrue(entry.message.contains("S01E01"))
+        assertTrue(entry.message.contains("Pilot"))
     }
 }

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerLifecycleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerLifecycleTest.kt
@@ -3,7 +3,6 @@ package com.justb81.watchbuddy.core.scrobbler
 import android.content.ComponentName
 import android.content.Context
 import android.media.session.MediaSessionManager
-import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
 import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktIds
@@ -32,15 +31,9 @@ class MediaSessionScrobblerLifecycleTest {
     private val testCandidate = ScrobbleCandidate(
         "com.netflix", "Breaking Bad S01E01", 0.95f, testShow, testEpisode
     )
-    private val testSnapshot = MediaMetadataSnapshot(
-        packageName = "com.netflix",
-        title = "Breaking Bad S01E01",
-    )
+    private val testSnapshot = snapshotOf("com.netflix", "title" to "Breaking Bad S01E01")
     private val testSessionKey = "com.netflix:Breaking Bad S01E01"
-    private val otherSnapshot = MediaMetadataSnapshot(
-        packageName = "com.netflix",
-        title = "Other Show",
-    )
+    private val otherSnapshot = snapshotOf("com.netflix", "title" to "Other Show")
     private val otherSessionKey = "com.netflix:Other Show"
 
     @BeforeEach
@@ -84,7 +77,6 @@ class MediaSessionScrobblerLifecycleTest {
             assertFalse(scrobbler.isListening.value)
             scrobbler.notificationAccessChecker = { true }
             scrobbler.startListening(component)
-            // isListening is set by the polling coroutine on the first tick, not synchronously
             scrobbler.stopListening()
             assertFalse(scrobbler.isListening.value)
         }
@@ -95,7 +87,6 @@ class MediaSessionScrobblerLifecycleTest {
             scrobbler.notificationAccessChecker = { true }
             assertFalse(scrobbler.isListening.value)
             scrobbler.startListening(component)
-            // First tick runs immediately on IO dispatcher; 200 ms is ample
             Thread.sleep(200)
             assertTrue(scrobbler.isListening.value)
             scrobbler.stopListening()
@@ -256,7 +247,7 @@ class MediaSessionScrobblerLifecycleTest {
         fun `high confidence candidate triggers dispatchStart not pendingConfirmation`() = runTest {
             coEvery { scrobbleDispatcher.dispatchStart(any(), any(), any()) } just runs
 
-            scrobbler.autoScrobble(testCandidate) // confidence 0.95 → auto
+            scrobbler.autoScrobble(testCandidate)
 
             coVerify { scrobbleDispatcher.dispatchStart(any(), any(), any()) }
         }

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerNullTitleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerNullTitleTest.kt
@@ -26,15 +26,11 @@ import org.junit.jupiter.api.Test
 /**
  * Regression tests for the null-`METADATA_KEY_TITLE` scrobble cascade. Previously
  * the polling loop early-returned when TITLE was null, dropping every Plex,
- * Jellyfin, and Netflix-skin session that ships the show in another field. The
- * fix identifies sessions by the first non-blank `candidateStrings()` entry
- * instead of raw title, so pause/stop dedup + vanished-stop reconciliation keep
- * working when TITLE is unavailable.
+ * Jellyfin, and Netflix-skin session that ships the show in another field.
  *
- * Also covers the `lastObservedSession` diagnostics StateFlow that surfaces the
- * full `MediaMetadataSnapshot` in the TV diagnostics view regardless of whether
- * a scrobble fired — so the user can see exactly what each streaming app is
- * publishing, rather than just a single "title='(null)'" row.
+ * With the text-blob snapshot shape the cascade iterates evidence lines in
+ * builder-insertion order, so albumArtist comes first regardless of whether
+ * the `title` field is present.
  */
 @DisplayName("MediaSessionScrobbler — null TITLE cascade + lastObservedSession")
 class MediaSessionScrobblerNullTitleTest {
@@ -52,15 +48,13 @@ class MediaSessionScrobblerNullTitleTest {
     )
     private val breakingBadEntry = TraktWatchedEntry(show = breakingBadShow)
 
-    // Plex: TITLE = episode name, ALBUM_ARTIST = show, DISPLAY_SUBTITLE = S##E##
-    // sessionKey = "${packageName}:${candidateStrings().first()}" — priority order
-    // is: albumArtist > album > artist > displayTitle > displaySubtitle > title >
-    // displayDescription, so the Plex snapshot below keys on "Breaking Bad".
-    private val plexPlayingSnapshot = MediaMetadataSnapshot(
-        packageName = "com.plexapp.android",
-        title = null,
-        albumArtist = "Breaking Bad",
-        displaySubtitle = "S01E01",
+    // Plex: ALBUM_ARTIST = show, DISPLAY_SUBTITLE = S##E##, no TITLE
+    // Builder priority: albumArtist > album > ... so first line = "Breaking Bad"
+    // sessionKey = "com.plexapp.android:Breaking Bad"
+    private val plexPlayingSnapshot = snapshotOf(
+        "com.plexapp.android",
+        "albumArtist" to "Breaking Bad",
+        "displaySubtitle" to "S01E01",
     )
     private val plexSessionKey = "com.plexapp.android:Breaking Bad"
 
@@ -99,7 +93,7 @@ class MediaSessionScrobblerNullTitleTest {
     }
 
     @Test
-    fun `publishObservedSession populates even when every string field is null`() {
+    fun `publishObservedSession populates even when text is blank`() {
         val emptySnapshot = MediaMetadataSnapshot(packageName = "com.example.splash")
 
         scrobbler.publishObservedSession(
@@ -112,7 +106,7 @@ class MediaSessionScrobblerNullTitleTest {
         val observed = scrobbler.lastObservedSession.value
         assertNotNull(observed)
         assertEquals(emptySnapshot, observed!!.snapshot)
-        assertTrue(emptySnapshot.candidateStrings().isEmpty())
+        assertTrue(emptySnapshot.text.isBlank())
     }
 
     @Test
@@ -125,10 +119,10 @@ class MediaSessionScrobblerNullTitleTest {
         assertNull(scrobbler.lastObservedSession.value)
     }
 
-    // ── Pause/stop dedup keyed by sessionKey, not raw title ───────────────────
+    // ── Pause/stop dedup keyed by sessionKey ──────────────────────────────────
 
     @Test
-    fun `Plex-shape pause deduped by session key when TITLE is null`() = runTest {
+    fun `Plex-shape pause deduped by session key when TITLE is absent`() = runTest {
         coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
         val candidate = scrobbler.matchSnapshot(plexPlayingSnapshot)
         assertNotNull(candidate)
@@ -136,14 +130,13 @@ class MediaSessionScrobblerNullTitleTest {
         clearMocks(scrobbleDispatcher, answers = false)
         coEvery { scrobbleDispatcher.dispatchPause(any(), any(), any()) } just runs
 
-        // Same session key → dispatchPause fires.
         scrobbler.handleScrobblePause(plexPlayingSnapshot, plexSessionKey, progress = 42f)
 
         coVerify { scrobbleDispatcher.dispatchPause(breakingBadShow, any(), 42f) }
     }
 
     @Test
-    fun `Plex-shape stop deduped by session key when TITLE is null`() = runTest {
+    fun `Plex-shape stop deduped by session key when TITLE is absent`() = runTest {
         coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
         val candidate = scrobbler.matchSnapshot(plexPlayingSnapshot)
         assertNotNull(candidate)
@@ -172,7 +165,7 @@ class MediaSessionScrobblerNullTitleTest {
         coVerify(exactly = 0) { scrobbleDispatcher.dispatchPause(any(), any(), any()) }
     }
 
-    // ── Vanished-stop uses the stashed snapshot (multi-field cascade) ──────────
+    // ── Vanished-stop uses the stashed snapshot ───────────────────────────────
 
     @Test
     fun `vanished session with stashed snapshot dispatches stop via matchSnapshot`() = runTest {
@@ -185,7 +178,6 @@ class MediaSessionScrobblerNullTitleTest {
             matchedEpisode = TraktEpisode(season = 1, number = 1),
         )
         scrobbler.autoScrobble(candidate, progress = 10f, sessionKey = plexSessionKey)
-        // Poll once — stash the snapshot alongside the progress so vanish can re-match.
         scrobbler.recordProgress(plexSessionKey, plexPlayingSnapshot, 55f)
 
         scrobbler.reconcileVanished(liveKeys = emptySet())
@@ -196,7 +188,7 @@ class MediaSessionScrobblerNullTitleTest {
     // ── sessionKey identity derivation ────────────────────────────────────────
 
     @Test
-    fun `sessionKey for snapshot with empty candidate strings is null`() {
+    fun `sessionKey for snapshot with blank text is null`() {
         val emptySnapshot = MediaMetadataSnapshot(packageName = "com.example.splash")
         with(scrobbler) {
             assertNull(emptySnapshot.sessionKey())
@@ -205,12 +197,12 @@ class MediaSessionScrobblerNullTitleTest {
 
     @Test
     fun `sessionKey derives from highest-priority non-blank field`() {
-        val plexSnapshot = MediaMetadataSnapshot(
-            packageName = "com.plexapp.android",
-            title = "Pilot",
-            albumArtist = "Breaking Bad",
+        val plexSnapshot = snapshotOf(
+            "com.plexapp.android",
+            "albumArtist" to "Breaking Bad",
+            "title" to "Pilot",
         )
-        // candidateStrings order: albumArtist > album > artist > displayTitle > displaySubtitle > title > displayDescription
+        // albumArtist is first line (highest priority), so key derives from it
         with(scrobbler) {
             assertEquals("com.plexapp.android:Breaking Bad", plexSnapshot.sessionKey())
         }

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerSnapshotTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerSnapshotTest.kt
@@ -1,7 +1,6 @@
 package com.justb81.watchbuddy.core.scrobbler
 
 import android.content.Context
-import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
 import com.justb81.watchbuddy.core.model.TitleExtractionResponse
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
@@ -55,11 +54,11 @@ class MediaSessionScrobblerSnapshotTest {
     fun `Plex-shape snapshot resolves show via ALBUM_ARTIST when TITLE is just the episode title`() = runTest {
         coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
 
-        val snapshot = MediaMetadataSnapshot(
-            packageName = "com.plexapp.android",
-            title = "Pilot",
-            albumArtist = "Breaking Bad",
-            displaySubtitle = "S01E01",
+        val snapshot = snapshotOf(
+            "com.plexapp.android",
+            "albumArtist" to "Breaking Bad",
+            "displaySubtitle" to "S01E01",
+            "title" to "Pilot",
         )
         val result = scrobbler.matchSnapshot(snapshot)
 
@@ -74,12 +73,12 @@ class MediaSessionScrobblerSnapshotTest {
     fun `Jellyfin-shape snapshot resolves show via ALBUM when ARTIST has the episode`() = runTest {
         coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
 
-        val snapshot = MediaMetadataSnapshot(
-            packageName = "org.jellyfin.mobile",
-            title = "Cat's in the Bag",
-            artist = "Cat's in the Bag",
-            album = "Breaking Bad",
-            displaySubtitle = "S01E02",
+        val snapshot = snapshotOf(
+            "org.jellyfin.mobile",
+            "album" to "Breaking Bad",
+            "artist" to "Cat's in the Bag",
+            "displaySubtitle" to "S01E02",
+            "title" to "Cat's in the Bag",
         )
         val result = scrobbler.matchSnapshot(snapshot)
 
@@ -99,10 +98,7 @@ class MediaSessionScrobblerSnapshotTest {
             confidence = 0.9f,
         )
 
-        val snapshot = MediaMetadataSnapshot(
-            packageName = "com.netflix.ninja",
-            title = "Chapter Seven",
-        )
+        val snapshot = snapshotOf("com.netflix.ninja", "title" to "Chapter Seven")
         val result = scrobbler.matchSnapshot(snapshot)
 
         assertNotNull(result)
@@ -133,10 +129,7 @@ class MediaSessionScrobblerSnapshotTest {
             confidence = 0.8f,
         )
 
-        val snapshot = MediaMetadataSnapshot(
-            packageName = "com.disney.disneyplus",
-            title = "System",
-        )
+        val snapshot = snapshotOf("com.disney.disneyplus", "title" to "System")
         val result = scrobbler.matchSnapshot(snapshot)
 
         assertNotNull(result)
@@ -150,7 +143,7 @@ class MediaSessionScrobblerSnapshotTest {
         coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
 
         val result = scrobbler.matchSnapshot(
-            MediaMetadataSnapshot(packageName = "com.netflix.ninja")
+            MediaSnapshotBuilder("com.netflix.ninja").build()
         )
 
         assertNull(result)
@@ -162,18 +155,17 @@ class MediaSessionScrobblerSnapshotTest {
     fun `SxxExx harvested from DISPLAY_SUBTITLE is honored even when show match comes from ALBUM_ARTIST`() = runTest {
         coEvery { watchedShowSource.getCachedShows() } returns listOf(breakingBadEntry)
 
-        val snapshot = MediaMetadataSnapshot(
-            packageName = "com.plexapp.android",
-            title = "Ozymandias",
-            albumArtist = "Breaking Bad",
-            displaySubtitle = "S05E14",
+        val snapshot = snapshotOf(
+            "com.plexapp.android",
+            "albumArtist" to "Breaking Bad",
+            "displaySubtitle" to "S05E14",
+            "title" to "Ozymandias",
         )
         val result = scrobbler.matchSnapshot(snapshot)
 
         assertNotNull(result)
         assertEquals(5, result!!.matchedEpisode?.season)
         assertEquals(14, result.matchedEpisode?.number)
-        // high-confidence cache match should skip the hint fallback path
         coVerify(exactly = 0) { watchedShowSource.getShowHint(any()) }
     }
 
@@ -183,13 +175,10 @@ class MediaSessionScrobblerSnapshotTest {
         coEvery { watchedShowSource.getTmdbApiKey() } returns null
         coEvery { titleExtractor.extract(any()) } returns null
 
-        val snapshot = MediaMetadataSnapshot(
-            packageName = "com.example.unknown",
-            title = "Mystery Episode",
-        )
+        val snapshot = snapshotOf("com.example.unknown", "title" to "Mystery Episode")
         val result = scrobbler.matchSnapshot(snapshot)
 
         assertNull(result)
-        assertTrue(true) // reached end of cascade without throwing
+        assertTrue(true)
     }
 }

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerStopTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerStopTest.kt
@@ -2,7 +2,6 @@ package com.justb81.watchbuddy.core.scrobbler
 
 import android.content.Context
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
-import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
 import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktIds
@@ -24,9 +23,6 @@ import org.junit.jupiter.api.Test
  * Regression tests for issue #403: handleScrobbleStop silently dropped stop events when
  * duration/position was unavailable (e.g. streaming apps that report duration=0 on the
  * last tick during credits or livestream segmentation).
- *
- * The fix treats a missing progress as "watched" and sends progress=100f, matching
- * the lenient fallback already used by handleScrobblePause (which defaults to 50f).
  */
 @DisplayName("MediaSessionScrobbler — Stop with unavailable progress (#403)")
 class MediaSessionScrobblerStopTest {
@@ -42,10 +38,7 @@ class MediaSessionScrobblerStopTest {
     private val testCandidate = ScrobbleCandidate(
         "com.netflix", "Breaking Bad S01E01", 0.95f, testShow, testEpisode
     )
-    private val testSnapshot = MediaMetadataSnapshot(
-        packageName = "com.netflix",
-        title = "Breaking Bad S01E01",
-    )
+    private val testSnapshot = snapshotOf("com.netflix", "title" to "Breaking Bad S01E01")
     private val testSessionKey = "com.netflix:Breaking Bad S01E01"
 
     @BeforeEach
@@ -79,7 +72,6 @@ class MediaSessionScrobblerStopTest {
 
         scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = null)
 
-        // autoScrobble must succeed for the same session key after the stop cleared state
         scrobbler.autoScrobble(testCandidate)
         coVerify { scrobbleDispatcher.dispatchStart(testShow, testEpisode, any()) }
     }
@@ -113,7 +105,7 @@ class MediaSessionScrobblerStopTest {
     fun `no dispatch when session key does not match currently scrobbling`() = runTest {
         primeScrobbling()
         val otherKey = "com.netflix:Other Show"
-        val otherSnapshot = MediaMetadataSnapshot(packageName = "com.netflix", title = "Other Show")
+        val otherSnapshot = snapshotOf("com.netflix", "title" to "Other Show")
 
         scrobbler.handleScrobbleStop(otherSnapshot, otherKey, progress = null)
 
@@ -144,7 +136,6 @@ class MediaSessionScrobblerStopTest {
         primeScrobbling()
 
         scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = null)
-        // Second call — currentlySessionKey is already null, so it should be a no-op
         scrobbler.handleScrobbleStop(testSnapshot, testSessionKey, progress = null)
 
         coVerify(exactly = 1) { scrobbleDispatcher.dispatchStop(any(), any(), any()) }

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/TestHelpers.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/TestHelpers.kt
@@ -1,0 +1,26 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
+import com.justb81.watchbuddy.core.model.PlaybackTick
+
+/**
+ * Builds a [MediaMetadataSnapshot] for tests using the same field-priority order
+ * that [MediaSnapshotBuilder] / [MediaSessionScrobbler.buildSnapshot] uses in
+ * production: albumArtist > album > artist > displayTitle > displaySubtitle >
+ * title > displayDescription. Pass only the fields relevant to each test case.
+ */
+internal fun snapshotOf(packageName: String, vararg fields: Pair<String, String>): MediaMetadataSnapshot {
+    val map = fields.toMap()
+    val builder = MediaSnapshotBuilder(packageName)
+    listOf("albumArtist", "album", "artist", "displayTitle", "displaySubtitle", "title", "displayDescription")
+        .forEach { key -> map[key]?.let { builder.add("mediaSession.$key", it) } }
+    return builder.build()
+}
+
+/** Builds a [PlaybackTick] for tests with sensible defaults. */
+internal fun tickOf(
+    state: Int = PlaybackTick.STATE_PLAYING,
+    positionMs: Long = 600_000L,
+    durationMs: Long = 2_700_000L,
+    capturedAtMs: Long = System.currentTimeMillis(),
+) = PlaybackTick(state = state, positionMs = positionMs, durationMs = durationMs, capturedAtMs = capturedAtMs)


### PR DESCRIPTION
## Summary

Implements the three coupled refactors from #470, split into four minimal self-contained commits:

- **Task 1** (`feat(core): add PlaybackTick`) — new `PlaybackTick` value type (`state`, `positionMs`, `durationMs`, `capturedAtMs`, computed `progress`/`isPlaying`/`isStopped`); uses inline constants (no Android import) so it's unit-testable in pure JVM. Added `PlaybackTick.UNKNOWN` sentinel.

- **Task 2** (`refactor(core): collapse MediaMetadataSnapshot to text blob; add MediaSnapshotBuilder + MetadataEnricher`) — `MediaMetadataSnapshot` reduced to `packageName + text + sources`; `MediaSnapshotBuilder` produces newline-joined `"tag: value"` lines in priority order; `MetadataEnricher` fun-interface lets future enrichers (#471, #472) add evidence without reopening `MediaSessionScrobbler`. Wire-skew compat: `text = ""` default + blank-text guard on `/scrobble/extract` returns `confidence=0` for old TV clients. `dedupKey` migrated to SHA-256 of the full text blob. All tests updated.

- **Task 3** (`refactor(core): thread PlaybackTick through LastObservedSession and matchSnapshot; add metadataEnrichers`) — `LastObservedSession` now holds a `PlaybackTick`; deprecated compat properties delegate to `tick.*`. `metadataEnrichers: List<MetadataEnricher>` added to constructor (empty default). `buildTick()` / `buildSnapshotWithEnrichers()` private helpers added. `matchSnapshot()` gains `tick` parameter for future duration-tiebreaker (#474). `TvDiagnosticsScreen` updated to read `last.tick.*` directly.

- **Task 4** (`feat(tv): add Now Playing section to TV diagnostics screen`) — new `NowPlayingSection` composable showing app package, first evidence line (title), human-readable state name, and progress %. New string resources in all 4 locales (en/de/fr/es). Section appears above the existing raw "Last media session" dump.

## Test plan

- [ ] Existing unit tests for `MediaSessionScrobbler`, `LlmTitleExtractor`, `CompanionHttpServer`, and `PhoneTitleExtractionClient` pass (CI `Test & Build`)
- [ ] CI `Build Android APKs` (debug) green for both phone and TV
- [ ] TV Diagnostics screen shows "Now Playing" section with green state when actively playing, yellow when paused/stopped, grey when no session
- [ ] Old TV client (pre-text-blob) connecting to new phone server receives `confidence=0` from `/scrobble/extract` without an exception (blank-text guard)
- [ ] Wire detekt / Android Lint clean (no new findings beyond baselines)

> **Note:** Android SDK not available in this sandbox; Gradle checks are gated on CI. The PR description surfaces this per the `precommit.sh` skip-notice convention.

Closes #470.

https://claude.ai/code/session_011D53ciWmF8yJat4yLPsqCE

---
_Generated by [Claude Code](https://claude.ai/code/session_011D53ciWmF8yJat4yLPsqCE)_