### PR TITLE
fix(tv): show TMDB synopsis as recap fallback when companion is unreachable

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
@@ -183,5 +183,6 @@ private fun TmdbShow.toProgressHint(): TmdbProgressHint = TmdbProgressHint(
     status = status,
     lastAired = last_episode_to_air,
     nextAired = next_episode_to_air,
-    seasons = seasons
+    seasons = seasons,
+    overview = overview
 )

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
@@ -148,6 +148,22 @@ class ShowRepositoryTest {
     }
 
     @Test
+    fun `getShows forwards TMDB overview into TmdbProgressHint`() = runTest {
+        every { settingsRepository.getTmdbApiKey() } returns flowOf("api-key")
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+        coEvery { traktApi.getWatchedShows(any()) } returns testShows
+        coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns
+            TmdbShow(100, "Show 1", overview = "A great show about things.", poster_path = "/one.jpg")
+        coEvery { tmdbApiService.getShow(200, "api-key", any()) } returns
+            TmdbShow(200, "Show 2", overview = null, poster_path = "/two.jpg")
+
+        val result = repository.getShows()
+
+        assertEquals("A great show about things.", result[0].tmdb?.overview)
+        assertNull(result[1].tmdb?.overview)
+    }
+
+    @Test
     fun `getShows emits shows sorted by last-watched DESC with unwatched at bottom`() = runTest {
         val entries = listOf(
             watchedEntry(trakt = 1, title = "Old", lastWatchedAt = "2026-04-10T10:00:00Z"),

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiClientFactory.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiClientFactory.kt
@@ -6,20 +6,28 @@ import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class PhoneApiClientFactory @Inject constructor(
-    private val httpClient: OkHttpClient
+    httpClient: OkHttpClient
 ) {
+    // LAN calls: fast connect; read timeout matches phone-side 75 s LLM cap with margin.
+    private val timeoutClient: OkHttpClient = httpClient.newBuilder()
+        .connectTimeout(5, TimeUnit.SECONDS)
+        .readTimeout(90, TimeUnit.SECONDS)
+        .callTimeout(95, TimeUnit.SECONDS)
+        .build()
+
     private val cache = mutableMapOf<String, PhoneApiService>()
 
     fun createClient(baseUrl: String): PhoneApiService =
         cache.getOrPut(baseUrl) {
             Retrofit.Builder()
                 .baseUrl(baseUrl)
-                .client(httpClient)
+                .client(timeoutClient)
                 .addConverterFactory(WatchBuddyJson.asConverterFactory("application/json".toMediaType()))
                 .build()
                 .create(PhoneApiService::class.java)

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
@@ -62,10 +62,11 @@ fun TvNavGraph() {
         composable(TvRoute.Recap.route) {
             val enriched = selectedEntry
             if (enriched != null) {
+                val tmdbOverview = enriched.tmdb?.overview?.takeIf { it.isNotBlank() }
                 RecapScreen(
                     traktShowId      = enriched.entry.show.ids.trakt ?: 0,
                     showTitle        = enriched.entry.show.title,
-                    fallbackSynopsis = stringResource(R.string.tv_no_description),
+                    fallbackSynopsis = tmdbOverview ?: stringResource(R.string.tv_no_description),
                     onClose          = { navController.popBackStack() },
                     onWatchNow       = {
                         // Pop back to detail, then trigger deep link

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -63,9 +64,14 @@ class RecapViewModel @Inject constructor(
             }
 
             // All phones were tried but all failed — distinguish from the "no phones" early return above.
+            DiagnosticLog.event(TAG, "recap_fallback_all_failed phones=${phones.size}")
             _state.value = RecapUiState.Fallback(fallbackSynopsis, allPhonesFailed = true)
         }
     }
 
     fun reset() { _state.value = RecapUiState.Idle }
+
+    private companion object {
+        const val TAG = "RecapViewModel"
+    }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/recap/RecapViewModelTest.kt
@@ -69,6 +69,18 @@ class RecapViewModelTest {
             assertEquals("Fallback synopsis text", state.synopsis)
             assertFalse(state.allPhonesFailed)
         }
+
+        @Test
+        fun `returns Fallback carrying TMDB synopsis when provided`() = runTest {
+            val tmdbSynopsis = "A drama set in the world of competitive baking."
+
+            viewModel.requestRecap(456, tmdbSynopsis)
+            advanceUntilIdle()
+
+            val state = viewModel.state.value as RecapUiState.Fallback
+            assertEquals(tmdbSynopsis, state.synopsis)
+            assertFalse(state.allPhonesFailed)
+        }
     }
 
     @Nested

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -113,7 +113,8 @@ data class TmdbProgressHint(
     val status: String? = null,
     val lastAired: TmdbEpisodeSummary? = null,
     val nextAired: TmdbEpisodeSummary? = null,
-    val seasons: List<TmdbSeasonSummary> = emptyList()
+    val seasons: List<TmdbSeasonSummary> = emptyList(),
+    val overview: String? = null
 )
 
 @Serializable


### PR DESCRIPTION
## Summary

Fixes #497 — TV Recap screen showed the literal "No description available" string when the companion app was unreachable instead of using the TMDB show synopsis.

**Root causes addressed:**
- `TmdbProgressHint` had no `overview` field, so the phone never shipped the TMDB synopsis to the TV.
- `TvNavGraph` hardcoded `tv_no_description` as `fallbackSynopsis` even though the show's TMDB data was available in `EnrichedShowEntry`.
- `PhoneApiClientFactory` used the default OkHttpClient with no timeouts, causing the recap request to hang indefinitely instead of failing quickly and triggering the fallback.

## Changes

- **`core/model/Models.kt`** — Add `overview: String? = null` to `TmdbProgressHint`
- **`app-phone/…/server/ShowRepository.kt`** — Populate `overview` from `TmdbShow.overview` in `toProgressHint()`
- **`app-tv/…/navigation/TvNavGraph.kt`** — Pass `enriched.tmdb?.overview` as `fallbackSynopsis`; only fall back to `tv_no_description` when no synopsis is available
- **`app-tv/…/discovery/PhoneApiClientFactory.kt`** — Add explicit OkHttp timeouts: connect=5 s, read=90 s, call=95 s (matches phone-side 75 s LLM cap with margin)
- **`app-tv/…/recap/RecapViewModel.kt`** — Emit `DiagnosticLog` breadcrumb when all phones fail so the case is visible in TV Diagnostics

## Tests

- **`ShowRepositoryTest`** — New test `getShows forwards TMDB overview into TmdbProgressHint` asserts that a non-null `TmdbShow.overview` is forwarded through to `EnrichedShowEntry.tmdb?.overview`, and that a `null` overview stays `null`.
- **`RecapViewModelTest`** — New test `returns Fallback carrying TMDB synopsis when provided` verifies the `Fallback` state carries the caller-supplied TMDB synopsis through unchanged.

## Verification

1. Unit tests above.
2. Manual: open a show, force the companion app off → Recap screen on TV shows the TMDB show synopsis under the fallback label.
3. Manual: same setup with a show that has no TMDB overview → falls back to `tv_no_description`.

> **Note:** Gradle scope skipped locally (no Android SDK in this environment). CI (`build-android.yml`) is the real gate for Kotlin/Android changes.

https://claude.ai/code/session_01Bmt2qL4nqG52md6G5vGbLY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bmt2qL4nqG52md6G5vGbLY)_