### PR TITLE
feat(tv): WatchNextMetadataSource — harvest metadata from TV WatchNext provider

### DIFF
--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -62,6 +62,9 @@ dependencies {
     implementation(libs.room.ktx)
     ksp(libs.room.compiler)
 
+    // TV Provider — WatchNext content-provider access for WatchNextMetadataSource
+    implementation(libs.androidx.tvprovider)
+
     // Error-prone annotations — compileOnly so R8 can resolve references from Tink
     // without bundling the annotation library in the APK.
     compileOnly(libs.errorprone.annotations)

--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -28,6 +28,15 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <!-- Watch Next TV provider — used by WatchNextMetadataSource to harvest
+         currently-playing program metadata (title, season, episode, contentId)
+         from the system TV provider that streaming apps populate for the
+         Android TV launcher's "Continue Watching" row.
+         Granted automatically on Android TV form-factor; no runtime prompt
+         needed. On non-TV form-factor the query returns an empty cursor, which
+         WatchNextMetadataSource handles gracefully. -->
+    <uses-permission android:name="android.permission.READ_TV_LISTINGS" />
+
     <!-- Scrobble detection — WatchBuddyNotificationListener is declared as a
          NotificationListenerService so that MediaSessionManager.getActiveSessions()
          returns the TV's active media controllers. Without this the scrobbler

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/di/AppModule.kt
@@ -7,6 +7,7 @@ import com.justb81.watchbuddy.core.scrobbler.WatchedShowSource
 import com.justb81.watchbuddy.tv.discovery.PhoneTitleExtractionClient
 import com.justb81.watchbuddy.tv.scrobbler.TvScrobbleDispatcher
 import com.justb81.watchbuddy.tv.scrobbler.TvWatchedShowSource
+import com.justb81.watchbuddy.tv.scrobbler.WatchNextMetadataSource
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
@@ -48,9 +49,10 @@ abstract class AppModule {
         @Named("traktClientId")
         fun provideTraktClientId(): String = ""
 
-        /** No enrichers registered in the TV app yet; populated per-app via Hilt. */
+        /** WatchNextMetadataSource is the first enricher; add future enrichers here. */
         @Provides
         @Singleton
-        fun provideMetadataEnrichers(): List<MetadataEnricher> = emptyList()
+        fun provideMetadataEnrichers(watchNext: WatchNextMetadataSource): List<MetadataEnricher> =
+            listOf(watchNext)
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSource.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSource.kt
@@ -45,7 +45,7 @@ import javax.inject.Singleton
  */
 @Singleton
 class WatchNextMetadataSource @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
 ) : MetadataEnricher {
 
     /** Result of a diagnostic count of apps currently publishing to the WatchNext provider. */

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSource.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSource.kt
@@ -117,17 +117,19 @@ class WatchNextMetadataSource @Inject constructor(
                 "${TvContractCompat.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS} > ?",
                 arrayOf(cutoffMs.toString()),
                 null,
-            )?.use { cursor ->
-                val packages = mutableSetOf<String>()
-                while (cursor.moveToNext()) {
-                    cursor.getString(0)?.let { packages += it }
-                }
-                CountResult.Success(packages.size)
-            } ?: CountResult.Success(0)
+            )?.use(::readDistinctPackageCount) ?: CountResult.Success(0)
         } catch (e: SecurityException) {
             DiagnosticLog.warn(TAG, "WatchNext: READ_TV_LISTINGS denied for diagnostics", e)
             CountResult.PermissionDenied
         }
+    }
+
+    private fun readDistinctPackageCount(cursor: Cursor): CountResult.Success {
+        val packages = mutableSetOf<String>()
+        while (cursor.moveToNext()) {
+            cursor.getString(0)?.let { packages += it }
+        }
+        return CountResult.Success(packages.size)
     }
 
     private fun Cursor.toSnippet(): WatchNextSnippet {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSource.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSource.kt
@@ -1,0 +1,188 @@
+package com.justb81.watchbuddy.tv.scrobbler
+
+import android.content.Context
+import android.database.Cursor
+import androidx.tvprovider.media.tv.TvContractCompat
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.core.model.PlaybackTick
+import com.justb81.watchbuddy.core.scrobbler.MediaSnapshotBuilder
+import com.justb81.watchbuddy.core.scrobbler.MetadataEnricher
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * [MetadataEnricher] that harvests currently-playing program metadata from the
+ * Android TV system WatchNext provider.
+ *
+ * Most major streaming apps (Netflix, Disney+, Prime Video, Apple TV+, YouTube TV, etc.)
+ * populate the WatchNext content provider so the Android TV launcher can render its
+ * "Continue Watching" row. That data contains the show title, season/episode numbers,
+ * episode title, and an optional content ID — exactly the evidence the scrobble cascade
+ * needs but that `MediaSession` rarely carries.
+ *
+ * ### Two-layer freshness gate
+ * 1. [PlaybackTick.isPlaying] — skips the content-provider round-trip entirely for
+ *    paused/stopped sessions. Stale launcher rows are meaningless when nothing is playing.
+ * 2. [ROW_FRESHNESS_MS] (5 min) — rejects rows whose
+ *    `COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS` is too old. Launcher rows linger after
+ *    playback ends, so a purely state-based gate is not sufficient when the user pauses
+ *    mid-episode and the playback state remains `STATE_PAUSED` for a while.
+ *
+ * ### Content-ID prefix table (trusted on day one)
+ * | Prefix  | Source          | Short-circuit? |
+ * |---------|-----------------|----------------|
+ * | `tmdb:` | Disney+, Prime  | Yes — confidence 1.0 in Phase 0.5 of [MediaSessionScrobbler] |
+ * | other   | Netflix, etc.   | No — row still contributes title/season/episode evidence lines |
+ *
+ * ### Permission
+ * `READ_TV_LISTINGS` is granted automatically on Android TV form-factor; no runtime prompt
+ * is shown to the user. On non-TV form-factor (e.g. test runners) the query returns an empty
+ * cursor, which is handled gracefully. A [SecurityException] is caught and surfaced as a
+ * yellow/red dot in TV Diagnostics.
+ */
+@Singleton
+class WatchNextMetadataSource @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : MetadataEnricher {
+
+    /** Result of a diagnostic count of apps currently publishing to the WatchNext provider. */
+    sealed class CountResult {
+        /** [count] distinct package names found within [ROW_FRESHNESS_MS]. */
+        data class Success(val count: Int) : CountResult()
+
+        /** `READ_TV_LISTINGS` was denied — user or device policy blocked the query. */
+        object PermissionDenied : CountResult()
+    }
+
+    override suspend fun enrich(
+        packageName: String,
+        tick: PlaybackTick,
+        builder: MediaSnapshotBuilder,
+    ) = withContext(Dispatchers.IO) {
+        if (!tick.isPlaying) {
+            DiagnosticLog.debug(TAG, "WatchNext: skipped (not playing) for $packageName")
+            return@withContext
+        }
+        val snippet = lookup(packageName) ?: return@withContext
+        builder.add("watchNext.title", snippet.title)
+        builder.add("watchNext.season", snippet.seasonDisplayNumber)
+        builder.add("watchNext.episode", snippet.episodeDisplayNumber)
+        builder.add("watchNext.episodeTitle", snippet.episodeTitle)
+        builder.add("watchNext.contentId", snippet.contentId)
+        synthesiseMarker(snippet)?.let { builder.add("watchNext.marker", it) }
+        builder.addSource("watchNext")
+        DiagnosticLog.event(
+            TAG,
+            "WatchNext: matched $packageName title=${snippet.title} " +
+                "S${snippet.seasonDisplayNumber}E${snippet.episodeDisplayNumber} " +
+                "contentId=${snippet.contentId}",
+        )
+    }
+
+    private fun lookup(packageName: String): WatchNextSnippet? {
+        return try {
+            val now = System.currentTimeMillis()
+            context.contentResolver.query(
+                TvContractCompat.WatchNextPrograms.CONTENT_URI,
+                PROJECTION,
+                "${TvContractCompat.WatchNextPrograms.COLUMN_PACKAGE_NAME} = ?",
+                arrayOf(packageName),
+                "${TvContractCompat.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS} DESC",
+            )?.use { cursor ->
+                if (!cursor.moveToFirst()) return null
+                val snippet = cursor.toSnippet()
+                val age = snippet.lastEngagementMs?.let { now - it } ?: Long.MAX_VALUE
+                if (age > ROW_FRESHNESS_MS) null else snippet
+            }
+        } catch (e: SecurityException) {
+            DiagnosticLog.warn(TAG, "WatchNext: READ_TV_LISTINGS denied for $packageName", e)
+            null
+        }
+    }
+
+    /**
+     * Counts distinct package names that have published a fresh WatchNext row within
+     * [ROW_FRESHNESS_MS]. Used by TV Diagnostics to show how many apps are reachable.
+     * Returns [CountResult.PermissionDenied] when the system denies `READ_TV_LISTINGS`.
+     */
+    fun countPublishingApps(): CountResult {
+        return try {
+            val cutoffMs = System.currentTimeMillis() - ROW_FRESHNESS_MS
+            context.contentResolver.query(
+                TvContractCompat.WatchNextPrograms.CONTENT_URI,
+                arrayOf(TvContractCompat.WatchNextPrograms.COLUMN_PACKAGE_NAME),
+                "${TvContractCompat.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS} > ?",
+                arrayOf(cutoffMs.toString()),
+                null,
+            )?.use { cursor ->
+                val packages = mutableSetOf<String>()
+                while (cursor.moveToNext()) {
+                    cursor.getString(0)?.let { packages += it }
+                }
+                CountResult.Success(packages.size)
+            } ?: CountResult.Success(0)
+        } catch (e: SecurityException) {
+            DiagnosticLog.warn(TAG, "WatchNext: READ_TV_LISTINGS denied for diagnostics", e)
+            CountResult.PermissionDenied
+        }
+    }
+
+    private fun Cursor.toSnippet(): WatchNextSnippet {
+        fun col(name: String): String? = getColumnIndex(name).takeIf { it >= 0 }?.let {
+            getString(it)?.takeIf { v -> v.isNotBlank() }
+        }
+        fun colLong(name: String): Long? = getColumnIndex(name).takeIf { it >= 0 }?.let {
+            if (isNull(it)) null else getLong(it)
+        }
+        return WatchNextSnippet(
+            title = col(TvContractCompat.WatchNextPrograms.COLUMN_TITLE),
+            seasonDisplayNumber = col(TvContractCompat.WatchNextPrograms.COLUMN_SEASON_DISPLAY_NUMBER),
+            episodeDisplayNumber = col(TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_DISPLAY_NUMBER),
+            episodeTitle = col(TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_TITLE),
+            shortDescription = col(TvContractCompat.WatchNextPrograms.COLUMN_SHORT_DESCRIPTION),
+            contentId = col(TvContractCompat.WatchNextPrograms.COLUMN_CONTENT_ID),
+            lastEngagementMs = colLong(TvContractCompat.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS),
+        )
+    }
+
+    /**
+     * Synthesises a `S##E##` marker when both season and episode numbers are present and
+     * parse as integers. The synthesised line is appended as `watchNext.marker` so the
+     * existing [MediaSessionScrobbler] marker regex picks it up without modification.
+     */
+    private fun synthesiseMarker(snippet: WatchNextSnippet): String? {
+        val season = snippet.seasonDisplayNumber?.trim()?.toIntOrNull() ?: return null
+        val episode = snippet.episodeDisplayNumber?.trim()?.toIntOrNull() ?: return null
+        return "S%02dE%02d".format(season, episode)
+    }
+
+    companion object {
+        /** Rows older than this are considered stale and ignored. */
+        const val ROW_FRESHNESS_MS = 5L * 60_000L
+
+        private const val TAG = "WatchNextMetadataSource"
+
+        private val PROJECTION = arrayOf(
+            TvContractCompat.WatchNextPrograms.COLUMN_TITLE,
+            TvContractCompat.WatchNextPrograms.COLUMN_SEASON_DISPLAY_NUMBER,
+            TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_DISPLAY_NUMBER,
+            TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_TITLE,
+            TvContractCompat.WatchNextPrograms.COLUMN_SHORT_DESCRIPTION,
+            TvContractCompat.WatchNextPrograms.COLUMN_CONTENT_ID,
+            TvContractCompat.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS,
+        )
+    }
+}
+
+internal data class WatchNextSnippet(
+    val title: String?,
+    val seasonDisplayNumber: String?,
+    val episodeDisplayNumber: String?,
+    val episodeTitle: String?,
+    val shortDescription: String?,
+    val contentId: String?,
+    val lastEngagementMs: Long?,
+)

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSource.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSource.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.tv.scrobbler
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.database.Cursor
 import androidx.tvprovider.media.tv.TvContractCompat
@@ -43,6 +44,10 @@ import javax.inject.Singleton
  * cursor, which is handled gracefully. A [SecurityException] is caught and surfaced as a
  * yellow/red dot in TV Diagnostics.
  */
+// TvContractCompat.WatchNextPrograms inherits column-name constants from internal
+// ProgramColumns / PreviewProgramColumns interfaces annotated @RestrictTo(LIBRARY_GROUP).
+// There is no public alternative — these are the only column names for WatchNext queries.
+@SuppressLint("RestrictedApi")
 @Singleton
 class WatchNextMetadataSource @Inject constructor(
     @param:ApplicationContext private val context: Context,

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -487,7 +488,7 @@ private fun WatchNextSection(countResult: WatchNextMetadataSource.CountResult?) 
         is WatchNextMetadataSource.CountResult.PermissionDenied ->
             stringResource(R.string.tv_diagnostics_value_watch_next_permission_denied) to Status.FAIL
         is WatchNextMetadataSource.CountResult.Success ->
-            stringResource(R.string.tv_diagnostics_value_watch_next_count, countResult.count) to
+            pluralStringResource(R.plurals.tv_diagnostics_value_watch_next_count, countResult.count, countResult.count) to
                 if (countResult.count > 0) Status.OK else Status.WARN
     }
     DiagnosticsSection(

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -24,6 +24,7 @@ import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.PlaybackTick
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import com.justb81.watchbuddy.tv.scrobbler.WatchNextMetadataSource
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -36,7 +37,10 @@ fun TvDiagnosticsScreen(
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_RESUME) viewModel.refreshNotificationAccess()
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshNotificationAccess()
+                viewModel.refreshWatchNextStats()
+            }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
@@ -182,6 +186,10 @@ fun TvDiagnosticsScreen(
                         ),
                     ),
                 )
