### PR TITLE
fix(tv): surface JustWatch errors, stop caching negatives on hard failures

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
@@ -5,16 +5,20 @@ import com.justb81.watchbuddy.core.justwatch.JustWatchGraphQlRequest
 import com.justb81.watchbuddy.core.justwatch.JustWatchOffer
 import com.justb81.watchbuddy.core.justwatch.JustWatchPackageMap
 import com.justb81.watchbuddy.core.justwatch.JustWatchTitle
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import java.util.ArrayDeque
 import javax.inject.Inject
 import javax.inject.Singleton
 
 private val ALLOWED_MONETIZATION = setOf("FLATRATE", "ADS", "FREE")
 private const val SEARCH_RESULT_LIMIT = 5
+private const val TAG = "JustWatchRepo"
+private val COUNTRY_CODE_REGEX = Regex("[A-Z]{2}")
 
 /**
  * Resolves JustWatch per-episode deep links with a persistent Room cache.
@@ -26,7 +30,10 @@ private const val SEARCH_RESULT_LIMIT = 5
  *   4. Show-level live JustWatch call on miss → caches all providers found
  *   5. Returns null → caller treats as Unavailable
  *
- * Positive hits are cached permanently; negative entries expire after 30 days.
+ * Negatives are only cached when JustWatch confirmed no offer (i.e. the full
+ * seasons/episodes graph was fetched but the provider had no match). Hard errors
+ * (network exception, GraphQL errors, search miss) do NOT write negatives so the
+ * next call can retry.
  *
  * Batch dedup: a Mutex-protected map prevents duplicate in-flight JustWatch API calls
  * for the same (showId, season, episode, countryCode) key.
@@ -36,6 +43,14 @@ class JustWatchDeepLinkRepository @Inject constructor(
     private val dao: JustWatchDeepLinkDao,
     private val api: JustWatchApiService,
 ) {
+
+    private sealed class SearchResult {
+        data class Found(val title: JustWatchTitle) : SearchResult()
+        /** The API returned a valid response but no node matched the TMDB ID. */
+        data object SearchMiss : SearchResult()
+        /** The API returned a top-level GraphQL errors array. */
+        data class GraphQlError(val summary: String) : SearchResult()
+    }
 
     private data class FetchKey(
         val tmdbShowId: Int,
@@ -47,6 +62,36 @@ class JustWatchDeepLinkRepository @Inject constructor(
     private val fetchMutexMap = mutableMapOf<FetchKey, Mutex>()
     private val mapLock = Mutex()
 
+    // ── In-memory diagnostics ─────────────────────────────────────────────────
+
+    @Volatile private var _lastError: String? = null
+    private val missTimestamps = ArrayDeque<Long>()
+    private val missLock = Any()
+
+    private fun recordMiss() = synchronized(missLock) {
+        missTimestamps.addLast(System.currentTimeMillis())
+    }
+
+    private fun recordError(message: String) {
+        _lastError = message
+    }
+
+    /** Returns the last error message produced by a fetch, or null if no error has occurred. */
+    fun lastFetchError(): String? = _lastError
+
+    /**
+     * Returns the number of JustWatch search misses in the given time window.
+     * A miss is counted when the API returned successfully but no JustWatch node
+     * matched the requested TMDB show ID.
+     */
+    fun searchMissCount(windowMs: Long = 24 * 60 * 60 * 1000L): Int = synchronized(missLock) {
+        val cutoff = System.currentTimeMillis() - windowMs
+        while (missTimestamps.isNotEmpty() && missTimestamps.peekFirst() < cutoff) {
+            missTimestamps.pollFirst()
+        }
+        missTimestamps.size
+    }
+
     // ── Public API ────────────────────────────────────────────────────────────
 
     suspend fun resolveDeepLink(
@@ -57,24 +102,26 @@ class JustWatchDeepLinkRepository @Inject constructor(
         countryCode: String,
         showTitle: String,
     ): String? {
+        val country = sanitizeCountryCode(countryCode)
+
         // 1. Episode-level cache
-        val epCached = dao.get(tmdbShowId, season, episode, providerId, countryCode)
+        val epCached = dao.get(tmdbShowId, season, episode, providerId, country)
         if (epCached != null && epCached.isValidCache()) return epCached.standardWebUrl
 
         // 2. Episode-level live fetch (deduped per episode)
-        val episodeKey = FetchKey(tmdbShowId, season, episode, countryCode)
+        val episodeKey = FetchKey(tmdbShowId, season, episode, country)
         getMutex(episodeKey).withLock {
             // Re-check cache after acquiring lock — another coroutine may have populated it
-            val refreshed = dao.get(tmdbShowId, season, episode, providerId, countryCode)
+            val refreshed = dao.get(tmdbShowId, season, episode, providerId, country)
             if (refreshed != null && refreshed.isValidCache()) return refreshed.standardWebUrl
-            fetchAndCacheEpisodeOffers(tmdbShowId, season, episode, countryCode, showTitle)
+            fetchAndCacheEpisodeOffers(tmdbShowId, season, episode, country, showTitle)
         }
 
         // Re-read after episode fetch
-        val epResult = dao.get(tmdbShowId, season, episode, providerId, countryCode)
+        val epResult = dao.get(tmdbShowId, season, episode, providerId, country)
         if (epResult != null && epResult.isValidCache()) return epResult.standardWebUrl
 
-        return resolveShowLevel(tmdbShowId, providerId, countryCode, showTitle)
+        return resolveShowLevel(tmdbShowId, providerId, country, showTitle)
     }
 
     suspend fun count(): Int = dao.countPositive()
@@ -119,6 +166,18 @@ class JustWatchDeepLinkRepository @Inject constructor(
         entry.standardWebUrl == null &&
             System.currentTimeMillis() - entry.fetchedAt >= JustWatchDeepLink.NEGATIVE_TTL_MS
 
+    /**
+     * Validates and sanitizes a country code. Returns the uppercased code when it is
+     * exactly two ASCII letters, otherwise logs a warning and returns "US".
+     */
+    private fun sanitizeCountryCode(raw: String): String {
+        val upper = raw.uppercase()
+        if (upper.matches(COUNTRY_CODE_REGEX)) return upper
+        DiagnosticLog.warn(TAG, "Unsupported country code '$raw', falling back to US")
+        recordError("Unsupported country code '$raw'")
+        return "US"
+    }
+
     private suspend fun fetchAndCacheEpisodeOffers(
         tmdbShowId: Int,
         season: Int,
@@ -128,61 +187,89 @@ class JustWatchDeepLinkRepository @Inject constructor(
     ) {
         try {
             val language = "en"
-            val jwNode = searchShowByTmdbId(tmdbShowId, showTitle, countryCode, language) ?: run {
-                cacheNegativeForAllKnownProviders(tmdbShowId, season, episode, countryCode)
-                return
-            }
 
-            // Cache show-level offers while we have the show node
-            cacheOffers(jwNode.offers, tmdbShowId, 0, 0, countryCode)
+            when (val result = searchShowByTmdbId(tmdbShowId, showTitle, countryCode, language)) {
+                is SearchResult.GraphQlError -> {
+                    val msg = "GraphQL error searching '$showTitle' (tmdb=$tmdbShowId): ${result.summary}"
+                    DiagnosticLog.error(TAG, msg)
+                    recordError(msg)
+                    return
+                }
+                is SearchResult.SearchMiss -> {
+                    DiagnosticLog.warn(TAG, "No JustWatch node matched tmdbId=$tmdbShowId title='$showTitle'")
+                    recordMiss()
+                    return
+                }
+                is SearchResult.Found -> {
+                    val jwNode = result.title
 
-            // Fetch seasons
-            val seasonsResp = api.query(
-                JustWatchGraphQlRequest(
-                    query = JustWatchApiService.SEASONS_QUERY,
-                    variables = buildJsonObject {
-                        put("nodeId", jwNode.id)
-                        put("country", countryCode.uppercase())
-                        put("language", language)
-                    },
-                )
-            )
-            val jwSeasons = seasonsResp.data?.node?.seasons
-            if (jwSeasons.isNullOrEmpty()) {
-                cacheNegativeForAllKnownProviders(tmdbShowId, season, episode, countryCode)
-                return
-            }
+                    // Cache show-level offers while we have the show node
+                    cacheOffers(jwNode.offers, tmdbShowId, 0, 0, countryCode)
 
-            // Match season by index (season 1 → index 0); JustWatch orders from S1
-            val seasonIndex = (season - 1).coerceIn(0, jwSeasons.size - 1)
-            val seasonId = jwSeasons[seasonIndex].id
+                    // Fetch seasons
+                    val seasonsResp = api.query(
+                        JustWatchGraphQlRequest(
+                            query = JustWatchApiService.SEASONS_QUERY,
+                            variables = buildJsonObject {
+                                put("nodeId", jwNode.id)
+                                put("country", countryCode)
+                                put("language", language)
+                            },
+                        )
+                    )
+                    if (!seasonsResp.errors.isNullOrEmpty()) {
+                        val msg = "GraphQL errors in seasons query for tmdbId=$tmdbShowId"
+                        DiagnosticLog.error(TAG, msg)
+                        recordError(msg)
+                        return
+                    }
+                    val jwSeasons = seasonsResp.data?.node?.seasons
+                    if (jwSeasons.isNullOrEmpty()) {
+                        DiagnosticLog.warn(TAG, "Empty seasons list for tmdbId=$tmdbShowId")
+                        return
+                    }
 
-            // Fetch episodes for this season
-            val episodesResp = api.query(
-                JustWatchGraphQlRequest(
-                    query = JustWatchApiService.EPISODES_QUERY,
-                    variables = buildJsonObject {
-                        put("nodeId", seasonId)
-                        put("country", countryCode.uppercase())
-                        put("language", language)
-                    },
-                )
-            )
-            val jwEpisodes = episodesResp.data?.node?.episodes
-            if (jwEpisodes.isNullOrEmpty()) {
-                cacheNegativeForAllKnownProviders(tmdbShowId, season, episode, countryCode)
-                return
-            }
+                    // Match season by index (season 1 → index 0); JustWatch orders from S1
+                    val seasonIndex = (season - 1).coerceIn(0, jwSeasons.size - 1)
+                    val seasonId = jwSeasons[seasonIndex].id
 
-            val jwEp = jwEpisodes.find { it.seasonNumber == season && it.episodeNumber == episode }
-            if (jwEp != null) {
-                cacheOffers(jwEp.offers, tmdbShowId, season, episode, countryCode)
-            } else {
-                cacheNegativeForAllKnownProviders(tmdbShowId, season, episode, countryCode)
+                    // Fetch episodes for this season
+                    val episodesResp = api.query(
+                        JustWatchGraphQlRequest(
+                            query = JustWatchApiService.EPISODES_QUERY,
+                            variables = buildJsonObject {
+                                put("nodeId", seasonId)
+                                put("country", countryCode)
+                                put("language", language)
+                            },
+                        )
+                    )
+                    if (!episodesResp.errors.isNullOrEmpty()) {
+                        val msg = "GraphQL errors in episodes query for tmdbId=$tmdbShowId S${season}"
+                        DiagnosticLog.error(TAG, msg)
+                        recordError(msg)
+                        return
+                    }
+                    val jwEpisodes = episodesResp.data?.node?.episodes
+                    if (jwEpisodes.isNullOrEmpty()) {
+                        DiagnosticLog.warn(TAG, "Empty episodes list for tmdbId=$tmdbShowId S${season}")
+                        return
+                    }
+
+                    val jwEp = jwEpisodes.find { it.seasonNumber == season && it.episodeNumber == episode }
+                    if (jwEp != null) {
+                        cacheOffers(jwEp.offers, tmdbShowId, season, episode, countryCode)
+                    } else {
+                        DiagnosticLog.warn(TAG, "Episode S${season}E${episode} not found in JustWatch for tmdbId=$tmdbShowId")
+                    }
+                }
             }
         } catch (e: CancellationException) {
             throw e
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            val msg = "${e.javaClass.simpleName}: ${e.message}"
+            DiagnosticLog.error(TAG, "Episode fetch failed for tmdbId=$tmdbShowId S${season}E${episode}: $msg", e)
+            recordError(msg)
             // Network/parse failure: do not cache negatives so the next attempt retries
         }
     }
@@ -193,14 +280,26 @@ class JustWatchDeepLinkRepository @Inject constructor(
         showTitle: String,
     ) {
         try {
-            val jwNode = searchShowByTmdbId(tmdbShowId, showTitle, countryCode, "en") ?: run {
-                cacheNegativeForAllKnownProviders(tmdbShowId, 0, 0, countryCode)
-                return
+            when (val result = searchShowByTmdbId(tmdbShowId, showTitle, countryCode, "en")) {
+                is SearchResult.GraphQlError -> {
+                    val msg = "GraphQL error searching '$showTitle' (tmdb=$tmdbShowId): ${result.summary}"
+                    DiagnosticLog.error(TAG, msg)
+                    recordError(msg)
+                }
+                is SearchResult.SearchMiss -> {
+                    DiagnosticLog.warn(TAG, "No JustWatch node matched tmdbId=$tmdbShowId title='$showTitle'")
+                    recordMiss()
+                }
+                is SearchResult.Found -> {
+                    cacheOffers(result.title.offers, tmdbShowId, 0, 0, countryCode)
+                }
             }
-            cacheOffers(jwNode.offers, tmdbShowId, 0, 0, countryCode)
         } catch (e: CancellationException) {
             throw e
-        } catch (_: Exception) {
+        } catch (e: Exception) {
+            val msg = "${e.javaClass.simpleName}: ${e.message}"
+            DiagnosticLog.error(TAG, "Show-level fetch failed for tmdbId=$tmdbShowId: $msg", e)
+            recordError(msg)
             // Network/parse failure: do not cache negatives
         }
     }
@@ -211,23 +310,26 @@ class JustWatchDeepLinkRepository @Inject constructor(
         showTitle: String,
         countryCode: String,
         language: String,
-    ): JustWatchTitle? {
+    ): SearchResult {
         val response = api.query(
             JustWatchGraphQlRequest(
                 query = JustWatchApiService.SEARCH_QUERY,
                 variables = buildJsonObject {
                     put("searchQuery", showTitle)
-                    put("country", countryCode.uppercase())
+                    put("country", countryCode)
                     put("language", language)
                     put("first", SEARCH_RESULT_LIMIT)
                 },
             )
         )
-        return response.data?.popularTitles?.edges
+        if (!response.errors.isNullOrEmpty()) {
+            val summary = response.errors.toString().take(200)
+            return SearchResult.GraphQlError(summary)
+        }
+        val match = response.data?.popularTitles?.edges
             ?.map { it.node }
-            ?.firstOrNull { node ->
-                node.content?.externalIds?.tmdbId == tmdbShowId.toString()
-            }
+            ?.firstOrNull { node -> node.content?.externalIds?.tmdbId == tmdbShowId.toString() }
+        return if (match != null) SearchResult.Found(match) else SearchResult.SearchMiss
     }
 
     /** Converts JustWatch offer list to Room entries and upserts them. */
@@ -252,7 +354,7 @@ class JustWatchDeepLinkRepository @Inject constructor(
         for ((providerId, url) in providerUrls) {
             dao.upsert(JustWatchDeepLink(tmdbShowId, season, episode, providerId, countryCode, url, now))
         }
-        // Cache negatives for known providers that had no offer
+        // Cache negatives for known providers confirmed to have no offer for this title
         val covered = providerUrls.keys
         for (providerId in JustWatchPackageMap.technicalNameToProviderId.values.toSet()) {
             if (providerId !in covered) {
@@ -261,19 +363,6 @@ class JustWatchDeepLinkRepository @Inject constructor(
                     dao.upsert(JustWatchDeepLink(tmdbShowId, season, episode, providerId, countryCode, null, now))
                 }
             }
-        }
-    }
-
-    /** Inserts negative cache entries for all known providers. */
-    private suspend fun cacheNegativeForAllKnownProviders(
-        tmdbShowId: Int,
-        season: Int,
-        episode: Int,
-        countryCode: String,
-    ) {
-        val now = System.currentTimeMillis()
-        for (providerId in JustWatchPackageMap.technicalNameToProviderId.values.toSet()) {
-            dao.upsert(JustWatchDeepLink(tmdbShowId, season, episode, providerId, countryCode, null, now))
         }
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
@@ -86,7 +86,7 @@ class JustWatchDeepLinkRepository @Inject constructor(
      */
     fun searchMissCount(windowMs: Long = 24 * 60 * 60 * 1000L): Int = synchronized(missLock) {
         val cutoff = System.currentTimeMillis() - windowMs
-        while (missTimestamps.isNotEmpty() && missTimestamps.peekFirst() < cutoff) {
+        while (missTimestamps.isNotEmpty() && missTimestamps.peekFirst()!! < cutoff) {
             missTimestamps.pollFirst()
         }
         missTimestamps.size
@@ -287,8 +287,8 @@ class JustWatchDeepLinkRepository @Inject constructor(
                     recordError(msg)
                 }
                 is SearchResult.SearchMiss -> {
-                    DiagnosticLog.warn(TAG, "No JustWatch node matched tmdbId=$tmdbShowId title='$showTitle'")
-                    recordMiss()
+                    DiagnosticLog.warn(TAG, "No JustWatch node matched tmdbId=$tmdbShowId title='$showTitle' (show-level)")
+                    // No miss recorded here — the episode-level fetch already counted it
                 }
                 is SearchResult.Found -> {
                     cacheOffers(result.title.offers, tmdbShowId, 0, 0, countryCode)

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
@@ -19,6 +19,8 @@ private val ALLOWED_MONETIZATION = setOf("FLATRATE", "ADS", "FREE")
 private const val SEARCH_RESULT_LIMIT = 5
 private const val TAG = "JustWatchRepo"
 private val COUNTRY_CODE_REGEX = Regex("[A-Z]{2}")
+private const val DEFAULT_MISS_WINDOW_MS = 24L * 60 * 60 * 1_000
+private const val MAX_ERROR_SUMMARY_LENGTH = 200
 
 /**
  * Resolves JustWatch per-episode deep links with a persistent Room cache.
@@ -46,8 +48,10 @@ class JustWatchDeepLinkRepository @Inject constructor(
 
     private sealed class SearchResult {
         data class Found(val title: JustWatchTitle) : SearchResult()
+
         /** The API returned a valid response but no node matched the TMDB ID. */
         data object SearchMiss : SearchResult()
+
         /** The API returned a top-level GraphQL errors array. */
         data class GraphQlError(val summary: String) : SearchResult()
     }
@@ -84,7 +88,7 @@ class JustWatchDeepLinkRepository @Inject constructor(
      * A miss is counted when the API returned successfully but no JustWatch node
      * matched the requested TMDB show ID.
      */
-    fun searchMissCount(windowMs: Long = 24 * 60 * 60 * 1000L): Int = synchronized(missLock) {
+    fun searchMissCount(windowMs: Long = DEFAULT_MISS_WINDOW_MS): Int = synchronized(missLock) {
         val cutoff = System.currentTimeMillis() - windowMs
         while (missTimestamps.isNotEmpty() && missTimestamps.peekFirst()!! < cutoff) {
             missTimestamps.pollFirst()
@@ -245,14 +249,14 @@ class JustWatchDeepLinkRepository @Inject constructor(
                         )
                     )
                     if (!episodesResp.errors.isNullOrEmpty()) {
-                        val msg = "GraphQL errors in episodes query for tmdbId=$tmdbShowId S${season}"
+                        val msg = "GraphQL errors in episodes query for tmdbId=$tmdbShowId S$season"
                         DiagnosticLog.error(TAG, msg)
                         recordError(msg)
                         return
                     }
                     val jwEpisodes = episodesResp.data?.node?.episodes
                     if (jwEpisodes.isNullOrEmpty()) {
-                        DiagnosticLog.warn(TAG, "Empty episodes list for tmdbId=$tmdbShowId S${season}")
+                        DiagnosticLog.warn(TAG, "Empty episodes list for tmdbId=$tmdbShowId S$season")
                         return
                     }
 
@@ -260,7 +264,7 @@ class JustWatchDeepLinkRepository @Inject constructor(
                     if (jwEp != null) {
                         cacheOffers(jwEp.offers, tmdbShowId, season, episode, countryCode)
                     } else {
-                        DiagnosticLog.warn(TAG, "Episode S${season}E${episode} not found in JustWatch for tmdbId=$tmdbShowId")
+                        DiagnosticLog.warn(TAG, "Episode S${season}E$episode not found in JustWatch for tmdbId=$tmdbShowId")
                     }
                 }
             }
@@ -268,7 +272,7 @@ class JustWatchDeepLinkRepository @Inject constructor(
             throw e
         } catch (e: Exception) {
             val msg = "${e.javaClass.simpleName}: ${e.message}"
-            DiagnosticLog.error(TAG, "Episode fetch failed for tmdbId=$tmdbShowId S${season}E${episode}: $msg", e)
+            DiagnosticLog.error(TAG, "Episode fetch failed for tmdbId=$tmdbShowId S${season}E$episode: $msg", e)
             recordError(msg)
             // Network/parse failure: do not cache negatives so the next attempt retries
         }
@@ -323,7 +327,7 @@ class JustWatchDeepLinkRepository @Inject constructor(
             )
         )
         if (!response.errors.isNullOrEmpty()) {
-            val summary = response.errors.toString().take(200)
+            val summary = response.errors.toString().take(MAX_ERROR_SUMMARY_LENGTH)
             return SearchResult.GraphQlError(summary)
         }
         val match = response.data?.popularTitles?.edges

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
@@ -191,7 +191,6 @@ class JustWatchDeepLinkRepository @Inject constructor(
     ) {
         try {
             val language = "en"
-
             when (val result = searchShowByTmdbId(tmdbShowId, showTitle, countryCode, language)) {
                 is SearchResult.GraphQlError -> {
                     val msg = "GraphQL error searching '$showTitle' (tmdb=$tmdbShowId): ${result.summary}"
@@ -204,69 +203,8 @@ class JustWatchDeepLinkRepository @Inject constructor(
                     recordMiss()
                     return
                 }
-                is SearchResult.Found -> {
-                    val jwNode = result.title
-
-                    // Cache show-level offers while we have the show node
-                    cacheOffers(jwNode.offers, tmdbShowId, 0, 0, countryCode)
-
-                    // Fetch seasons
-                    val seasonsResp = api.query(
-                        JustWatchGraphQlRequest(
-                            query = JustWatchApiService.SEASONS_QUERY,
-                            variables = buildJsonObject {
-                                put("nodeId", jwNode.id)
-                                put("country", countryCode)
-                                put("language", language)
-                            },
-                        )
-                    )
-                    if (!seasonsResp.errors.isNullOrEmpty()) {
-                        val msg = "GraphQL errors in seasons query for tmdbId=$tmdbShowId"
-                        DiagnosticLog.error(TAG, msg)
-                        recordError(msg)
-                        return
-                    }
-                    val jwSeasons = seasonsResp.data?.node?.seasons
-                    if (jwSeasons.isNullOrEmpty()) {
-                        DiagnosticLog.warn(TAG, "Empty seasons list for tmdbId=$tmdbShowId")
-                        return
-                    }
-
-                    // Match season by index (season 1 → index 0); JustWatch orders from S1
-                    val seasonIndex = (season - 1).coerceIn(0, jwSeasons.size - 1)
-                    val seasonId = jwSeasons[seasonIndex].id
-
-                    // Fetch episodes for this season
-                    val episodesResp = api.query(
-                        JustWatchGraphQlRequest(
-                            query = JustWatchApiService.EPISODES_QUERY,
-                            variables = buildJsonObject {
-                                put("nodeId", seasonId)
-                                put("country", countryCode)
-                                put("language", language)
-                            },
-                        )
-                    )
-                    if (!episodesResp.errors.isNullOrEmpty()) {
-                        val msg = "GraphQL errors in episodes query for tmdbId=$tmdbShowId S$season"
-                        DiagnosticLog.error(TAG, msg)
-                        recordError(msg)
-                        return
-                    }
-                    val jwEpisodes = episodesResp.data?.node?.episodes
-                    if (jwEpisodes.isNullOrEmpty()) {
-                        DiagnosticLog.warn(TAG, "Empty episodes list for tmdbId=$tmdbShowId S$season")
-                        return
-                    }
-
-                    val jwEp = jwEpisodes.find { it.seasonNumber == season && it.episodeNumber == episode }
-                    if (jwEp != null) {
-                        cacheOffers(jwEp.offers, tmdbShowId, season, episode, countryCode)
-                    } else {
-                        DiagnosticLog.warn(TAG, "Episode S${season}E$episode not found in JustWatch for tmdbId=$tmdbShowId")
-                    }
-                }
+                is SearchResult.Found ->
+                    fetchEpisodeOffersForNode(result.title, tmdbShowId, season, episode, countryCode, language)
             }
         } catch (e: CancellationException) {
             throw e
@@ -275,6 +213,75 @@ class JustWatchDeepLinkRepository @Inject constructor(
             DiagnosticLog.error(TAG, "Episode fetch failed for tmdbId=$tmdbShowId S${season}E$episode: $msg", e)
             recordError(msg)
             // Network/parse failure: do not cache negatives so the next attempt retries
+        }
+    }
+
+    private suspend fun fetchEpisodeOffersForNode(
+        jwNode: JustWatchTitle,
+        tmdbShowId: Int,
+        season: Int,
+        episode: Int,
+        countryCode: String,
+        language: String,
+    ) {
+        // Cache show-level offers while we have the show node
+        cacheOffers(jwNode.offers, tmdbShowId, 0, 0, countryCode)
+
+        // Fetch seasons
+        val seasonsResp = api.query(
+            JustWatchGraphQlRequest(
+                query = JustWatchApiService.SEASONS_QUERY,
+                variables = buildJsonObject {
+                    put("nodeId", jwNode.id)
+                    put("country", countryCode)
+                    put("language", language)
+                },
+            )
+        )
+        if (!seasonsResp.errors.isNullOrEmpty()) {
+            val msg = "GraphQL errors in seasons query for tmdbId=$tmdbShowId"
+            DiagnosticLog.error(TAG, msg)
+            recordError(msg)
+            return
+        }
+        val jwSeasons = seasonsResp.data?.node?.seasons
+        if (jwSeasons.isNullOrEmpty()) {
+            DiagnosticLog.warn(TAG, "Empty seasons list for tmdbId=$tmdbShowId")
+            return
+        }
+
+        // Match season by index (season 1 → index 0); JustWatch orders from S1
+        val seasonIndex = (season - 1).coerceIn(0, jwSeasons.size - 1)
+        val seasonId = jwSeasons[seasonIndex].id
+
+        // Fetch episodes for this season
+        val episodesResp = api.query(
+            JustWatchGraphQlRequest(
+                query = JustWatchApiService.EPISODES_QUERY,
+                variables = buildJsonObject {
+                    put("nodeId", seasonId)
+                    put("country", countryCode)
+                    put("language", language)
+                },
+            )
+        )
+        if (!episodesResp.errors.isNullOrEmpty()) {
+            val msg = "GraphQL errors in episodes query for tmdbId=$tmdbShowId S$season"
+            DiagnosticLog.error(TAG, msg)
+            recordError(msg)
+            return
+        }
+        val jwEpisodes = episodesResp.data?.node?.episodes
+        if (jwEpisodes.isNullOrEmpty()) {
+            DiagnosticLog.warn(TAG, "Empty episodes list for tmdbId=$tmdbShowId S$season")
+            return
+        }
+
+        val jwEp = jwEpisodes.find { it.seasonNumber == season && it.episodeNumber == episode }
+        if (jwEp != null) {
+            cacheOffers(jwEp.offers, tmdbShowId, season, episode, countryCode)
+        } else {
+            DiagnosticLog.warn(TAG, "Episode S${season}E$episode not found in JustWatch for tmdbId=$tmdbShowId")
         }
     }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -220,6 +220,8 @@ fun TvDiagnosticsScreen(
                     cachedCount = uiState.cachedDeepLinkCount,
                     negativeCount = uiState.negativeDeepLinkCount,
                     lastFetchMs = uiState.lastDeepLinkFetchMs,
+                    lastError = uiState.lastJustWatchError,
+                    searchMisses24h = uiState.justWatchSearchMisses24h,
                     onClearCache = { viewModel.clearJustWatchCache() },
                 )
             }
@@ -515,6 +517,8 @@ private fun StreamingDeepLinksSection(
     cachedCount: Int,
     negativeCount: Int,
     lastFetchMs: Long,
+    lastError: String?,
+    searchMisses24h: Int,
     onClearCache: () -> Unit,
 ) {
     Text(
@@ -534,18 +538,38 @@ private fun StreamingDeepLinksSection(
                 DiagRow(stringResource(R.string.tv_diagnostics_row_cached_urls), cachedCount.toString(), Status.NEUTRAL),
                 DiagRow(stringResource(R.string.tv_diagnostics_row_negative_entries), negativeCount.toString(), Status.NEUTRAL),
                 DiagRow(stringResource(R.string.tv_diagnostics_row_last_fetch), formatAge(lastFetchMs), Status.NEUTRAL),
+                DiagRow(
+                    label = stringResource(R.string.tv_diagnostics_row_jw_search_misses),
+                    value = searchMisses24h.toString(),
+                    status = if (searchMisses24h > 0) Status.WARN else Status.NEUTRAL,
+                ),
+                DiagRow(
+                    label = stringResource(R.string.tv_diagnostics_row_jw_last_error),
+                    value = lastError ?: "—",
+                    status = if (lastError != null) Status.FAIL else Status.NEUTRAL,
+                ),
             ).forEach { row ->
                 Row(
                     modifier = Modifier.fillMaxWidth().padding(vertical = 6.dp),
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
-                    Row(verticalAlignment = Alignment.CenterVertically) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.weight(1f),
+                    ) {
                         Box(Modifier.size(10.dp).background(statusColor(row.status), RoundedCornerShape(2.dp)))
                         Spacer(Modifier.width(12.dp))
                         Text(row.label, fontSize = 14.sp, color = Color.White)
                     }
-                    Text(row.value, fontSize = 13.sp, color = Color.White.copy(alpha = 0.7f))
+                    Text(
+                        row.value,
+                        fontSize = 13.sp,
+                        color = Color.White.copy(alpha = 0.7f),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f),
+                    )
                 }
             }
             Spacer(Modifier.height(8.dp))

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
@@ -40,6 +40,8 @@ data class TvDiagnosticsUiState(
     val cachedDeepLinkCount: Int = 0,
     val negativeDeepLinkCount: Int = 0,
     val lastDeepLinkFetchMs: Long = 0L,
+    val lastJustWatchError: String? = null,
+    val justWatchSearchMisses24h: Int = 0,
     /** null = not yet checked, PermissionDenied or Success from the WatchNext provider query. */
     val watchNextCountResult: WatchNextMetadataSource.CountResult? = null,
     /**
@@ -120,6 +122,8 @@ class TvDiagnosticsViewModel @Inject constructor(
                         cachedDeepLinkCount = it.cachedDeepLinkCount,
                         negativeDeepLinkCount = it.negativeDeepLinkCount,
                         lastDeepLinkFetchMs = it.lastDeepLinkFetchMs,
+                        lastJustWatchError = it.lastJustWatchError,
+                        justWatchSearchMisses24h = it.justWatchSearchMisses24h,
                         watchNextCountResult = it.watchNextCountResult,
                         notificationTrackedCount = it.notificationTrackedCount,
                         appProfileStats = it.appProfileStats,
@@ -155,11 +159,15 @@ class TvDiagnosticsViewModel @Inject constructor(
             val count = justWatchRepo.count()
             val negCount = justWatchRepo.negativeCount()
             val lastFetch = justWatchRepo.lastFetchedAt() ?: 0L
+            val lastError = justWatchRepo.lastFetchError()
+            val misses24h = justWatchRepo.searchMissCount()
             _uiState.update {
                 it.copy(
                     cachedDeepLinkCount = count,
                     negativeDeepLinkCount = negCount,
                     lastDeepLinkFetchMs = lastFetch,
+                    lastJustWatchError = lastError,
+                    justWatchSearchMisses24h = misses24h,
                 )
             }
         }

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -71,6 +71,8 @@
     <string name="tv_diagnostics_row_negative_entries">Negative Einträge</string>
     <string name="tv_diagnostics_row_last_fetch">Letzter Abruf</string>
     <string name="tv_diagnostics_action_clear_streaming_cache">Streaming-Link-Cache löschen</string>
+    <string name="tv_diagnostics_row_jw_search_misses">Suchtreffer fehler (24 Std.)</string>
+    <string name="tv_diagnostics_row_jw_last_error">Letzter JustWatch-Fehler</string>
 
     <!-- TV Settings hub (#344 / #367) -->
     <string name="tv_settings_title">Einstellungen</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -74,6 +74,8 @@
     <string name="tv_diagnostics_row_negative_entries">Entradas negativas</string>
     <string name="tv_diagnostics_row_last_fetch">Última descarga</string>
     <string name="tv_diagnostics_action_clear_streaming_cache">Vaciar caché de enlaces de streaming</string>
+    <string name="tv_diagnostics_row_jw_search_misses">Búsquedas fallidas (24 h)</string>
+    <string name="tv_diagnostics_row_jw_last_error">Último error de JustWatch</string>
 
     <!-- TV Settings hub (#344 / #367) -->
     <string name="tv_settings_title">Ajustes</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -74,6 +74,8 @@
     <string name="tv_diagnostics_row_negative_entries">Entrées négatives</string>
     <string name="tv_diagnostics_row_last_fetch">Dernier téléchargement</string>
     <string name="tv_diagnostics_action_clear_streaming_cache">Vider le cache des liens streaming</string>
+    <string name="tv_diagnostics_row_jw_search_misses">Recherches manquées (24 h)</string>
+    <string name="tv_diagnostics_row_jw_last_error">Dernière erreur JustWatch</string>
 
     <!-- TV Settings hub (#344 / #367) -->
     <string name="tv_settings_title">Paramètres</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -71,6 +71,8 @@
     <string name="tv_diagnostics_row_negative_entries">Negative entries</string>
     <string name="tv_diagnostics_row_last_fetch">Last fetch</string>
     <string name="tv_diagnostics_action_clear_streaming_cache">Clear streaming-link cache</string>
+    <string name="tv_diagnostics_row_jw_search_misses">Search misses (24 h)</string>
+    <string name="tv_diagnostics_row_jw_last_error">Last JustWatch error</string>
 
     <!-- TV Settings hub (#344 / #367) -->
     <string name="tv_settings_title">Settings</string>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
@@ -20,7 +20,11 @@ import io.mockk.mockk
 import io.mockk.runs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -66,6 +70,14 @@ class JustWatchDeepLinkRepositoryTest {
             )
         )
     )
+
+    private fun makeGraphQlErrorResponse(message: String = "Field not found") =
+        JustWatchGraphQlResponse(
+            data = null,
+            errors = buildJsonArray {
+                add(buildJsonObject { put("message", message) })
+            },
+        )
 
     private fun makeSeasonsResponse(seasonIds: List<String> = listOf("season-1-id")) =
         JustWatchGraphQlResponse(
@@ -204,7 +216,7 @@ class JustWatchDeepLinkRepositoryTest {
         }
 
         @Test
-        fun `caches negative when search returns no matching TMDB id`() = runTest {
+        fun `does not cache negatives when search returns no matching TMDB id`() = runTest {
             coEvery { dao.get(100, 1, 2, 8, "US") } returns null andThen null
             coEvery { dao.get(100, 0, 0, 8, "US") } returns null andThen null
 
@@ -214,8 +226,19 @@ class JustWatchDeepLinkRepositoryTest {
 
             repository.resolveDeepLink(100, 1, 2, 8, "US", "Unknown Show")
 
-            // Should have cached negatives for all known providers
-            coVerify(atLeast = 1) { dao.upsert(match { it.standardWebUrl == null }) }
+            // No negatives should be cached — the search miss may be a title mismatch, allow retry
+            coVerify(exactly = 0) { dao.upsert(any()) }
+        }
+
+        @Test
+        fun `increments miss counter when search returns no matching TMDB id`() = runTest {
+            coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
+            coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } returns
+                makeSearchResponse(tmdbId = "999")
+
+            repository.resolveDeepLink(100, 1, 2, 8, "US", "Unknown Show")
+
+            assertEquals(1, repository.searchMissCount())
         }
 
         @Test
@@ -230,6 +253,51 @@ class JustWatchDeepLinkRepositoryTest {
             assertNull(result)
             // No negatives should be cached — allow retry on next call
             coVerify(exactly = 0) { dao.upsert(any()) }
+        }
+
+        @Test
+        fun `records error message on API exception`() = runTest {
+            coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
+            coEvery { api.query(any()) } throws RuntimeException("connection refused")
+
+            repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
+
+            assertNotNull(repository.lastFetchError())
+        }
+
+        @Test
+        fun `does not cache negatives on GraphQL errors in search response`() = runTest {
+            coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
+            coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } returns
+                makeGraphQlErrorResponse("Unknown field 'tmdbId'")
+
+            repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
+
+            coVerify(exactly = 0) { dao.upsert(any()) }
+        }
+
+        @Test
+        fun `records last error on GraphQL errors in search response`() = runTest {
+            coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
+            coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } returns
+                makeGraphQlErrorResponse("Unknown field 'tmdbId'")
+
+            repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
+
+            assertNotNull(repository.lastFetchError())
+        }
+
+        @Test
+        fun `does not cache negatives on GraphQL errors in seasons response`() = runTest {
+            coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
+            coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } returns
+                makeSearchResponse()
+            coEvery { api.query(match { it.query == JustWatchApiService.SEASONS_QUERY }) } returns
+                makeGraphQlErrorResponse("Season field unavailable")
+
+            repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
+
+            coVerify(exactly = 0) { dao.upsert(match { it.standardWebUrl == null }) }
         }
 
         @Test
@@ -255,6 +323,64 @@ class JustWatchDeepLinkRepositoryTest {
             coVerify(exactly = 0) {
                 dao.upsert(match { it.providerId == 350 && it.standardWebUrl != null })
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("country code sanitization")
+    inner class CountryCodeTests {
+
+        @Test
+        fun `accepts valid 2-letter country code`() = runTest {
+            coEvery { dao.get(100, 1, 2, 8, "DE") } returns
+                makeLink(countryCode = "DE", url = "https://www.netflix.com/watch/99")
+
+            val result = repository.resolveDeepLink(100, 1, 2, 8, "DE", "Breaking Bad")
+
+            assertEquals("https://www.netflix.com/watch/99", result)
+        }
+
+        @Test
+        fun `falls back to US for invalid country code`() = runTest {
+            coEvery { dao.get(100, 1, 2, 8, "US") } returns
+                makeLink(countryCode = "US", url = "https://www.netflix.com/watch/99")
+
+            // Pass an invalid code — the repository should sanitize to US before the DAO call
+            val result = repository.resolveDeepLink(100, 1, 2, 8, "XYZ", "Breaking Bad")
+
+            assertEquals("https://www.netflix.com/watch/99", result)
+        }
+
+        @Test
+        fun `falls back to US for empty country code`() = runTest {
+            coEvery { dao.get(100, 1, 2, 8, "US") } returns
+                makeLink(countryCode = "US", url = "https://www.netflix.com/watch/99")
+
+            val result = repository.resolveDeepLink(100, 1, 2, 8, "", "Breaking Bad")
+
+            assertEquals("https://www.netflix.com/watch/99", result)
+        }
+
+        @Test
+        fun `records error on invalid country code`() = runTest {
+            coEvery { dao.get(100, 1, 2, 8, "US") } returns null
+            coEvery { dao.get(100, 0, 0, 8, "US") } returns null
+
+            coEvery { api.query(any()) } returns JustWatchGraphQlResponse(data = null)
+
+            repository.resolveDeepLink(100, 1, 2, 8, "INVALID", "Breaking Bad")
+
+            assertNotNull(repository.lastFetchError())
+        }
+
+        @Test
+        fun `uppercases lowercase country code`() = runTest {
+            coEvery { dao.get(100, 1, 2, 8, "DE") } returns
+                makeLink(countryCode = "DE", url = "https://www.netflix.com/watch/99")
+
+            val result = repository.resolveDeepLink(100, 1, 2, 8, "de", "Breaking Bad")
+
+            assertEquals("https://www.netflix.com/watch/99", result)
         }
     }
 
@@ -309,6 +435,16 @@ class JustWatchDeepLinkRepositoryTest {
             coEvery { dao.deleteAll() } just runs
             repository.clearAll()
             coVerify { dao.deleteAll() }
+        }
+
+        @Test
+        fun `searchMissCount returns 0 when no misses recorded`() = runTest {
+            assertEquals(0, repository.searchMissCount())
+        }
+
+        @Test
+        fun `lastFetchError returns null initially`() {
+            assertNull(repository.lastFetchError())
         }
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
@@ -288,7 +288,7 @@ class JustWatchDeepLinkRepositoryTest {
         }
 
         @Test
-        fun `does not cache negatives on GraphQL errors in seasons response`() = runTest {
+        fun `does not cache episode-level negatives on GraphQL errors in seasons response`() = runTest {
             coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
             coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } returns
                 makeSearchResponse()
@@ -297,7 +297,10 @@ class JustWatchDeepLinkRepositoryTest {
 
             repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
 
-            coVerify(exactly = 0) { dao.upsert(match { it.standardWebUrl == null }) }
+            // Episode-level negatives must not be written — the error came from the API, not a confirmed miss
+            coVerify(exactly = 0) {
+                dao.upsert(match { it.season == 1 && it.episode == 2 && it.standardWebUrl == null })
+            }
         }
 
         @Test

--- a/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchApiService.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchApiService.kt
@@ -1,6 +1,7 @@
 package com.justb81.watchbuddy.core.justwatch
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -91,6 +92,7 @@ data class JustWatchGraphQlRequest(
 @Serializable
 data class JustWatchGraphQlResponse(
     val data: JustWatchData? = null,
+    val errors: JsonArray? = null,
 )
 
 @Serializable


### PR DESCRIPTION
## Summary

Fixes the root causes that kept JustWatch deep-link chips permanently "Unavailable" (#495).

- **Stop poisoning the negative cache on hard failures.** Previously, a search miss (TMDB ID not found in JustWatch results), an API exception, or a GraphQL error would all write 30-day negative entries via `cacheNegativeForAllKnownProviders`. Now negative caching only happens inside `cacheOffers` — the single path where JustWatch actually confirmed there is no offer for a provider. Misses and errors no longer cache anything, so the next attempt retries freely.
- **Detect GraphQL errors.** Added `errors: JsonArray?` to `JustWatchGraphQlResponse`. A non-empty `errors` field is now classified as a hard error (no cache, error logged) instead of silently looking like empty data.
- **Distinguish search miss from hard error.** Introduced a `SearchResult` sealed class (`Found` / `SearchMiss` / `GraphQlError`) so each failure mode is handled independently.
- **Country-code sanitization.** If the caller passes a code that doesn't match `[A-Z]{2}` (e.g. an empty string or a locale-derived 3-char code) the repository logs a warning and falls back to `"US"`, preventing the JustWatch `Country!` enum from rejecting the request.
- **DiagnosticLog breadcrumbs.** GraphQL errors, search misses, empty seasons/episodes lists, and caught exceptions all emit `DiagnosticLog.warn/error` entries visible in TV Diagnostics → Recent Events.
- **Diagnostics surface.** TV Diagnostics → Streaming Links section gains two new rows: "Search misses (24 h)" (WARN dot when > 0) and "Last JustWatch error" (FAIL dot when set). Both are cleared/updated via the existing `refreshJustWatchCacheStats()` call on `ON_RESUME`.

## Files changed

| File | Change |
|------|--------|
| `core/.../JustWatchApiService.kt` | Add `errors: JsonArray?` to response model |
| `app-tv/.../JustWatchDeepLinkRepository.kt` | `SearchResult` sealed class, sanitize country, DiagnosticLog breadcrumbs, in-memory miss/error stats, remove hard-error negative caches |
| `app-tv/.../TvDiagnosticsViewModel.kt` | Add `lastJustWatchError` and `justWatchSearchMisses24h` to state |
| `app-tv/.../TvDiagnosticsScreen.kt` | Render last error + miss count in `StreamingDeepLinksSection` |
| `app-tv/.../res/values{,-de,-fr,-es}/strings.xml` | Two new diagnostic row labels |
| `app-tv/.../JustWatchDeepLinkRepositoryTest.kt` | Tests for GraphQL errors, country fallback, miss counter, no-cache-on-exception |

## Test plan

- [ ] Install on a Google TV in DE locale that previously showed all-Unavailable chips — verify at least one chip now resolves after clearing the cache
- [ ] Clear cache → DE locale → flight mode → reopen ShowDetail → open Diagnostics → verify "Last JustWatch error" shows a network error message
- [ ] Clear cache → valid show → verify "Search misses (24 h)" increments if the TMDB ID isn't found, stays zero if found
- [ ] CI unit tests (`JustWatchDeepLinkRepositoryTest`) cover GraphQL error response, country-code fallback, miss counter, and no-negative-on-exception

> ⚠️ Gradle/Kotlin checks were skipped locally (no Android SDK in this environment). CI (`Test & Build`) is the gate.

Closes #495

https://claude.ai/code/session_01HJoved66TvYcX6jyD6Fqve

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJoved66TvYcX6jyD6Fqve)_