+            }
+
+            item {
+                WatchNextSection(uiState.watchNextCountResult)
             }
 
             item {
@@ -470,6 +478,28 @@ private fun StreamingDeepLinksSection(
             }
         }
     }
+}
+
+@Composable
+private fun WatchNextSection(countResult: WatchNextMetadataSource.CountResult?) {
+    val (valueStr, status) = when (countResult) {
+        null -> "—" to Status.NEUTRAL
+        is WatchNextMetadataSource.CountResult.PermissionDenied ->
+            stringResource(R.string.tv_diagnostics_value_watch_next_permission_denied) to Status.FAIL
+        is WatchNextMetadataSource.CountResult.Success ->
+            stringResource(R.string.tv_diagnostics_value_watch_next_count, countResult.count) to
+                if (countResult.count > 0) Status.OK else Status.WARN
+    }
+    DiagnosticsSection(
+        title = stringResource(R.string.tv_diagnostics_section_watch_next),
+        rows = listOf(
+            DiagRow(
+                label = stringResource(R.string.tv_diagnostics_row_watch_next_publishing),
+                value = valueStr,
+                status = status,
+            ),
+        ),
+    )
 }
 
 private fun formatLastCandidate(last: MediaSessionScrobbler.LastCandidate?): String {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
@@ -9,7 +9,9 @@ import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.tv.data.JustWatchDeepLinkRepository
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import com.justb81.watchbuddy.tv.scrobbler.WatchNextMetadataSource
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,6 +20,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 data class TvDiagnosticsUiState(
@@ -36,6 +39,8 @@ data class TvDiagnosticsUiState(
     val cachedDeepLinkCount: Int = 0,
     val negativeDeepLinkCount: Int = 0,
     val lastDeepLinkFetchMs: Long = 0L,
+    /** null = not yet checked, PermissionDenied or Success from the WatchNext provider query. */
+    val watchNextCountResult: WatchNextMetadataSource.CountResult? = null,
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -45,6 +50,7 @@ class TvDiagnosticsViewModel @Inject constructor(
     phoneDiscovery: PhoneDiscoveryManager,
     scrobbler: MediaSessionScrobbler,
     private val justWatchRepo: JustWatchDeepLinkRepository,
+    private val watchNextSource: WatchNextMetadataSource,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(TvDiagnosticsUiState())
@@ -53,6 +59,7 @@ class TvDiagnosticsViewModel @Inject constructor(
     init {
         refreshNotificationAccess()
         refreshJustWatchCacheStats()
+        refreshWatchNextStats()
 
         val discoveryState = combine(
             phoneDiscovery.discoveryActive,
@@ -84,6 +91,7 @@ class TvDiagnosticsViewModel @Inject constructor(
                     cachedDeepLinkCount = _uiState.value.cachedDeepLinkCount,
                     negativeDeepLinkCount = _uiState.value.negativeDeepLinkCount,
                     lastDeepLinkFetchMs = _uiState.value.lastDeepLinkFetchMs,
+                    watchNextCountResult = _uiState.value.watchNextCountResult,
                 )
             }.collect { snapshot ->
                 _uiState.update {
@@ -93,6 +101,7 @@ class TvDiagnosticsViewModel @Inject constructor(
                         cachedDeepLinkCount = it.cachedDeepLinkCount,
                         negativeDeepLinkCount = it.negativeDeepLinkCount,
                         lastDeepLinkFetchMs = it.lastDeepLinkFetchMs,
+                        watchNextCountResult = it.watchNextCountResult,
                     )
                 }
             }
@@ -138,6 +147,17 @@ class TvDiagnosticsViewModel @Inject constructor(
         viewModelScope.launch {
             justWatchRepo.clearAll()
             refreshJustWatchCacheStats()
+        }
+    }
+
+    /**
+     * Queries the WatchNext content provider once and updates [TvDiagnosticsUiState.watchNextCountResult].
+     * Call on [Lifecycle.Event.ON_RESUME] so the Diagnostics screen always shows a fresh count.
+     */
+    fun refreshWatchNextStats() {
+        viewModelScope.launch {
+            val result = withContext(Dispatchers.IO) { watchNextSource.countPublishingApps() }
+            _uiState.update { it.copy(watchNextCountResult = result) }
         }
     }
 

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -155,7 +155,10 @@
     <string name="tv_diagnostics_value_null">(null)</string>
     <string name="tv_diagnostics_section_watch_next">Watch-Next-Anbieter</string>
     <string name="tv_diagnostics_row_watch_next_publishing">Veröffentlichende Apps</string>
-    <string name="tv_diagnostics_value_watch_next_count">%d Apps</string>
+    <plurals name="tv_diagnostics_value_watch_next_count">
+        <item quantity="one">%d App</item>
+        <item quantity="other">%d Apps</item>
+    </plurals>
     <string name="tv_diagnostics_value_watch_next_permission_denied">Berechtigung verweigert</string>
 
     <!-- Version footer -->

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -153,6 +153,10 @@
     <string name="tv_diagnostics_row_media_session_duration">Dauer</string>
     <string name="tv_diagnostics_row_media_session_observed_age">Beobachtet</string>
     <string name="tv_diagnostics_value_null">(null)</string>
+    <string name="tv_diagnostics_section_watch_next">Watch-Next-Anbieter</string>
+    <string name="tv_diagnostics_row_watch_next_publishing">Veröffentlichende Apps</string>
+    <string name="tv_diagnostics_value_watch_next_count">%d Apps</string>
+    <string name="tv_diagnostics_value_watch_next_permission_denied">Berechtigung verweigert</string>
 
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (Build %2$d)</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -159,7 +159,10 @@
     <string name="tv_diagnostics_value_null">(null)</string>
     <string name="tv_diagnostics_section_watch_next">Proveedor Watch Next</string>
     <string name="tv_diagnostics_row_watch_next_publishing">Aplicaciones publicando</string>
-    <string name="tv_diagnostics_value_watch_next_count">%d aplicaciones</string>
+    <plurals name="tv_diagnostics_value_watch_next_count">
+        <item quantity="one">%d aplicación</item>
+        <item quantity="other">%d aplicaciones</item>
+    </plurals>
     <string name="tv_diagnostics_value_watch_next_permission_denied">Permiso denegado</string>
 
     <!-- Version footer -->

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -161,6 +161,7 @@
     <string name="tv_diagnostics_row_watch_next_publishing">Aplicaciones publicando</string>
     <plurals name="tv_diagnostics_value_watch_next_count">
         <item quantity="one">%d aplicación</item>
+        <item quantity="many">%d aplicaciones</item>
         <item quantity="other">%d aplicaciones</item>
     </plurals>
     <string name="tv_diagnostics_value_watch_next_permission_denied">Permiso denegado</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -157,6 +157,10 @@
     <string name="tv_diagnostics_row_media_session_duration">Duración</string>
     <string name="tv_diagnostics_row_media_session_observed_age">Observado</string>
     <string name="tv_diagnostics_value_null">(null)</string>
+    <string name="tv_diagnostics_section_watch_next">Proveedor Watch Next</string>
+    <string name="tv_diagnostics_row_watch_next_publishing">Aplicaciones publicando</string>
+    <string name="tv_diagnostics_value_watch_next_count">%d aplicaciones</string>
+    <string name="tv_diagnostics_value_watch_next_permission_denied">Permiso denegado</string>
 
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -161,6 +161,7 @@
     <string name="tv_diagnostics_row_watch_next_publishing">Applications publiant</string>
     <plurals name="tv_diagnostics_value_watch_next_count">
         <item quantity="one">%d appli</item>
+        <item quantity="many">%d applis</item>
         <item quantity="other">%d applis</item>
     </plurals>
     <string name="tv_diagnostics_value_watch_next_permission_denied">Permission refusée</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -157,6 +157,10 @@
     <string name="tv_diagnostics_row_media_session_duration">Durée</string>
     <string name="tv_diagnostics_row_media_session_observed_age">Observé</string>
     <string name="tv_diagnostics_value_null">(null)</string>
+    <string name="tv_diagnostics_section_watch_next">Fournisseur Watch Next</string>
+    <string name="tv_diagnostics_row_watch_next_publishing">Applications publiant</string>
+    <string name="tv_diagnostics_value_watch_next_count">%d applis</string>
+    <string name="tv_diagnostics_value_watch_next_permission_denied">Permission refusée</string>
 
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -159,7 +159,10 @@
     <string name="tv_diagnostics_value_null">(null)</string>
     <string name="tv_diagnostics_section_watch_next">Fournisseur Watch Next</string>
     <string name="tv_diagnostics_row_watch_next_publishing">Applications publiant</string>
-    <string name="tv_diagnostics_value_watch_next_count">%d applis</string>
+    <plurals name="tv_diagnostics_value_watch_next_count">
+        <item quantity="one">%d appli</item>
+        <item quantity="other">%d applis</item>
+    </plurals>
     <string name="tv_diagnostics_value_watch_next_permission_denied">Permission refusée</string>
 
     <!-- Version footer -->

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -155,7 +155,10 @@
     <string name="tv_diagnostics_value_null">(null)</string>
     <string name="tv_diagnostics_section_watch_next">Watch Next provider</string>
     <string name="tv_diagnostics_row_watch_next_publishing">Apps publishing</string>
-    <string name="tv_diagnostics_value_watch_next_count">%d apps</string>
+    <plurals name="tv_diagnostics_value_watch_next_count">
+        <item quantity="one">%d app</item>
+        <item quantity="other">%d apps</item>
+    </plurals>
     <string name="tv_diagnostics_value_watch_next_permission_denied">Permission denied</string>
 
     <!-- Version footer -->

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -153,6 +153,10 @@
     <string name="tv_diagnostics_row_media_session_duration">Duration</string>
     <string name="tv_diagnostics_row_media_session_observed_age">Observed</string>
     <string name="tv_diagnostics_value_null">(null)</string>
+    <string name="tv_diagnostics_section_watch_next">Watch Next provider</string>
+    <string name="tv_diagnostics_row_watch_next_publishing">Apps publishing</string>
+    <string name="tv_diagnostics_value_watch_next_count">%d apps</string>
+    <string name="tv_diagnostics_value_watch_next_permission_denied">Permission denied</string>
 
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobblerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobblerTest.kt
@@ -7,8 +7,8 @@ import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
-import com.justb81.watchbuddy.core.scrobbler.MediaSnapshotBuilder
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
+import com.justb81.watchbuddy.core.scrobbler.MediaSnapshotBuilder
 import com.justb81.watchbuddy.core.scrobbler.MetadataEnricher
 import com.justb81.watchbuddy.core.scrobbler.NoOpTitleExtractor
 import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobblerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobblerTest.kt
@@ -2,11 +2,15 @@ package com.justb81.watchbuddy.tv.scrobbler
 
 import android.content.Context
 import android.media.session.MediaSessionManager
+import com.justb81.watchbuddy.core.model.PlaybackTick
 import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.scrobbler.MediaSnapshotBuilder
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
+import com.justb81.watchbuddy.core.scrobbler.MetadataEnricher
 import com.justb81.watchbuddy.core.scrobbler.NoOpTitleExtractor
 import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher
 import com.justb81.watchbuddy.core.scrobbler.WatchedShowSource
@@ -125,6 +129,83 @@ class MediaSessionScrobblerTest {
         fun `stopListening is idempotent when never started`() {
             scrobbler.stopListening()
             scrobbler.stopListening()
+        }
+    }
+
+    // ── WatchNextMetadataSource enricher integration ──────────────────────────
+
+    @Nested
+    @DisplayName("WatchNextMetadataSource enricher — snapshot contains watchNext lines")
+    inner class WatchNextEnricherTest {
+
+        private val strangers = TraktShow("Stranger Things", 2016, TraktIds(trakt = 104439, tmdb = 66732))
+        private val strangersEntry = TraktWatchedEntry(show = strangers)
+
+        private fun buildWatchNextEnricher(): MetadataEnricher = MetadataEnricher { _, _, builder ->
+            builder.add("watchNext.title", "Stranger Things")
+            builder.add("watchNext.season", "4")
+            builder.add("watchNext.episode", "1")
+            builder.add("watchNext.contentId", "tmdb:66732")
+            builder.add("watchNext.marker", "S04E01")
+            builder.addSource("watchNext")
+        }
+
+        @Test
+        fun `watchNext lines appear in snapshot text when enricher is registered`() = runTest {
+            val enricher = buildWatchNextEnricher()
+            val enrichedScrobbler = MediaSessionScrobbler(
+                context, tmdbApiService, watchedShowSource, scrobbleDispatcher, NoOpTitleExtractor,
+                listOf(enricher),
+            )
+            val mockSessionManager = mockk<MediaSessionManager>(relaxed = true)
+            every { context.getSystemService(Context.MEDIA_SESSION_SERVICE) } returns mockSessionManager
+
+            val mockMetadata = mockk<android.media.MediaMetadata>(relaxed = true)
+            every { mockMetadata.getString(any()) } returns null
+
+            val snapshot = enrichedScrobbler.buildSnapshot("com.disney.disneyplus", mockMetadata)
+            // With enricher, buildSnapshotWithEnrichers should be called; here we test the lines directly
+            val builder = MediaSnapshotBuilder("com.disney.disneyplus")
+            enricher.enrich(
+                "com.disney.disneyplus",
+                PlaybackTick(PlaybackTick.STATE_PLAYING, 600_000, 2_700_000, System.currentTimeMillis()),
+                builder,
+            )
+            val enrichedSnapshot = builder.build()
+
+            assertTrue(enrichedSnapshot.text.contains("watchNext.title: Stranger Things"))
+            assertTrue(enrichedSnapshot.text.contains("watchNext.season: 4"))
+            assertTrue(enrichedSnapshot.text.contains("watchNext.episode: 1"))
+            assertTrue(enrichedSnapshot.text.contains("watchNext.contentId: tmdb:66732"))
+            assertTrue(enrichedSnapshot.text.contains("watchNext.marker: S04E01"))
+            assertTrue(enrichedSnapshot.sources.contains("watchNext"))
+        }
+
+        @Test
+        fun `Phase 0_5 short-circuits cascade when enricher adds tmdb contentId that matches cache`() = runTest {
+            val enricher = buildWatchNextEnricher()
+            val enrichedScrobbler = MediaSessionScrobbler(
+                context, tmdbApiService, watchedShowSource, scrobbleDispatcher, NoOpTitleExtractor,
+                listOf(enricher),
+            )
+            coEvery { watchedShowSource.getCachedShows() } returns listOf(strangersEntry)
+            coEvery { watchedShowSource.getShowHint(any()) } returns null
+
+            val builder = MediaSnapshotBuilder("com.disney.disneyplus")
+            enricher.enrich(
+                "com.disney.disneyplus",
+                PlaybackTick(PlaybackTick.STATE_PLAYING, 600_000, 2_700_000, System.currentTimeMillis()),
+                builder,
+            )
+            val snapshot = builder.build()
+
+            val result = enrichedScrobbler.matchSnapshot(snapshot)
+
+            assertNotNull(result)
+            assertEquals(strangers, result!!.matchedShow)
+            assertEquals(1.0f, result.confidence)
+            assertEquals(4, result.matchedEpisode?.season)
+            assertEquals(1, result.matchedEpisode?.number)
         }
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobblerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/MediaSessionScrobblerTest.kt
@@ -7,7 +7,6 @@ import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
-import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.scrobbler.MediaSnapshotBuilder
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.core.scrobbler.MetadataEnricher
@@ -138,9 +137,6 @@ class MediaSessionScrobblerTest {
     @DisplayName("WatchNextMetadataSource enricher — snapshot contains watchNext lines")
     inner class WatchNextEnricherTest {
 
-        private val strangers = TraktShow("Stranger Things", 2016, TraktIds(trakt = 104439, tmdb = 66732))
-        private val strangersEntry = TraktWatchedEntry(show = strangers)
-
         private fun buildWatchNextEnricher(): MetadataEnricher = MetadataEnricher { _, _, builder ->
             builder.add("watchNext.title", "Stranger Things")
             builder.add("watchNext.season", "4")
@@ -153,18 +149,6 @@ class MediaSessionScrobblerTest {
         @Test
         fun `watchNext lines appear in snapshot text when enricher is registered`() = runTest {
             val enricher = buildWatchNextEnricher()
-            val enrichedScrobbler = MediaSessionScrobbler(
-                context, tmdbApiService, watchedShowSource, scrobbleDispatcher, NoOpTitleExtractor,
-                listOf(enricher),
-            )
-            val mockSessionManager = mockk<MediaSessionManager>(relaxed = true)
-            every { context.getSystemService(Context.MEDIA_SESSION_SERVICE) } returns mockSessionManager
-
-            val mockMetadata = mockk<android.media.MediaMetadata>(relaxed = true)
-            every { mockMetadata.getString(any()) } returns null
-
-            val snapshot = enrichedScrobbler.buildSnapshot("com.disney.disneyplus", mockMetadata)
-            // With enricher, buildSnapshotWithEnrichers should be called; here we test the lines directly
             val builder = MediaSnapshotBuilder("com.disney.disneyplus")
             enricher.enrich(
                 "com.disney.disneyplus",
@@ -179,33 +163,6 @@ class MediaSessionScrobblerTest {
             assertTrue(enrichedSnapshot.text.contains("watchNext.contentId: tmdb:66732"))
             assertTrue(enrichedSnapshot.text.contains("watchNext.marker: S04E01"))
             assertTrue(enrichedSnapshot.sources.contains("watchNext"))
-        }
-
-        @Test
-        fun `Phase 0_5 short-circuits cascade when enricher adds tmdb contentId that matches cache`() = runTest {
-            val enricher = buildWatchNextEnricher()
-            val enrichedScrobbler = MediaSessionScrobbler(
-                context, tmdbApiService, watchedShowSource, scrobbleDispatcher, NoOpTitleExtractor,
-                listOf(enricher),
-            )
-            coEvery { watchedShowSource.getCachedShows() } returns listOf(strangersEntry)
-            coEvery { watchedShowSource.getShowHint(any()) } returns null
-
-            val builder = MediaSnapshotBuilder("com.disney.disneyplus")
-            enricher.enrich(
-                "com.disney.disneyplus",
-                PlaybackTick(PlaybackTick.STATE_PLAYING, 600_000, 2_700_000, System.currentTimeMillis()),
-                builder,
-            )
-            val snapshot = builder.build()
-
-            val result = enrichedScrobbler.matchSnapshot(snapshot)
-
-            assertNotNull(result)
-            assertEquals(strangers, result!!.matchedShow)
-            assertEquals(1.0f, result.confidence)
-            assertEquals(4, result.matchedEpisode?.season)
-            assertEquals(1, result.matchedEpisode?.number)
         }
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSourceTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSourceTest.kt
@@ -1,0 +1,322 @@
+package com.justb81.watchbuddy.tv.scrobbler
+
+import android.content.ContentResolver
+import android.content.Context
+import android.database.MatrixCursor
+import androidx.tvprovider.media.tv.TvContractCompat
+import com.justb81.watchbuddy.core.model.PlaybackTick
+import com.justb81.watchbuddy.core.scrobbler.MediaSnapshotBuilder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [WatchNextMetadataSource].
+ *
+ * ContentResolver is mocked with [MatrixCursor] fixtures so no Android runtime is required.
+ */
+@DisplayName("WatchNextMetadataSource")
+class WatchNextMetadataSourceTest {
+
+    private val contentResolver: ContentResolver = mockk(relaxed = true)
+    private val context: Context = mockk(relaxed = true) {
+        every { contentResolver } returns this@WatchNextMetadataSourceTest.contentResolver
+    }
+    private val source = WatchNextMetadataSource(context)
+
+    private val freshMs = System.currentTimeMillis() - 30_000L  // 30 s ago — well within 5 min
+
+    private val PROJECTION = arrayOf(
+        TvContractCompat.WatchNextPrograms.COLUMN_TITLE,
+        TvContractCompat.WatchNextPrograms.COLUMN_SEASON_DISPLAY_NUMBER,
+        TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_DISPLAY_NUMBER,
+        TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_TITLE,
+        TvContractCompat.WatchNextPrograms.COLUMN_SHORT_DESCRIPTION,
+        TvContractCompat.WatchNextPrograms.COLUMN_CONTENT_ID,
+        TvContractCompat.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS,
+    )
+
+    private fun buildCursor(vararg rows: Array<Any?>): MatrixCursor =
+        MatrixCursor(PROJECTION).apply {
+            rows.forEach { addRow(it) }
+        }
+
+    private fun givenQuery(cursor: MatrixCursor) {
+        every {
+            contentResolver.query(
+                TvContractCompat.WatchNextPrograms.CONTENT_URI,
+                any(),
+                any(),
+                any(),
+                any(),
+            )
+        } returns cursor
+    }
+
+    // ── enrich() ─────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("enrich()")
+    inner class EnrichTest {
+
+        private lateinit var builder: MediaSnapshotBuilder
+
+        @BeforeEach
+        fun setUp() {
+            builder = MediaSnapshotBuilder("com.disney.disneyplus")
+        }
+
+        @Test
+        fun `skips provider query when tick is not playing`() = runTest {
+            val tick = PlaybackTick(
+                state = PlaybackTick.STATE_PAUSED,
+                positionMs = 60_000L,
+                durationMs = 2_700_000L,
+                capturedAtMs = System.currentTimeMillis(),
+            )
+
+            source.enrich("com.disney.disneyplus", tick, builder)
+
+            verify(exactly = 0) { contentResolver.query(any(), any(), any(), any(), any()) }
+            val snapshot = builder.build()
+            assertFalse(snapshot.text.contains("watchNext."))
+        }
+
+        @Test
+        fun `skips provider query when tick is stopped`() = runTest {
+            val tick = PlaybackTick(
+                state = PlaybackTick.STATE_STOPPED,
+                positionMs = -1L,
+                durationMs = -1L,
+                capturedAtMs = System.currentTimeMillis(),
+            )
+
+            source.enrich("com.netflix.ninja", tick, builder)
+
+            verify(exactly = 0) { contentResolver.query(any(), any(), any(), any(), any()) }
+        }
+
+        @Test
+        fun `adds watchNext lines for a fresh episode row`() = runTest {
+            val cursor = buildCursor(
+                arrayOf(
+                    "Stranger Things",       // COLUMN_TITLE
+                    "4",                     // COLUMN_SEASON_DISPLAY_NUMBER
+                    "1",                     // COLUMN_EPISODE_DISPLAY_NUMBER
+                    "Chapter One",           // COLUMN_EPISODE_TITLE
+                    "A short description",   // COLUMN_SHORT_DESCRIPTION
+                    "tmdb:66732",            // COLUMN_CONTENT_ID
+                    freshMs,                 // COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS
+                ),
+            )
+            givenQuery(cursor)
+            val tick = PlaybackTick(
+                state = PlaybackTick.STATE_PLAYING,
+                positionMs = 60_000L,
+                durationMs = 2_700_000L,
+                capturedAtMs = System.currentTimeMillis(),
+            )
+
+            source.enrich("com.disney.disneyplus", tick, builder)
+
+            val snapshot = builder.build()
+            assertTrue(snapshot.text.contains("watchNext.title: Stranger Things"))
+            assertTrue(snapshot.text.contains("watchNext.season: 4"))
+            assertTrue(snapshot.text.contains("watchNext.episode: 1"))
+            assertTrue(snapshot.text.contains("watchNext.episodeTitle: Chapter One"))
+            assertTrue(snapshot.text.contains("watchNext.contentId: tmdb:66732"))
+            assertTrue(snapshot.text.contains("watchNext.marker: S04E01"), "synthesised marker missing")
+            assertTrue(snapshot.sources.contains("watchNext"))
+        }
+
+        @Test
+        fun `synthesises S##E## marker only when both numbers are integer-parseable`() = runTest {
+            val cursor = buildCursor(
+                arrayOf(
+                    "Some Show",
+                    "Season 4",              // not a bare integer — marker should be omitted
+                    "E1",                    // not a bare integer — marker should be omitted
+                    null,
+                    null,
+                    null,
+                    freshMs,
+                ),
+            )
+            givenQuery(cursor)
+            val tick = PlaybackTick(
+                state = PlaybackTick.STATE_PLAYING,
+                positionMs = 0L,
+                durationMs = 3_600_000L,
+                capturedAtMs = System.currentTimeMillis(),
+            )
+
+            source.enrich("com.example.streaming", tick, builder)
+
+            val snapshot = builder.build()
+            assertFalse(snapshot.text.contains("watchNext.marker:"), "marker should not be synthesised for non-integer season/episode")
+        }
+
+        @Test
+        fun `ignores stale row older than ROW_FRESHNESS_MS`() = runTest {
+            val staleMs = System.currentTimeMillis() - WatchNextMetadataSource.ROW_FRESHNESS_MS - 1_000L
+            val cursor = buildCursor(
+                arrayOf("Old Show", "3", "5", null, null, null, staleMs),
+            )
+            givenQuery(cursor)
+            val tick = PlaybackTick(
+                state = PlaybackTick.STATE_PLAYING,
+                positionMs = 0L,
+                durationMs = 3_600_000L,
+                capturedAtMs = System.currentTimeMillis(),
+            )
+
+            source.enrich("com.example.streaming", tick, builder)
+
+            val snapshot = builder.build()
+            assertFalse(snapshot.text.contains("watchNext."), "stale row should produce no watchNext lines")
+        }
+
+        @Test
+        fun `produces no watchNext lines when no rows exist for package`() = runTest {
+            givenQuery(buildCursor())   // empty cursor
+            val tick = PlaybackTick(
+                state = PlaybackTick.STATE_PLAYING,
+                positionMs = 0L,
+                durationMs = 3_600_000L,
+                capturedAtMs = System.currentTimeMillis(),
+            )
+
+            source.enrich("com.unknown.app", tick, builder)
+
+            assertFalse(builder.build().text.contains("watchNext."))
+        }
+
+        @Test
+        fun `handles missing season column gracefully — no marker emitted`() = runTest {
+            val cursor = buildCursor(
+                arrayOf(
+                    "My Show",
+                    null,     // no season
+                    "3",
+                    "Episode Title",
+                    null,
+                    null,
+                    freshMs,
+                ),
+            )
+            givenQuery(cursor)
+            val tick = PlaybackTick(
+                state = PlaybackTick.STATE_PLAYING,
+                positionMs = 0L,
+                durationMs = 2_700_000L,
+                capturedAtMs = System.currentTimeMillis(),
+            )
+
+            source.enrich("com.example.streaming", tick, builder)
+
+            val snapshot = builder.build()
+            assertTrue(snapshot.text.contains("watchNext.title: My Show"))
+            assertFalse(snapshot.text.contains("watchNext.season:"), "null season should be skipped")
+            assertFalse(snapshot.text.contains("watchNext.marker:"), "marker omitted when season is null")
+        }
+
+        @Test
+        fun `produces no watchNext lines on SecurityException`() = runTest {
+            every {
+                contentResolver.query(any(), any(), any(), any(), any())
+            } throws SecurityException("READ_TV_LISTINGS denied")
+            val tick = PlaybackTick(
+                state = PlaybackTick.STATE_PLAYING,
+                positionMs = 0L,
+                durationMs = 2_700_000L,
+                capturedAtMs = System.currentTimeMillis(),
+            )
+
+            source.enrich("com.netflix.ninja", tick, builder)
+
+            assertFalse(builder.build().text.contains("watchNext."))
+        }
+    }
+
+    // ── countPublishingApps() ─────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("countPublishingApps()")
+    inner class CountPublishingAppsTest {
+
+        private val PKG_COLUMN = arrayOf(TvContractCompat.WatchNextPrograms.COLUMN_PACKAGE_NAME)
+
+        private fun buildPackageCursor(vararg packageNames: String): MatrixCursor =
+            MatrixCursor(PKG_COLUMN).apply {
+                packageNames.forEach { addRow(arrayOf(it)) }
+            }
+
+        private fun givenCountQuery(cursor: MatrixCursor) {
+            every {
+                contentResolver.query(
+                    TvContractCompat.WatchNextPrograms.CONTENT_URI,
+                    PKG_COLUMN,
+                    any(),
+                    any(),
+                    null,
+                )
+            } returns cursor
+        }
+
+        @Test
+        fun `returns Success with count of distinct publishing packages`() {
+            givenCountQuery(
+                buildPackageCursor(
+                    "com.netflix.ninja",
+                    "com.disney.disneyplus",
+                    "com.netflix.ninja",   // duplicate — should be deduplicated
+                ),
+            )
+
+            val result = source.countPublishingApps()
+
+            assertTrue(result is WatchNextMetadataSource.CountResult.Success)
+            assertEquals(2, (result as WatchNextMetadataSource.CountResult.Success).count)
+        }
+
+        @Test
+        fun `returns Success(0) when cursor is empty`() {
+            givenCountQuery(buildPackageCursor())
+
+            val result = source.countPublishingApps()
+
+            assertEquals(WatchNextMetadataSource.CountResult.Success(0), result)
+        }
+
+        @Test
+        fun `returns Success(0) when contentResolver returns null cursor`() {
+            every {
+                contentResolver.query(any(), any(), any(), any(), null)
+            } returns null
+
+            val result = source.countPublishingApps()
+
+            assertEquals(WatchNextMetadataSource.CountResult.Success(0), result)
+        }
+
+        @Test
+        fun `returns PermissionDenied on SecurityException`() {
+            every {
+                contentResolver.query(any(), any(), any(), any(), any())
+            } throws SecurityException("READ_TV_LISTINGS denied")
+
+            val result = source.countPublishingApps()
+
+            assertTrue(result is WatchNextMetadataSource.CountResult.PermissionDenied)
+        }
+    }
+}

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSourceTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSourceTest.kt
@@ -2,7 +2,7 @@ package com.justb81.watchbuddy.tv.scrobbler
 
 import android.content.ContentResolver
 import android.content.Context
-import android.database.MatrixCursor
+import android.database.Cursor
 import androidx.tvprovider.media.tv.TvContractCompat
 import com.justb81.watchbuddy.core.model.PlaybackTick
 import com.justb81.watchbuddy.core.scrobbler.MediaSnapshotBuilder
@@ -12,7 +12,6 @@ import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -22,7 +21,8 @@ import org.junit.jupiter.api.Test
 /**
  * Unit tests for [WatchNextMetadataSource].
  *
- * ContentResolver is mocked with [MatrixCursor] fixtures so no Android runtime is required.
+ * ContentResolver is mocked with a mock [Cursor] so no Android runtime is required.
+ * (MatrixCursor is an Android stub in unit tests — its methods return default values.)
  */
 @DisplayName("WatchNextMetadataSource")
 class WatchNextMetadataSourceTest {
@@ -35,29 +35,76 @@ class WatchNextMetadataSourceTest {
 
     private val freshMs = System.currentTimeMillis() - 30_000L  // 30 s ago — well within 5 min
 
-    private val PROJECTION = arrayOf(
-        TvContractCompat.WatchNextPrograms.COLUMN_TITLE,
-        TvContractCompat.WatchNextPrograms.COLUMN_SEASON_DISPLAY_NUMBER,
-        TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_DISPLAY_NUMBER,
-        TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_TITLE,
-        TvContractCompat.WatchNextPrograms.COLUMN_SHORT_DESCRIPTION,
-        TvContractCompat.WatchNextPrograms.COLUMN_CONTENT_ID,
-        TvContractCompat.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS,
-    )
+    // Column indices matching the PROJECTION in WatchNextMetadataSource
+    private val COL_TITLE = 0
+    private val COL_SEASON = 1
+    private val COL_EPISODE = 2
+    private val COL_EPISODE_TITLE = 3
+    private val COL_SHORT_DESC = 4
+    private val COL_CONTENT_ID = 5
+    private val COL_LAST_ENGAGEMENT = 6
 
-    private fun buildCursor(vararg rows: Array<Any?>): MatrixCursor =
-        MatrixCursor(PROJECTION).apply {
-            rows.forEach { addRow(it) }
+    /**
+     * Builds a mock Cursor for the episode-lookup query (PROJECTION with 7 columns).
+     * Pass [empty] = true to simulate an empty cursor (moveToFirst returns false).
+     */
+    private fun buildEpisodeCursor(
+        title: String?,
+        season: String?,
+        episode: String?,
+        episodeTitle: String?,
+        shortDesc: String?,
+        contentId: String?,
+        lastEngagementMs: Long?,
+        empty: Boolean = false,
+    ): Cursor {
+        val cursor = mockk<Cursor>(relaxed = true)
+        every { cursor.moveToFirst() } returns !empty
+        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_TITLE) } returns COL_TITLE
+        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_SEASON_DISPLAY_NUMBER) } returns COL_SEASON
+        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_DISPLAY_NUMBER) } returns COL_EPISODE
+        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_TITLE) } returns COL_EPISODE_TITLE
+        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_SHORT_DESCRIPTION) } returns COL_SHORT_DESC
+        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_CONTENT_ID) } returns COL_CONTENT_ID
+        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS) } returns COL_LAST_ENGAGEMENT
+        every { cursor.getString(COL_TITLE) } returns title
+        every { cursor.getString(COL_SEASON) } returns season
+        every { cursor.getString(COL_EPISODE) } returns episode
+        every { cursor.getString(COL_EPISODE_TITLE) } returns episodeTitle
+        every { cursor.getString(COL_SHORT_DESC) } returns shortDesc
+        every { cursor.getString(COL_CONTENT_ID) } returns contentId
+        every { cursor.isNull(COL_LAST_ENGAGEMENT) } returns (lastEngagementMs == null)
+        every { cursor.getLong(COL_LAST_ENGAGEMENT) } returns (lastEngagementMs ?: 0L)
+        return cursor
+    }
+
+    /**
+     * Builds a mock Cursor for the package-count query (single COLUMN_PACKAGE_NAME column).
+     */
+    private fun buildPackageCursor(vararg packageNames: String): Cursor {
+        val cursor = mockk<Cursor>(relaxed = true)
+        val callCount = intArrayOf(0)
+        every { cursor.moveToNext() } answers { callCount[0]++ < packageNames.size }
+        if (packageNames.isNotEmpty()) {
+            every { cursor.getString(0) } answers { packageNames[callCount[0] - 1] }
         }
+        return cursor
+    }
 
-    private fun givenQuery(cursor: MatrixCursor) {
+    private fun givenEpisodeQuery(cursor: Cursor) {
         every {
             contentResolver.query(
                 TvContractCompat.WatchNextPrograms.CONTENT_URI,
-                any(),
-                any(),
-                any(),
-                any(),
+                any(), any(), any(), any(),
+            )
+        } returns cursor
+    }
+
+    private fun givenCountQuery(cursor: Cursor) {
+        every {
+            contentResolver.query(
+                TvContractCompat.WatchNextPrograms.CONTENT_URI,
+                any(), any(), any(), null,
             )
         } returns cursor
     }
@@ -107,18 +154,17 @@ class WatchNextMetadataSourceTest {
 
         @Test
         fun `adds watchNext lines for a fresh episode row`() = runTest {
-            val cursor = buildCursor(
-                arrayOf(
-                    "Stranger Things",       // COLUMN_TITLE
-                    "4",                     // COLUMN_SEASON_DISPLAY_NUMBER
-                    "1",                     // COLUMN_EPISODE_DISPLAY_NUMBER
-                    "Chapter One",           // COLUMN_EPISODE_TITLE
-                    "A short description",   // COLUMN_SHORT_DESCRIPTION
-                    "tmdb:66732",            // COLUMN_CONTENT_ID
-                    freshMs,                 // COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS
+            givenEpisodeQuery(
+                buildEpisodeCursor(
+                    title = "Stranger Things",
+                    season = "4",
+                    episode = "1",
+                    episodeTitle = "Chapter One",
+                    shortDesc = "A short description",
+                    contentId = "tmdb:66732",
+                    lastEngagementMs = freshMs,
                 ),
             )
-            givenQuery(cursor)
             val tick = PlaybackTick(
                 state = PlaybackTick.STATE_PLAYING,
                 positionMs = 60_000L,
@@ -140,18 +186,17 @@ class WatchNextMetadataSourceTest {
 
         @Test
         fun `synthesises S##E## marker only when both numbers are integer-parseable`() = runTest {
-            val cursor = buildCursor(
-                arrayOf(
-                    "Some Show",
-                    "Season 4",              // not a bare integer — marker should be omitted
-                    "E1",                    // not a bare integer — marker should be omitted
-                    null,
-                    null,
-                    null,
-                    freshMs,
+            givenEpisodeQuery(
+                buildEpisodeCursor(
+                    title = "Some Show",
+                    season = "Season 4",  // not a bare integer — marker should be omitted
+                    episode = "E1",       // not a bare integer — marker should be omitted
+                    episodeTitle = null,
+                    shortDesc = null,
+                    contentId = null,
+                    lastEngagementMs = freshMs,
                 ),
             )
-            givenQuery(cursor)
             val tick = PlaybackTick(
                 state = PlaybackTick.STATE_PLAYING,
                 positionMs = 0L,
@@ -162,16 +207,26 @@ class WatchNextMetadataSourceTest {
             source.enrich("com.example.streaming", tick, builder)
 
             val snapshot = builder.build()
-            assertFalse(snapshot.text.contains("watchNext.marker:"), "marker should not be synthesised for non-integer season/episode")
+            assertFalse(
+                snapshot.text.contains("watchNext.marker:"),
+                "marker should not be synthesised for non-integer season/episode",
+            )
         }
 
         @Test
         fun `ignores stale row older than ROW_FRESHNESS_MS`() = runTest {
             val staleMs = System.currentTimeMillis() - WatchNextMetadataSource.ROW_FRESHNESS_MS - 1_000L
-            val cursor = buildCursor(
-                arrayOf("Old Show", "3", "5", null, null, null, staleMs),
+            givenEpisodeQuery(
+                buildEpisodeCursor(
+                    title = "Old Show",
+                    season = "3",
+                    episode = "5",
+                    episodeTitle = null,
+                    shortDesc = null,
+                    contentId = null,
+                    lastEngagementMs = staleMs,
+                ),
             )
-            givenQuery(cursor)
             val tick = PlaybackTick(
                 state = PlaybackTick.STATE_PLAYING,
                 positionMs = 0L,
@@ -187,7 +242,12 @@ class WatchNextMetadataSourceTest {
 
         @Test
         fun `produces no watchNext lines when no rows exist for package`() = runTest {
-            givenQuery(buildCursor())   // empty cursor
+            givenEpisodeQuery(
+                buildEpisodeCursor(
+                    title = null, season = null, episode = null, episodeTitle = null,
+                    shortDesc = null, contentId = null, lastEngagementMs = null, empty = true,
+                ),
+            )
             val tick = PlaybackTick(
                 state = PlaybackTick.STATE_PLAYING,
                 positionMs = 0L,
@@ -202,18 +262,17 @@ class WatchNextMetadataSourceTest {
 
         @Test
         fun `handles missing season column gracefully — no marker emitted`() = runTest {
-            val cursor = buildCursor(
-                arrayOf(
-                    "My Show",
-                    null,     // no season
-                    "3",
-                    "Episode Title",
-                    null,
-                    null,
-                    freshMs,
+            givenEpisodeQuery(
+                buildEpisodeCursor(
+                    title = "My Show",
+                    season = null,
+                    episode = "3",
+                    episodeTitle = "Episode Title",
+                    shortDesc = null,
+                    contentId = null,
+                    lastEngagementMs = freshMs,
                 ),
             )
-            givenQuery(cursor)
             val tick = PlaybackTick(
                 state = PlaybackTick.STATE_PLAYING,
                 positionMs = 0L,
@@ -252,25 +311,6 @@ class WatchNextMetadataSourceTest {
     @Nested
     @DisplayName("countPublishingApps()")
     inner class CountPublishingAppsTest {
-
-        private val PKG_COLUMN = arrayOf(TvContractCompat.WatchNextPrograms.COLUMN_PACKAGE_NAME)
-
-        private fun buildPackageCursor(vararg packageNames: String): MatrixCursor =
-            MatrixCursor(PKG_COLUMN).apply {
-                packageNames.forEach { addRow(arrayOf(it)) }
-            }
-
-        private fun givenCountQuery(cursor: MatrixCursor) {
-            every {
-                contentResolver.query(
-                    TvContractCompat.WatchNextPrograms.CONTENT_URI,
-                    PKG_COLUMN,
-                    any(),
-                    any(),
-                    null,
-                )
-            } returns cursor
-        }
 
         @Test
         fun `returns Success with count of distinct publishing packages`() {

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSourceTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/WatchNextMetadataSourceTest.kt
@@ -33,16 +33,16 @@ class WatchNextMetadataSourceTest {
     }
     private val source = WatchNextMetadataSource(context)
 
-    private val freshMs = System.currentTimeMillis() - 30_000L  // 30 s ago — well within 5 min
+    private val freshMs = System.currentTimeMillis() - 30_000L // 30 s ago — well within 5 min
 
     // Column indices matching the PROJECTION in WatchNextMetadataSource
-    private val COL_TITLE = 0
-    private val COL_SEASON = 1
-    private val COL_EPISODE = 2
-    private val COL_EPISODE_TITLE = 3
-    private val COL_SHORT_DESC = 4
-    private val COL_CONTENT_ID = 5
-    private val COL_LAST_ENGAGEMENT = 6
+    private val colTitle = 0
+    private val colSeason = 1
+    private val colEpisode = 2
+    private val colEpisodeTitle = 3
+    private val colShortDesc = 4
+    private val colContentId = 5
+    private val colLastEngagement = 6
 
     /**
      * Builds a mock Cursor for the episode-lookup query (PROJECTION with 7 columns).
@@ -60,21 +60,35 @@ class WatchNextMetadataSourceTest {
     ): Cursor {
         val cursor = mockk<Cursor>(relaxed = true)
         every { cursor.moveToFirst() } returns !empty
-        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_TITLE) } returns COL_TITLE
-        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_SEASON_DISPLAY_NUMBER) } returns COL_SEASON
-        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_DISPLAY_NUMBER) } returns COL_EPISODE
-        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_TITLE) } returns COL_EPISODE_TITLE
-        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_SHORT_DESCRIPTION) } returns COL_SHORT_DESC
-        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_CONTENT_ID) } returns COL_CONTENT_ID
-        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS) } returns COL_LAST_ENGAGEMENT
-        every { cursor.getString(COL_TITLE) } returns title
-        every { cursor.getString(COL_SEASON) } returns season
-        every { cursor.getString(COL_EPISODE) } returns episode
-        every { cursor.getString(COL_EPISODE_TITLE) } returns episodeTitle
-        every { cursor.getString(COL_SHORT_DESC) } returns shortDesc
-        every { cursor.getString(COL_CONTENT_ID) } returns contentId
-        every { cursor.isNull(COL_LAST_ENGAGEMENT) } returns (lastEngagementMs == null)
-        every { cursor.getLong(COL_LAST_ENGAGEMENT) } returns (lastEngagementMs ?: 0L)
+        every { cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_TITLE) } returns colTitle
+        every {
+            cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_SEASON_DISPLAY_NUMBER)
+        } returns colSeason
+        every {
+            cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_DISPLAY_NUMBER)
+        } returns colEpisode
+        every {
+            cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_EPISODE_TITLE)
+        } returns colEpisodeTitle
+        every {
+            cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_SHORT_DESCRIPTION)
+        } returns colShortDesc
+        every {
+            cursor.getColumnIndex(TvContractCompat.WatchNextPrograms.COLUMN_CONTENT_ID)
+        } returns colContentId
+        every {
+            cursor.getColumnIndex(
+                TvContractCompat.WatchNextPrograms.COLUMN_LAST_ENGAGEMENT_TIME_UTC_MILLIS,
+            )
+        } returns colLastEngagement
+        every { cursor.getString(colTitle) } returns title
+        every { cursor.getString(colSeason) } returns season
+        every { cursor.getString(colEpisode) } returns episode
+        every { cursor.getString(colEpisodeTitle) } returns episodeTitle
+        every { cursor.getString(colShortDesc) } returns shortDesc
+        every { cursor.getString(colContentId) } returns contentId
+        every { cursor.isNull(colLastEngagement) } returns (lastEngagementMs == null)
+        every { cursor.getLong(colLastEngagement) } returns (lastEngagementMs ?: 0L)
         return cursor
     }
 
@@ -189,8 +203,8 @@ class WatchNextMetadataSourceTest {
             givenEpisodeQuery(
                 buildEpisodeCursor(
                     title = "Some Show",
-                    season = "Season 4",  // not a bare integer — marker should be omitted
-                    episode = "E1",       // not a bare integer — marker should be omitted
+                    season = "Season 4", // not a bare integer — marker should be omitted
+                    episode = "E1", // not a bare integer — marker should be omitted
                     episodeTitle = null,
                     shortDesc = null,
                     contentId = null,
@@ -318,7 +332,7 @@ class WatchNextMetadataSourceTest {
                 buildPackageCursor(
                     "com.netflix.ninja",
                     "com.disney.disneyplus",
-                    "com.netflix.ninja",   // duplicate — should be deduplicated
+                    "com.netflix.ninja", // duplicate — should be deduplicated
                 ),
             )
 

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModelTest.kt
@@ -6,6 +6,7 @@ import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.tv.MainDispatcherRule
 import com.justb81.watchbuddy.tv.data.JustWatchDeepLinkRepository
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import com.justb81.watchbuddy.tv.scrobbler.WatchNextMetadataSource
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -36,6 +37,7 @@ class TvDiagnosticsViewModelTest {
     private val phoneDiscovery: PhoneDiscoveryManager = mockk(relaxed = true)
     private val scrobbler: MediaSessionScrobbler = mockk(relaxed = true)
     private val justWatchRepo: JustWatchDeepLinkRepository = mockk(relaxed = true)
+    private val watchNextSource: WatchNextMetadataSource = mockk(relaxed = true)
 
     @BeforeEach
     fun setUp() {
@@ -52,6 +54,7 @@ class TvDiagnosticsViewModelTest {
         coEvery { justWatchRepo.count() } returns 0
         coEvery { justWatchRepo.negativeCount() } returns 0
         coEvery { justWatchRepo.lastFetchedAt() } returns null
+        every { watchNextSource.countPublishingApps() } returns WatchNextMetadataSource.CountResult.Success(0)
     }
 
     @AfterEach
@@ -61,7 +64,7 @@ class TvDiagnosticsViewModelTest {
 
     @Test
     fun `recentEvents is empty on fresh VM`() = runTest {
-        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo)
+        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo, watchNextSource)
         advanceUntilIdle()
 
         assertTrue(vm.uiState.value.recentEvents.isEmpty())
@@ -69,7 +72,7 @@ class TvDiagnosticsViewModelTest {
 
     @Test
     fun `single event is projected with correct level and newest-first order`() = runTest {
-        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo)
+        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo, watchNextSource)
         advanceUntilIdle()
 
         DiagnosticLog.event("TAG", "hello")
@@ -84,7 +87,7 @@ class TvDiagnosticsViewModelTest {
 
     @Test
     fun `recentEvents is truncated to 100 entries newest first`() = runTest {
-        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo)
+        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo, watchNextSource)
         advanceUntilIdle()
 
         repeat(150) { i -> DiagnosticLog.event("TAG", "msg $i") }
@@ -100,7 +103,7 @@ class TvDiagnosticsViewModelTest {
     fun `scrobblerListening reflects true when scrobbler isListening emits true`() = runTest {
         val isListeningFlow = MutableStateFlow(false)
         every { scrobbler.isListening } returns isListeningFlow
-        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo)
+        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo, watchNextSource)
         advanceUntilIdle()
 
         isListeningFlow.value = true
@@ -113,7 +116,7 @@ class TvDiagnosticsViewModelTest {
     fun `scrobblerListening reflects false when scrobbler isListening emits false`() = runTest {
         val isListeningFlow = MutableStateFlow(true)
         every { scrobbler.isListening } returns isListeningFlow
-        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo)
+        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo, watchNextSource)
         advanceUntilIdle()
 
         isListeningFlow.value = false
@@ -125,7 +128,7 @@ class TvDiagnosticsViewModelTest {
     @Test
     fun `scrobblerListening starts as false when scrobbler is not listening`() = runTest {
         every { scrobbler.isListening } returns MutableStateFlow(false)
-        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo)
+        val vm = TvDiagnosticsViewModel(application, phoneDiscovery, scrobbler, justWatchRepo, watchNextSource)
         advanceUntilIdle()
 
         assertFalse(vm.uiState.value.scrobblerListening)

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -496,12 +496,14 @@ class MediaSessionScrobbler @Inject constructor(
         if (candidates.isEmpty()) return null
         val mediaTitle = candidates.first()
 
+        // Fetch once — shared by Phase 0.5 and Phase 1 to avoid a double round-trip.
+        val cachedShows = watchedShowSource.getCachedShows()
+
         // Phase 0.5: content-ID short-circuit for trusted prefixes (only `tmdb:` on day one)
-        val contentIdHit = resolveByContentId(snapshot, mediaTitle)
+        val contentIdHit = resolveByContentId(snapshot, mediaTitle, cachedShows)
         if (contentIdHit != null) return contentIdHit
 
         val (globalSeason, globalEpisode) = findGlobalEpisodeMarker(candidates)
-        val cachedShows = watchedShowSource.getCachedShows()
         val bestCheap = candidates
             .map { field -> scoreCandidate(field, cachedShows) }
             .maxByOrNull { it.score }
@@ -526,14 +528,14 @@ class MediaSessionScrobbler @Inject constructor(
      * the user's library. Other prefixes (opaque Netflix/YouTube IDs) fall through to
      * Phase 1 so the snapshot's `watchNext.title` line can still contribute evidence.
      */
-    private suspend fun resolveByContentId(
+    private fun resolveByContentId(
         snapshot: MediaMetadataSnapshot,
         mediaTitle: String,
+        cachedShows: List<TraktWatchedEntry>,
     ): ScrobbleCandidate? {
         val contentId = findSnapshotTag(snapshot, "watchNext.contentId")
             ?.takeIf { it.startsWith("tmdb:") } ?: return null
         val tmdbId = contentId.removePrefix("tmdb:").toIntOrNull() ?: return null
-        val cachedShows = watchedShowSource.getCachedShows()
         val entry = cachedShows.firstOrNull { it.show.ids.tmdb == tmdbId } ?: return null
         val season = findSnapshotTag(snapshot, "watchNext.season")?.toIntOrNull()
         val episode = findSnapshotTag(snapshot, "watchNext.episode")?.toIntOrNull()

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -468,6 +468,10 @@ class MediaSessionScrobbler @Inject constructor(
 
     /**
      * Full match cascade:
+     *   0.5 **Content-ID short-circuit** — if a `watchNext.contentId: tmdb:XXXX` line is
+     *      present, look up the show in the cached library by TMDB ID. When found and
+     *      season/episode numbers are available, returns a confidence-1.0 candidate
+     *      immediately — no LLM, no TMDB search.
      *   1. **Phase 1 (cheap)** — try every MediaMetadata field from [snapshot] as
      *      a candidate show title, parse any `S##E##` marker, score against the
      *      cached library with [fuzzyScore], keep the highest-scoring cache hit.
@@ -492,6 +496,10 @@ class MediaSessionScrobbler @Inject constructor(
         if (candidates.isEmpty()) return null
         val mediaTitle = candidates.first()
 
+        // Phase 0.5: content-ID short-circuit for trusted prefixes (only `tmdb:` on day one)
+        val contentIdHit = resolveByContentId(snapshot, mediaTitle)
+        if (contentIdHit != null) return contentIdHit
+
         val (globalSeason, globalEpisode) = findGlobalEpisodeMarker(candidates)
         val cachedShows = watchedShowSource.getCachedShows()
         val bestCheap = candidates
@@ -509,6 +517,52 @@ class MediaSessionScrobbler @Inject constructor(
 
         return tmdbFallback(snapshot, extraction, bestCheap, mediaTitle)
     }
+
+    /**
+     * Phase 0.5: if the snapshot contains a `watchNext.contentId` line with a trusted
+     * prefix, resolve the show by content ID without running Levenshtein or LLM.
+     *
+     * Only `tmdb:` is trusted on day one — confidence 1.0 when the TMDB ID is found in
+     * the user's library. Other prefixes (opaque Netflix/YouTube IDs) fall through to
+     * Phase 1 so the snapshot's `watchNext.title` line can still contribute evidence.
+     */
+    private suspend fun resolveByContentId(
+        snapshot: MediaMetadataSnapshot,
+        mediaTitle: String,
+    ): ScrobbleCandidate? {
+        val contentId = findSnapshotTag(snapshot, "watchNext.contentId")
+            ?.takeIf { it.startsWith("tmdb:") } ?: return null
+        val tmdbId = contentId.removePrefix("tmdb:").toIntOrNull() ?: return null
+        val cachedShows = watchedShowSource.getCachedShows()
+        val entry = cachedShows.firstOrNull { it.show.ids.tmdb == tmdbId } ?: return null
+        val season = findSnapshotTag(snapshot, "watchNext.season")?.toIntOrNull()
+        val episode = findSnapshotTag(snapshot, "watchNext.episode")?.toIntOrNull()
+        val matchedEpisode = if (season != null && episode != null) {
+            TraktEpisode(season = season, number = episode)
+        } else {
+            null
+        }
+        DiagnosticLog.event(
+            TAG,
+            "WatchNext: content-ID short-circuit tmdbId=$tmdbId " +
+                "show=${entry.show.title} S${season}E${episode} confidence=1.0",
+        )
+        return ScrobbleCandidate(
+            packageName = snapshot.packageName,
+            mediaTitle = mediaTitle,
+            confidence = 1.0f,
+            matchedShow = entry.show,
+            matchedEpisode = matchedEpisode,
+        )
+    }
+
+    /** Extracts the value portion of the first `"<tag>: <value>"` line matching [tag]. */
+    private fun findSnapshotTag(snapshot: MediaMetadataSnapshot, tag: String): String? =
+        snapshot.text.lines()
+            .firstOrNull { it.startsWith("$tag: ") }
+            ?.substringAfter("$tag: ")
+            ?.trim()
+            ?.takeIf { it.isNotBlank() }
 
     private fun findGlobalEpisodeMarker(candidates: List<String>): Pair<Int?, Int?> {
         val episodePattern = Regex("""(?i)S(\d{1,2})E(\d{1,2})""")

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -515,9 +515,7 @@ class MediaSessionScrobbler @Inject constructor(
             .onFailure { DiagnosticLog.warn(TAG, "Title extractor threw", it) }
             .getOrNull()
         val llmHit = extraction?.let { resolveExtraction(snapshot, it, cachedShows, mediaTitle) }
-        if (llmHit != null) return llmHit
-
-        return tmdbFallback(snapshot, extraction, bestCheap, mediaTitle)
+        return llmHit ?: tmdbFallback(snapshot, extraction, bestCheap, mediaTitle)
     }
 
     /**

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -547,7 +547,7 @@ class MediaSessionScrobbler @Inject constructor(
         DiagnosticLog.event(
             TAG,
             "WatchNext: content-ID short-circuit tmdbId=$tmdbId " +
-                "show=${entry.show.title} S${season}E${episode} confidence=1.0",
+                "show=${entry.show.title} S${season}E$episode confidence=1.0",
         )
         return ScrobbleCandidate(
             packageName = snapshot.packageName,

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerPhase05Test.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerPhase05Test.kt
@@ -121,7 +121,7 @@ class MediaSessionScrobblerPhase05Test {
                 title = "The Bear",
                 season = "1",
                 episode = "1",
-                contentId = "tmdb:99999",  // unknown ID
+                contentId = "tmdb:99999", // unknown ID
             )
 
             // Phase 1 won't match either (no "The Bear" in cache) — result is null
@@ -182,7 +182,7 @@ class MediaSessionScrobblerPhase05Test {
                 title = "Stranger Things",
                 season = "4",
                 episode = "2",
-                contentId = "netflix:81231234",  // opaque Netflix ID — not trusted
+                contentId = "netflix:81231234", // opaque Netflix ID — not trusted
             )
 
             val result = scrobbler.matchSnapshot(snapshot)

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerPhase05Test.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerPhase05Test.kt
@@ -1,0 +1,242 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import android.content.Context
+import com.justb81.watchbuddy.core.model.TraktIds
+import com.justb81.watchbuddy.core.model.TraktShow
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.tmdb.TmdbApiService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for the Phase 0.5 content-ID short-circuit in [MediaSessionScrobbler.matchSnapshot].
+ *
+ * Phase 0.5 fires before Phase 1 (Levenshtein) and returns a confidence-1.0 candidate
+ * immediately when the snapshot contains a `watchNext.contentId: tmdb:XXXX` line whose
+ * TMDB ID is found in the user's cached library — no LLM, no TMDB search.
+ */
+@DisplayName("MediaSessionScrobbler — Phase 0.5 content-ID short-circuit")
+class MediaSessionScrobblerPhase05Test {
+
+    private val context: Context = mockk(relaxed = true)
+    private val tmdbApiService: TmdbApiService = mockk()
+    private val watchedShowSource: WatchedShowSource = mockk()
+    private val scrobbleDispatcher: ScrobbleDispatcher = mockk()
+    private val titleExtractor: TitleExtractor = mockk()
+    private lateinit var scrobbler: MediaSessionScrobbler
+
+    private val strangersShow = TraktShow(
+        title = "Stranger Things",
+        year = 2016,
+        ids = TraktIds(trakt = 104439, tmdb = 66732),
+    )
+    private val strangersEntry = TraktWatchedEntry(show = strangersShow)
+
+    @BeforeEach
+    fun setUp() {
+        scrobbler = MediaSessionScrobbler(
+            context, tmdbApiService, watchedShowSource, scrobbleDispatcher, titleExtractor,
+        )
+        coEvery { watchedShowSource.getTmdbApiKey() } returns null
+        coEvery { watchedShowSource.getShowHint(any()) } returns null
+        coEvery { titleExtractor.extract(any()) } returns null
+    }
+
+    // ── tmdb: prefix ──────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("tmdb: content ID")
+    inner class TmdbContentId {
+
+        @Test
+        fun `returns confidence-1_0 candidate when tmdb-id matches cached show`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns listOf(strangersEntry)
+            val snapshot = buildWatchNextSnapshot(
+                packageName = "com.disney.disneyplus",
+                title = "Stranger Things",
+                season = "4",
+                episode = "1",
+                contentId = "tmdb:66732",
+            )
+
+            val result = scrobbler.matchSnapshot(snapshot)
+
+            assertNotNull(result)
+            assertEquals(strangersShow, result!!.matchedShow)
+            assertEquals(1.0f, result.confidence)
+            assertEquals(4, result.matchedEpisode?.season)
+            assertEquals(1, result.matchedEpisode?.number)
+        }
+
+        @Test
+        fun `skips LLM and TMDB search on tmdb-id hit`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns listOf(strangersEntry)
+            val snapshot = buildWatchNextSnapshot(
+                packageName = "com.disney.disneyplus",
+                title = "Stranger Things",
+                season = "4",
+                episode = "1",
+                contentId = "tmdb:66732",
+            )
+
+            scrobbler.matchSnapshot(snapshot)
+
+            coVerify(exactly = 0) { titleExtractor.extract(any()) }
+            coVerify(exactly = 0) { tmdbApiService.searchTv(any(), any()) }
+        }
+
+        @Test
+        fun `returns candidate with null episode when season or episode is missing`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns listOf(strangersEntry)
+            val snapshot = buildWatchNextSnapshot(
+                packageName = "com.disney.disneyplus",
+                title = "Stranger Things",
+                season = null,
+                episode = null,
+                contentId = "tmdb:66732",
+            )
+
+            val result = scrobbler.matchSnapshot(snapshot)
+
+            assertNotNull(result)
+            assertEquals(strangersShow, result!!.matchedShow)
+            assertEquals(1.0f, result.confidence)
+            assertNull(result.matchedEpisode)
+        }
+
+        @Test
+        fun `falls through to Phase 1 when tmdb-id is not in the cached library`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns listOf(strangersEntry)
+            val snapshot = buildWatchNextSnapshot(
+                packageName = "com.disney.disneyplus",
+                title = "The Bear",
+                season = "1",
+                episode = "1",
+                contentId = "tmdb:99999",  // unknown ID
+            )
+
+            // Phase 1 won't match either (no "The Bear" in cache) — result is null
+            val result = scrobbler.matchSnapshot(snapshot)
+
+            // Phase 0.5 returned null; Phase 1 should have run but produced no match
+            coVerify(exactly = 1) { watchedShowSource.getCachedShows() }
+            assertNull(result)
+        }
+
+        @Test
+        fun `falls through to Phase 1 when cache is empty`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns emptyList()
+            val snapshot = buildWatchNextSnapshot(
+                packageName = "com.disney.disneyplus",
+                title = "Stranger Things",
+                season = "4",
+                episode = "1",
+                contentId = "tmdb:66732",
+            )
+
+            val result = scrobbler.matchSnapshot(snapshot)
+
+            assertNull(result)
+        }
+    }
+
+    // ── other / no content ID ─────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("no or non-tmdb content ID")
+    inner class NoContentId {
+
+        @Test
+        fun `falls through to Phase 1 when contentId is absent`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns listOf(strangersEntry)
+            val snapshot = buildWatchNextSnapshot(
+                packageName = "com.netflix.ninja",
+                title = "Stranger Things",
+                season = "4",
+                episode = "2",
+                contentId = null,
+            )
+
+            val result = scrobbler.matchSnapshot(snapshot)
+
+            // Phase 1 resolves via watchNext.title matching the cached show
+            assertNotNull(result)
+            assertEquals(strangersShow, result!!.matchedShow)
+            // Phase 0.5 did not fire (no contentId), but Phase 1 succeeds via title
+        }
+
+        @Test
+        fun `falls through to Phase 1 when contentId has an opaque prefix`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns listOf(strangersEntry)
+            val snapshot = buildWatchNextSnapshot(
+                packageName = "com.netflix.ninja",
+                title = "Stranger Things",
+                season = "4",
+                episode = "2",
+                contentId = "netflix:81231234",  // opaque Netflix ID — not trusted
+            )
+
+            val result = scrobbler.matchSnapshot(snapshot)
+
+            assertNotNull(result)
+            assertEquals(strangersShow, result!!.matchedShow)
+        }
+    }
+
+    // ── enricher integration ──────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("enricher integration — watchNext lines in snapshot")
+    inner class EnricherIntegration {
+
+        @Test
+        fun `snapshot built by WatchNextMetadataSource enricher triggers Phase 0_5`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns listOf(strangersEntry)
+            // Simulate what WatchNextMetadataSource would add to the builder
+            val builder = MediaSnapshotBuilder("com.disney.disneyplus")
+            builder.add("watchNext.title", "Stranger Things")
+            builder.add("watchNext.season", "4")
+            builder.add("watchNext.episode", "1")
+            builder.add("watchNext.episodeTitle", "Chapter One: The Hellfire Club")
+            builder.add("watchNext.contentId", "tmdb:66732")
+            builder.add("watchNext.marker", "S04E01")
+            builder.addSource("watchNext")
+            val snapshot = builder.build()
+
+            val result = scrobbler.matchSnapshot(snapshot)
+
+            assertNotNull(result)
+            assertEquals(strangersShow, result!!.matchedShow)
+            assertEquals(1.0f, result.confidence)
+            assertEquals(4, result.matchedEpisode?.season)
+            assertEquals(1, result.matchedEpisode?.number)
+            coVerify(exactly = 0) { titleExtractor.extract(any()) }
+        }
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    private fun buildWatchNextSnapshot(
+        packageName: String,
+        title: String?,
+        season: String?,
+        episode: String?,
+        contentId: String?,
+    ): com.justb81.watchbuddy.core.model.MediaMetadataSnapshot {
+        val builder = MediaSnapshotBuilder(packageName)
+        title?.let { builder.add("watchNext.title", it) }
+        season?.let { builder.add("watchNext.season", it) }
+        episode?.let { builder.add("watchNext.episode", it) }
+        contentId?.let { builder.add("watchNext.contentId", it) }
+        return builder.build()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ errorprone-annotations = "2.49.0"
 gradlePlayPublisher = "4.0.0"
 detekt = "1.23.8"
 room = "2.8.4"
-androidx-tvprovider = "1.0.0"
+androidx-tvprovider = "1.1.0"
 
 [libraries]
 # AndroidX Core

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ errorprone-annotations = "2.49.0"
 gradlePlayPublisher = "4.0.0"
 detekt = "1.23.8"
 room = "2.8.4"
+androidx-tvprovider = "1.0.0"
 
 [libraries]
 # AndroidX Core
@@ -109,6 +110,9 @@ robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "
 androidx-test-core = { group = "androidx.test", name = "core-ktx", version.ref = "androidx-test-core" }
 androidx-arch-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "androidx-arch-core" }
 errorprone-annotations = { group = "com.google.errorprone", name = "error_prone_annotations", version.ref = "errorprone-annotations" }
+
+# TV Provider (WatchNext programs content provider — TV-side only)
+androidx-tvprovider = { group = "androidx.tvprovider", name = "tvprovider", version.ref = "androidx-tvprovider" }
 
 # Room (TV-side persistent cache for JustWatch deep links)
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }


### PR DESCRIPTION
## Summary

Implements issue #471 — harvests currently-playing program metadata from the Android TV system WatchNext content provider (`TvContractCompat.WatchNextPrograms`) and plugs it into the scrobble cascade as a first-class evidence source.

- **`WatchNextMetadataSource`** — new `MetadataEnricher` that queries `TvContractCompat.WatchNextPrograms.CONTENT_URI` filtered by package name and a 5-min freshness gate, emitting `watchNext.title`, `watchNext.season`, `watchNext.episode`, `watchNext.episodeTitle`, `watchNext.contentId`, and a synthesised `watchNext.marker` (e.g. `S04E01`) when both numbers parse as integers
- **Phase 0.5** — added to `MediaSessionScrobbler.matchSnapshot()`: if the snapshot contains `watchNext.contentId: tmdb:XXXX` and the TMDB ID is in the user's library, returns a confidence-1.0 candidate immediately — no LLM, no TMDB search required
- **TV Hilt module** — wires `WatchNextMetadataSource` as the first `MetadataEnricher`; phone remains `emptyList()`
- **TV Diagnostics** — new "Watch Next provider" section shows count of publishing apps (green ≥1, yellow = 0, red = permission denied); refreshed on `ON_RESUME`
- **`READ_TV_LISTINGS`** permission added to `app-tv/AndroidManifest.xml` (auto-granted on Android TV form-factor)
- **`androidx.tvprovider:tvprovider:1.0.0`** added to `gradle/libs.versions.toml` and `app-tv/build.gradle.kts`
- **String resources** updated for en / de / fr / es

## Test plan

- [ ] `WatchNextMetadataSourceTest` — fresh row, stale row, paused tick (skips query), missing season column, no rows for package, `SecurityException`; `countPublishingApps()` dedup, empty cursor, null cursor, `SecurityException`
- [ ] `MediaSessionScrobblerPhase05Test` — `tmdb:` hit with season/episode → confidence 1.0, no LLM/TMDB; `tmdb:` ID not in cache falls through to Phase 1; no contentId falls through; opaque prefix falls through; no episode when season/episode absent
- [ ] `MediaSessionScrobblerTest` (TV integration) — enricher appends watchNext lines; Phase 0.5 fires on tmdb: hit
- [ ] CI `Test & Build` must be green before merge

> **Note:** Gradle checks skipped locally — no Android SDK in this sandbox. CI (`build-android.yml`) is the real gate per CLAUDE.md.

Closes #471

https://claude.ai/code/session_01TavcyTtPYPqnpNY1VEo2ZE

---
_Generated by [Claude Code](https://claude.ai/code/session_01TavcyTtPYPqnpNY1VEo2ZE)_