### PR TITLE
feat(tv): auto-add unknown shows to Trakt library on overlay confirm (#468)

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.phone.server
 import com.justb81.watchbuddy.core.locale.LocaleHelper
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.AmbiguousScrobbleEvent
+import com.justb81.watchbuddy.core.model.PhoneAddToLibraryRequest
 import com.justb81.watchbuddy.core.model.ScrobbleAction
 import com.justb81.watchbuddy.core.model.ScrobbleDisplayEvent
 import com.justb81.watchbuddy.core.model.TitleExtractionRequest
@@ -13,6 +14,10 @@ import com.justb81.watchbuddy.core.network.WatchBuddyJson
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.core.tmdb.TmdbCache
 import com.justb81.watchbuddy.core.trakt.ScrobbleBody
+import com.justb81.watchbuddy.core.trakt.SyncHistoryBody
+import com.justb81.watchbuddy.core.trakt.SyncHistoryEpisodeItem
+import com.justb81.watchbuddy.core.trakt.SyncHistorySeasonItem
+import com.justb81.watchbuddy.core.trakt.SyncHistoryShowItem
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.auth.TokenRepository
@@ -57,6 +62,7 @@ private const val MAX_PAGE_SIZE = 200
  *   POST /scrobble/extract     → LLM fallback — normalize raw MediaSession
  *                                metadata into (showTitle, season?, episode?)
  *   POST /scrobble/prompt      → Deliver ambiguous-scrobble prompt; consumed via state stream
+ *   POST /shows/add-to-library → Add an episode to Trakt history (unknown-show overlay confirm)
  */
 @Singleton
 class CompanionHttpServer @Inject constructor(
@@ -316,6 +322,41 @@ internal fun Application.configureCompanionRoutes(
             )
             call.respond(HttpStatusCode.NoContent)
         }
+
+        post("/shows/add-to-library") {
+            val token = tokenRefreshManager.getValidAccessToken()
+                ?: return@post call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
+            val body = try {
+                call.receive<PhoneAddToLibraryRequest>()
+            } catch (_: Exception) {
+                return@post call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid request body"))
+            }
+            try {
+                val syncBody = SyncHistoryBody(
+                    shows = listOf(
+                        SyncHistoryShowItem(
+                            ids = body.show.ids,
+                            seasons = listOf(
+                                SyncHistorySeasonItem(
+                                    number = body.episode.season,
+                                    episodes = listOf(SyncHistoryEpisodeItem(number = body.episode.number))
+                                )
+                            )
+                        )
+                    )
+                )
+                traktApiService.addToHistory("Bearer $token", syncBody)
+                showRepository.invalidateCache()
+                DiagnosticLog.event(
+                    TAG,
+                    "add-to-library ok show='${body.show.title}' S${body.episode.season}E${body.episode.number}",
+                )
+                call.respond(AddToLibraryResponse(success = true))
+            } catch (e: Exception) {
+                DiagnosticLog.error(TAG, "add-to-library failed for '${body.show.title}'", e)
+                call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Add to library failed"))
+            }
+        }
     }
 }
 
@@ -376,5 +417,10 @@ private data class ScrobbleRequestBody(
 
 @Serializable
 private data class ScrobbleActionResponse(
+    val success: Boolean
+)
+
+@Serializable
+private data class AddToLibraryResponse(
     val success: Boolean
 )

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -5,6 +5,7 @@ import com.justb81.watchbuddy.core.model.LlmBackend
 import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
 import com.justb81.watchbuddy.core.model.ScrobbleAction
 import com.justb81.watchbuddy.core.model.DeviceCapability
+import com.justb81.watchbuddy.core.trakt.SyncHistoryResult
 import com.justb81.watchbuddy.core.model.TitleExtractionResponse
 import com.justb81.watchbuddy.core.model.TmdbEpisode
 import com.justb81.watchbuddy.core.model.TmdbShow
@@ -901,6 +902,112 @@ class CompanionHttpServerTest {
             assertEquals(HttpStatusCode.OK, response.status)
             val body = response.bodyAsText()
             assertEquals("{}", body)
+        }
+    }
+
+    // ── POST /shows/add-to-library ────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("POST /shows/add-to-library (#468)")
+    inner class AddToLibraryEndpoint {
+
+        private val addToLibraryBody = """
+            {
+              "show": {"title":"Stranger Things","year":2016,"ids":{"tmdb":66732}},
+              "episode": {"season":1,"number":1,"ids":{}}
+            }
+        """.trimIndent()
+
+        @Test
+        fun `returns 401 when access token is missing`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns null
+
+            val response = client.post("/shows/add-to-library") {
+                contentType(ContentType.Application.Json)
+                setBody(addToLibraryBody)
+            }
+
+            assertEquals(HttpStatusCode.Unauthorized, response.status)
+        }
+
+        @Test
+        fun `returns 400 when request body is invalid`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "token"
+
+            val response = client.post("/shows/add-to-library") {
+                contentType(ContentType.Application.Json)
+                setBody("not-valid-json")
+            }
+
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+        }
+
+        @Test
+        fun `returns 200 and calls addToHistory on Trakt`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+            coEvery { traktApiService.addToHistory("Bearer test-token", any()) } returns
+                SyncHistoryResult(added = com.justb81.watchbuddy.core.trakt.SyncHistoryCount(episodes = 1))
+            every { showRepository.invalidateCache() } just runs
+
+            val response = client.post("/shows/add-to-library") {
+                contentType(ContentType.Application.Json)
+                setBody(addToLibraryBody)
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertTrue(response.bodyAsText().contains("true"))
+            coVerify { traktApiService.addToHistory("Bearer test-token", any()) }
+        }
+
+        @Test
+        fun `invalidates ShowRepository cache after successful add`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+            coEvery { traktApiService.addToHistory(any(), any()) } returns SyncHistoryResult()
+            every { showRepository.invalidateCache() } just runs
+
+            client.post("/shows/add-to-library") {
+                contentType(ContentType.Application.Json)
+                setBody(addToLibraryBody)
+            }
+
+            verify { showRepository.invalidateCache() }
+        }
+
+        @Test
+        fun `returns 503 when Trakt addToHistory throws`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "token"
+            coEvery { traktApiService.addToHistory(any(), any()) } throws RuntimeException("Trakt error")
+
+            val response = client.post("/shows/add-to-library") {
+                contentType(ContentType.Application.Json)
+                setBody(addToLibraryBody)
+            }
+
+            assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+            assertFalse(response.bodyAsText().contains("Trakt error"))
+        }
+
+        @Test
+        fun `builds correct SyncHistoryBody from request show and episode`() = testApp {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+            val capturedBodies = mutableListOf<com.justb81.watchbuddy.core.trakt.SyncHistoryBody>()
+            coEvery { traktApiService.addToHistory(any(), capture(capturedBodies)) } returns SyncHistoryResult()
+            every { showRepository.invalidateCache() } just runs
+
+            client.post("/shows/add-to-library") {
+                contentType(ContentType.Application.Json)
+                setBody(addToLibraryBody)
+            }
+
+            assertEquals(1, capturedBodies.size)
+            val body = capturedBodies.first()
+            assertEquals(1, body.shows.size)
+            val showItem = body.shows.first()
+            assertEquals(66732, showItem.ids.tmdb)
+            assertEquals(1, showItem.seasons.size)
+            assertEquals(1, showItem.seasons.first().number)
+            assertEquals(1, showItem.seasons.first().episodes.size)
+            assertEquals(1, showItem.seasons.first().episodes.first().number)
         }
     }
 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -1,11 +1,10 @@
 package com.justb81.watchbuddy.phone.server
 
+import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.LlmBackend
 import com.justb81.watchbuddy.core.model.MediaMetadataSnapshot
 import com.justb81.watchbuddy.core.model.ScrobbleAction
-import com.justb81.watchbuddy.core.model.DeviceCapability
-import com.justb81.watchbuddy.core.trakt.SyncHistoryResult
 import com.justb81.watchbuddy.core.model.TitleExtractionResponse
 import com.justb81.watchbuddy.core.model.TmdbEpisode
 import com.justb81.watchbuddy.core.model.TmdbShow
@@ -18,6 +17,7 @@ import com.justb81.watchbuddy.core.model.TraktWatchedSeason
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.core.tmdb.TmdbCache
 import com.justb81.watchbuddy.core.trakt.ScrobbleResponse
+import com.justb81.watchbuddy.core.trakt.SyncHistoryResult
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.auth.TokenRepository

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiService.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneApiService.kt
@@ -2,6 +2,7 @@ package com.justb81.watchbuddy.tv.discovery
 
 import com.justb81.watchbuddy.core.model.AmbiguousScrobbleEvent
 import com.justb81.watchbuddy.core.model.EnrichedShowEntry
+import com.justb81.watchbuddy.core.model.PhoneAddToLibraryRequest
 import com.justb81.watchbuddy.core.model.TitleExtractionRequest
 import com.justb81.watchbuddy.core.model.TitleExtractionResponse
 import com.justb81.watchbuddy.core.model.TraktEpisode
@@ -46,6 +47,13 @@ interface PhoneApiService {
      */
     @POST("/scrobble/prompt")
     suspend fun scrobblePrompt(@Body body: AmbiguousScrobbleEvent): PhoneScrobbleActionResponse
+
+    /**
+     * Adds ([show], [episode]) to the phone user's Trakt history.
+     * Called on overlay confirm for unknown shows (TMDB-only candidates).
+     */
+    @POST("/shows/add-to-library")
+    suspend fun addShowToLibrary(@Body body: PhoneAddToLibraryRequest): PhoneScrobbleActionResponse
 }
 
 @Serializable

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.tv.scrobbler
 import android.util.Log
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.AmbiguousScrobbleEvent
+import com.justb81.watchbuddy.core.model.PhoneAddToLibraryRequest
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher
@@ -78,6 +79,14 @@ class TvScrobbleDispatcher(
 
     /** Session keys for which an ambiguous prompt has already been dispatched. Cleared on resolution. */
     private val dispatchedAmbiguousKeys: MutableSet<String> =
+        Collections.newSetFromMap(ConcurrentHashMap())
+
+    /**
+     * TMDB IDs for which the user has already confirmed an add-to-library this session.
+     * Prevents duplicate Trakt history writes when the overlay is confirmed more than once
+     * for the same unknown show. Cleared on service restart.
+     */
+    private val confirmedUnknownTmdbIds: MutableSet<Int> =
         Collections.newSetFromMap(ConcurrentHashMap())
 
     init {
@@ -183,6 +192,54 @@ class TvScrobbleDispatcher(
 
     override suspend fun dispatchStop(show: TraktShow, episode: TraktEpisode, progress: Float) =
         dispatch(ScrobbleAction.STOP, show, episode, progress)
+
+    /**
+     * Fans an add-to-library request to every reachable phone in parallel so the episode
+     * is written to each user's Trakt history immediately after overlay confirmation.
+     *
+     * Idempotent per TMDB id — a second confirmation for the same unknown show within the
+     * same session is silently dropped to prevent duplicate Trakt history entries.
+     * Per-phone failures are logged and do not block other phones.
+     */
+    override suspend fun dispatchAddToLibrary(show: TraktShow, episode: TraktEpisode) {
+        val tmdbId = show.ids.tmdb ?: run {
+            DiagnosticLog.warn(TAG, "add-to-library: skipped — show has no TMDB id '${show.title}'")
+            return
+        }
+        if (!confirmedUnknownTmdbIds.add(tmdbId)) {
+            DiagnosticLog.event(TAG, "add-to-library: dedup skip tmdbId=$tmdbId '${show.title}'")
+            return
+        }
+        DiagnosticLog.event(
+            TAG,
+            "add-to-library-confirmed: '${show.title}' S${episode.season}E${episode.number} tmdbId=$tmdbId",
+        )
+        val phones = availablePhones()
+        if (phones.isEmpty()) {
+            DiagnosticLog.warn(TAG, "add-to-library: no phones reachable for tmdbId=$tmdbId '${show.title}'")
+            return
+        }
+        coroutineScope {
+            phones.forEach { phone ->
+                launch {
+                    try {
+                        val client = phoneApiClientFactory.createClient(phone.baseUrl)
+                        client.addShowToLibrary(PhoneAddToLibraryRequest(show = show, episode = episode))
+                        Log.i(TAG, "add-to-library-ok ${phone.baseUrl}: ${show.title} S${episode.season}E${episode.number}")
+                        DiagnosticLog.event(TAG, "add-to-library-ok phone=${phone.baseUrl} '${show.title}'")
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: IOException) {
+                        Log.e(TAG, "add-to-library failed for ${phone.baseUrl}", e)
+                        DiagnosticLog.warn(TAG, "add-to-library-err phone=${phone.baseUrl}: ${e.message}")
+                    } catch (e: HttpException) {
+                        Log.e(TAG, "add-to-library HTTP error for ${phone.baseUrl}: ${e.code()}", e)
+                        DiagnosticLog.warn(TAG, "add-to-library-err phone=${phone.baseUrl} http=${e.code()}")
+                    }
+                }
+            }
+        }
+    }
 
     /**
      * Fans [event] to every reachable phone in parallel. Idempotent on [AmbiguousScrobbleEvent.sessionKey]:

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
+import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -16,12 +17,15 @@ import javax.inject.Inject
  * Bridges [MediaSessionScrobbler] with the [ScrobbleOverlay] UI.
  *
  * Candidates with confidence 0.70–0.95 land here for user confirmation.
+ * For unknown shows (TMDB-only candidates), even high-confidence matches
+ * are routed here instead of auto-scrobbling.
  * Dismissed episodes are remembered so the overlay is not shown again
  * for the same episode during this session.
  */
 @HiltViewModel
 class ScrobbleViewModel @Inject constructor(
-    private val scrobbler: MediaSessionScrobbler
+    private val scrobbler: MediaSessionScrobbler,
+    private val scrobbleDispatcher: ScrobbleDispatcher,
 ) : ViewModel() {
 
     private val _pendingCandidate = MutableStateFlow<ScrobbleCandidate?>(null)
@@ -45,6 +49,15 @@ class ScrobbleViewModel @Inject constructor(
         val candidate = _pendingCandidate.value ?: return
         _pendingCandidate.value = null
         viewModelScope.launch {
+            if (candidate.isUnknownShow()) {
+                val show = candidate.matchedShow
+                val episode = candidate.matchedEpisode
+                if (show != null && episode != null) {
+                    launch {
+                        runCatching { scrobbleDispatcher.dispatchAddToLibrary(show, episode) }
+                    }
+                }
+            }
             scrobbler.autoScrobble(candidate)
         }
     }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
@@ -7,7 +7,6 @@ import com.justb81.watchbuddy.tv.discovery.DiscoveryConstants
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneApiService
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
-import com.justb81.watchbuddy.core.model.PhoneAddToLibraryRequest
 import com.justb81.watchbuddy.tv.discovery.PhoneScrobbleRequest
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
@@ -7,6 +7,7 @@ import com.justb81.watchbuddy.tv.discovery.DiscoveryConstants
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
 import com.justb81.watchbuddy.tv.discovery.PhoneApiService
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import com.justb81.watchbuddy.core.model.PhoneAddToLibraryRequest
 import com.justb81.watchbuddy.tv.discovery.PhoneScrobbleRequest
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -421,6 +422,112 @@ class TvScrobbleDispatcherTest {
             advanceUntilIdle()
 
             coVerify(exactly = 1) { phoneApiService.scrobbleStart(any()) }
+        }
+    }
+
+    // ── dispatchAddToLibrary ───────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("dispatchAddToLibrary (#468)")
+    inner class AddToLibraryTest {
+
+        @Test
+        fun `fans out to all available phones in parallel`() = runTest(UnconfinedTestDispatcher()) {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+            val apiService1: PhoneApiService = mockk()
+            val apiService2: PhoneApiService = mockk()
+            val phone1 = makePhone(baseUrl = "http://phone1:8765/", name = "phone1")
+            val phone2 = makePhone(baseUrl = "http://phone2:8765/", name = "phone2")
+            phonesFlow.value = listOf(phone1, phone2)
+            coEvery { phoneApiClientFactory.createClient("http://phone1:8765/") } returns apiService1
+            coEvery { phoneApiClientFactory.createClient("http://phone2:8765/") } returns apiService2
+            coEvery { apiService1.addShowToLibrary(any()) } returns mockk()
+            coEvery { apiService2.addShowToLibrary(any()) } returns mockk()
+
+            val show = TestFixtures.traktShow(ids = TestFixtures.traktIds(trakt = null, tmdb = 66732))
+            dispatcher.dispatchAddToLibrary(show, TestFixtures.traktEpisode())
+
+            coVerify { apiService1.addShowToLibrary(any()) }
+            coVerify { apiService2.addShowToLibrary(any()) }
+        }
+
+        @Test
+        fun `IOException on one phone does not block dispatch to other phones`() = runTest(UnconfinedTestDispatcher()) {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+            val apiService1: PhoneApiService = mockk()
+            val apiService2: PhoneApiService = mockk()
+            val phone1 = makePhone(baseUrl = "http://phone1:8765/", name = "phone1")
+            val phone2 = makePhone(baseUrl = "http://phone2:8765/", name = "phone2")
+            phonesFlow.value = listOf(phone1, phone2)
+            coEvery { phoneApiClientFactory.createClient("http://phone1:8765/") } returns apiService1
+            coEvery { phoneApiClientFactory.createClient("http://phone2:8765/") } returns apiService2
+            coEvery { apiService1.addShowToLibrary(any()) } throws java.io.IOException("connection refused")
+            coEvery { apiService2.addShowToLibrary(any()) } returns mockk()
+
+            val show = TestFixtures.traktShow(ids = TestFixtures.traktIds(trakt = null, tmdb = 66732))
+            // Should not throw even when one phone fails.
+            dispatcher.dispatchAddToLibrary(show, TestFixtures.traktEpisode())
+
+            coVerify { apiService2.addShowToLibrary(any()) }
+        }
+
+        @Test
+        fun `session dedup prevents a second dispatch for the same TMDB id`() = runTest(UnconfinedTestDispatcher()) {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+            val phone = makePhone()
+            phonesFlow.value = listOf(phone)
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.addShowToLibrary(any()) } returns mockk()
+
+            val show = TestFixtures.traktShow(ids = TestFixtures.traktIds(trakt = null, tmdb = 66732))
+            dispatcher.dispatchAddToLibrary(show, TestFixtures.traktEpisode())
+            dispatcher.dispatchAddToLibrary(show, TestFixtures.traktEpisode())
+
+            // Only the first call should reach the phone API.
+            coVerify(exactly = 1) { phoneApiService.addShowToLibrary(any()) }
+        }
+
+        @Test
+        fun `different TMDB ids are each dispatched`() = runTest(UnconfinedTestDispatcher()) {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+            val phone = makePhone()
+            phonesFlow.value = listOf(phone)
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.addShowToLibrary(any()) } returns mockk()
+
+            val show1 = TestFixtures.traktShow(ids = TestFixtures.traktIds(trakt = null, tmdb = 111))
+            val show2 = TestFixtures.traktShow(ids = TestFixtures.traktIds(trakt = null, tmdb = 222))
+            dispatcher.dispatchAddToLibrary(show1, TestFixtures.traktEpisode())
+            dispatcher.dispatchAddToLibrary(show2, TestFixtures.traktEpisode())
+
+            coVerify(exactly = 2) { phoneApiService.addShowToLibrary(any()) }
+        }
+
+        @Test
+        fun `no-op when show has no TMDB id`() = runTest(UnconfinedTestDispatcher()) {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+            val phone = makePhone()
+            phonesFlow.value = listOf(phone)
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+
+            val showWithoutTmdbId = TestFixtures.traktShow(
+                ids = TestFixtures.traktIds(trakt = null, tmdb = null)
+            )
+            dispatcher.dispatchAddToLibrary(showWithoutTmdbId, TestFixtures.traktEpisode())
+
+            coVerify(exactly = 0) { phoneApiClientFactory.createClient(any()) }
+        }
+
+        @Test
+        fun `skips dispatch when no phones are available`() = runTest(UnconfinedTestDispatcher()) {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+            phonesFlow.value = emptyList()
+
+            val show = TestFixtures.traktShow(ids = TestFixtures.traktIds(trakt = null, tmdb = 66732))
+            // Should not throw.
+            dispatcher.dispatchAddToLibrary(show, TestFixtures.traktEpisode())
+
+            coVerify(exactly = 0) { phoneApiClientFactory.createClient(any()) }
         }
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModelTest.kt
@@ -6,10 +6,10 @@ import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.tv.MainDispatcherRule
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
+import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -29,6 +29,7 @@ class ScrobbleViewModelTest {
     }
 
     private val scrobbler: MediaSessionScrobbler = mockk()
+    private val scrobbleDispatcher: ScrobbleDispatcher = mockk()
     private val pendingFlow = MutableSharedFlow<ScrobbleCandidate>()
     private lateinit var viewModel: ScrobbleViewModel
 
@@ -38,10 +39,16 @@ class ScrobbleViewModelTest {
         "com.netflix", "Breaking Bad S01E01", 0.85f, testShow, testEpisode
     )
 
+    private val unknownShow = TraktShow("Stranger Things", 2016, TraktIds(tmdb = 66732))
+    private val unknownCandidate = ScrobbleCandidate(
+        "com.plex.android", "Stranger Things S01E01", 0.95f, unknownShow, testEpisode
+    )
+
     @BeforeEach
     fun setUp() {
         every { scrobbler.pendingConfirmation } returns pendingFlow
-        viewModel = ScrobbleViewModel(scrobbler)
+        coEvery { scrobbleDispatcher.dispatchAddToLibrary(any(), any()) } just runs
+        viewModel = ScrobbleViewModel(scrobbler, scrobbleDispatcher)
     }
 
     @Test
@@ -104,6 +111,41 @@ class ScrobbleViewModelTest {
         // Different episode should appear
         pendingFlow.emit(candidate2)
         assertNotNull(viewModel.pendingCandidate.value)
+    }
+
+    @Nested
+    @DisplayName("Unknown-show confirm (#468)")
+    inner class UnknownShowConfirmTest {
+
+        @Test
+        fun `confirmScrobble on unknown show calls dispatchAddToLibrary`() = runTest {
+            coEvery { scrobbler.autoScrobble(any()) } just runs
+
+            pendingFlow.emit(unknownCandidate)
+            viewModel.confirmScrobble()
+
+            coVerify(exactly = 1) { scrobbleDispatcher.dispatchAddToLibrary(unknownShow, testEpisode) }
+        }
+
+        @Test
+        fun `confirmScrobble on known show does not call dispatchAddToLibrary`() = runTest {
+            coEvery { scrobbler.autoScrobble(any()) } just runs
+
+            pendingFlow.emit(testCandidate)
+            viewModel.confirmScrobble()
+
+            coVerify(exactly = 0) { scrobbleDispatcher.dispatchAddToLibrary(any(), any()) }
+        }
+
+        @Test
+        fun `confirmScrobble on unknown show still calls autoScrobble`() = runTest {
+            coEvery { scrobbler.autoScrobble(any()) } just runs
+
+            pendingFlow.emit(unknownCandidate)
+            viewModel.confirmScrobble()
+
+            coVerify(exactly = 1) { scrobbler.autoScrobble(unknownCandidate) }
+        }
     }
 
     @Nested

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/scrobble/ScrobbleViewModelTest.kt
@@ -4,9 +4,9 @@ import com.justb81.watchbuddy.core.model.ScrobbleCandidate
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
-import com.justb81.watchbuddy.tv.MainDispatcherRule
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher
+import com.justb81.watchbuddy.tv.MainDispatcherRule
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -206,7 +206,10 @@ data class ScrobbleCandidate(
     val confidence: Float,              // 0.0–1.0
     val matchedShow: TraktShow? = null,
     val matchedEpisode: TraktEpisode? = null
-)
+) {
+    /** True when the cascade matched via TMDB but the show has no Trakt ID — not yet in the user's library. */
+    fun isUnknownShow(): Boolean = matchedShow?.ids?.trakt == null && matchedShow?.ids?.tmdb != null
+}
 
 /**
  * One stable string of evidence per session tick, plus the package name.
@@ -270,6 +273,13 @@ data class TitleExtractionResponse(
     val libraryTraktId: Int? = null,
     /** Self-reported, clamped to `[0.0, 1.0]` server-side. */
     val confidence: Float = 0f,
+)
+
+/** Request body for `POST /shows/add-to-library`. Shared between TV (client) and phone (server). */
+@Serializable
+data class PhoneAddToLibraryRequest(
+    val show: TraktShow,
+    val episode: TraktEpisode,
 )
 
 // ── Scrobble Display ─────────────────────────────────────────────────────────

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -503,7 +503,7 @@ class MediaSessionScrobbler @Inject constructor(
         _lastObservedSession.value = null
     }
 
-    private suspend fun processPlayingMedia(
+    internal suspend fun processPlayingMedia(
         snapshot: MediaMetadataSnapshot,
         sessionKey: String,
         progress: Float?,
@@ -520,7 +520,15 @@ class MediaSessionScrobbler @Inject constructor(
             }
             return
         }
-        if (candidate.confidence >= AUTO_SCROBBLE_THRESHOLD) {
+        val isUnknown = candidate.isUnknownShow()
+        if (isUnknown) {
+            DiagnosticLog.event(
+                TAG,
+                "unknown-show-detected: '${candidate.matchedShow?.title}' " +
+                    "tmdb=${candidate.matchedShow?.ids?.tmdb} confidence=${candidate.confidence}",
+            )
+        }
+        if (candidate.confidence >= AUTO_SCROBBLE_THRESHOLD && !isUnknown) {
             if (intent != null) {
                 playbackIntentProvider.recordHit()
                 playbackIntentProvider.consumeIntent(snapshot.packageName)

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/ScrobbleContracts.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/ScrobbleContracts.kt
@@ -34,6 +34,13 @@ interface ScrobbleDispatcher {
     suspend fun dispatchStart(show: TraktShow, episode: TraktEpisode, progress: Float)
     suspend fun dispatchPause(show: TraktShow, episode: TraktEpisode, progress: Float)
     suspend fun dispatchStop(show: TraktShow, episode: TraktEpisode, progress: Float)
+
+    /**
+     * Best-effort add of ([show], [episode]) to every connected user's Trakt history.
+     * Only called from the overlay-confirm path for unknown shows (TMDB-only match).
+     * Per-phone failures are logged and do not block other phones.
+     */
+    suspend fun dispatchAddToLibrary(show: TraktShow, episode: TraktEpisode)
 }
 
 /**

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerUnknownShowTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobblerUnknownShowTest.kt
@@ -1,0 +1,225 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import android.content.Context
+import com.justb81.watchbuddy.core.model.ScrobbleCandidate
+import com.justb81.watchbuddy.core.model.TmdbShow
+import com.justb81.watchbuddy.core.model.TmdbTvSearchResponse
+import com.justb81.watchbuddy.core.model.TraktEpisode
+import com.justb81.watchbuddy.core.model.TraktIds
+import com.justb81.watchbuddy.core.model.TraktShow
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.tmdb.TmdbApiService
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for issue #468: unknown-show detection and forced overlay.
+ *
+ * An "unknown show" is a candidate whose matchedShow has no Trakt ID but does have a TMDB ID —
+ * the result of the TMDB fallback cascade for a show not yet in the user's library.
+ */
+@DisplayName("MediaSessionScrobbler — Unknown-show detection (#468)")
+class MediaSessionScrobblerUnknownShowTest {
+
+    private val context: Context = mockk(relaxed = true)
+    private val tmdbApiService: TmdbApiService = mockk()
+    private val watchedShowSource: WatchedShowSource = mockk()
+    private val scrobbleDispatcher: ScrobbleDispatcher = mockk()
+    private lateinit var scrobbler: MediaSessionScrobbler
+
+    private val knownShow = TraktShow("Breaking Bad", 2008, TraktIds(trakt = 1, tmdb = 100))
+    private val testEpisode = TraktEpisode(season = 1, number = 1)
+
+    private val strangerThingsTmdb = TmdbShow(
+        id = 66732,
+        name = "Stranger Things",
+        first_air_date = "2016-07-15",
+    )
+    private val strangerThingsSearchResult = TmdbTvSearchResponse(
+        results = listOf(strangerThingsTmdb),
+    )
+
+    @BeforeEach
+    fun setUp() {
+        scrobbler = MediaSessionScrobbler(
+            context, tmdbApiService, watchedShowSource, scrobbleDispatcher, NoOpTitleExtractor
+        )
+        coEvery { scrobbleDispatcher.dispatchStart(any(), any(), any()) } just runs
+        coEvery { scrobbleDispatcher.dispatchStop(any(), any(), any()) } just runs
+        coEvery { watchedShowSource.getCachedShows() } returns emptyList()
+        coEvery { watchedShowSource.getTmdbApiKey() } returns null
+    }
+
+    // ── ScrobbleCandidate.isUnknownShow() ─────────────────────────────────────
+
+    @Nested
+    @DisplayName("ScrobbleCandidate.isUnknownShow()")
+    inner class IsUnknownShowTest {
+
+        @Test
+        fun `returns true when show has tmdb id but no trakt id`() {
+            val candidate = ScrobbleCandidate(
+                packageName = "com.plex.android",
+                mediaTitle = "Stranger Things",
+                confidence = 0.95f,
+                matchedShow = TraktShow("Stranger Things", 2016, TraktIds(tmdb = 66732)),
+                matchedEpisode = testEpisode,
+            )
+            assertTrue(candidate.isUnknownShow())
+        }
+
+        @Test
+        fun `returns false when show has both trakt and tmdb ids`() {
+            val candidate = ScrobbleCandidate(
+                packageName = "com.netflix.ninja",
+                mediaTitle = "Breaking Bad",
+                confidence = 0.95f,
+                matchedShow = TraktShow("Breaking Bad", 2008, TraktIds(trakt = 1, tmdb = 100)),
+                matchedEpisode = testEpisode,
+            )
+            assertFalse(candidate.isUnknownShow())
+        }
+
+        @Test
+        fun `returns false when show has only trakt id`() {
+            val candidate = ScrobbleCandidate(
+                packageName = "com.netflix.ninja",
+                mediaTitle = "Breaking Bad",
+                confidence = 0.95f,
+                matchedShow = TraktShow("Breaking Bad", 2008, TraktIds(trakt = 1)),
+                matchedEpisode = testEpisode,
+            )
+            assertFalse(candidate.isUnknownShow())
+        }
+
+        @Test
+        fun `returns false when matchedShow is null`() {
+            val candidate = ScrobbleCandidate(
+                packageName = "com.netflix.ninja",
+                mediaTitle = "Breaking Bad",
+                confidence = 0.50f,
+                matchedShow = null,
+                matchedEpisode = null,
+            )
+            assertFalse(candidate.isUnknownShow())
+        }
+
+        @Test
+        fun `returns false when show has no ids at all`() {
+            val candidate = ScrobbleCandidate(
+                packageName = "com.netflix.ninja",
+                mediaTitle = "Something",
+                confidence = 0.80f,
+                matchedShow = TraktShow("Something", null, TraktIds()),
+                matchedEpisode = testEpisode,
+            )
+            assertFalse(candidate.isUnknownShow())
+        }
+    }
+
+    // ── processPlayingMedia routing ───────────────────────────────────────────
+
+    @Nested
+    @DisplayName("processPlayingMedia — unknown show routes to overlay")
+    inner class UnknownShowRoutingTest {
+
+        @Test
+        fun `unknown show at AUTO_SCROBBLE_THRESHOLD does not call dispatchStart`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns emptyList()
+            coEvery { watchedShowSource.getTmdbApiKey() } returns "tmdb-key"
+            coEvery { tmdbApiService.searchTv(any(), "tmdb-key") } returns strangerThingsSearchResult
+
+            val snapshot = snapshotOf("com.plex.android", "title" to "Stranger Things S01E01")
+            scrobbler.processPlayingMedia(snapshot, "com.plex.android:Stranger Things S01E01", progress = 50f)
+
+            // TMDB-only candidate (unknown show) must NOT auto-scrobble regardless of confidence.
+            coVerify(exactly = 0) { scrobbleDispatcher.dispatchStart(any(), any(), any()) }
+        }
+
+        @Test
+        fun `known show at AUTO_SCROBBLE_THRESHOLD auto-scrobbles as before`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns listOf(TraktWatchedEntry(show = knownShow))
+            coEvery { watchedShowSource.getShowHint(any()) } returns null
+
+            val snapshot = snapshotOf("com.netflix.ninja", "title" to "Breaking Bad S01E01")
+            scrobbler.processPlayingMedia(snapshot, "com.netflix.ninja:Breaking Bad S01E01", progress = 50f)
+
+            // Known show (has Trakt ID) at high confidence must still auto-scrobble.
+            coVerify(exactly = 1) { scrobbleDispatcher.dispatchStart(any(), any(), any()) }
+        }
+
+        @Test
+        fun `unknown show at OVERLAY_THRESHOLD sets lastCandidate with autoScrobbled=false`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns emptyList()
+            coEvery { watchedShowSource.getTmdbApiKey() } returns "tmdb-key"
+            coEvery { tmdbApiService.searchTv(any(), "tmdb-key") } returns strangerThingsSearchResult
+
+            val snapshot = snapshotOf("com.plex.android", "title" to "Stranger Things S01E01")
+            scrobbler.processPlayingMedia(snapshot, "com.plex.android:Stranger Things S01E01", progress = 50f)
+
+            val last = scrobbler.lastCandidate.value
+            assertNotNull(last)
+            assertFalse(last!!.autoScrobbled, "Unknown show must surface via overlay, not auto-scrobble")
+            assertTrue(last.candidate.isUnknownShow(), "Candidate must be an unknown show")
+        }
+
+        @Test
+        fun `unknown show below OVERLAY_THRESHOLD is ignored`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns emptyList()
+            coEvery { watchedShowSource.getTmdbApiKey() } returns "tmdb-key"
+            // Return a TMDB result with a very low fuzzy score.
+            coEvery { tmdbApiService.searchTv(any(), "tmdb-key") } returns TmdbTvSearchResponse(
+                results = listOf(TmdbShow(id = 12345, name = "ZZZTotallyDifferentXXX"))
+            )
+
+            val snapshot = snapshotOf("com.plex.android", "title" to "Stranger Things S01E01")
+            scrobbler.processPlayingMedia(snapshot, "com.plex.android:Stranger Things S01E01", progress = 50f)
+
+            coVerify(exactly = 0) { scrobbleDispatcher.dispatchStart(any(), any(), any()) }
+        }
+    }
+
+    // ── matchSnapshot — TMDB fallback path ───────────────────────────────────
+
+    @Nested
+    @DisplayName("matchSnapshot — TMDB fallback produces isUnknownShow() candidate")
+    inner class TmdbFallbackCandidateTest {
+
+        @Test
+        fun `TMDB fallback with empty library produces TMDB-only candidate`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns emptyList()
+            coEvery { watchedShowSource.getTmdbApiKey() } returns "tmdb-key"
+            coEvery { tmdbApiService.searchTv("Stranger Things", "tmdb-key") } returns
+                strangerThingsSearchResult
+
+            val snapshot = snapshotOf("com.plex.android", "title" to "Stranger Things S01E01")
+            val candidate = scrobbler.matchSnapshot(snapshot)
+
+            assertNotNull(candidate)
+            assertTrue(candidate!!.isUnknownShow(), "TMDB-fallback candidate must be an unknown show")
+        }
+
+        @Test
+        fun `library match produces known show candidate — isUnknownShow returns false`() = runTest {
+            coEvery { watchedShowSource.getCachedShows() } returns listOf(TraktWatchedEntry(show = knownShow))
+            coEvery { watchedShowSource.getShowHint(any()) } returns null
+
+            val snapshot = snapshotOf("com.netflix.ninja", "title" to "Breaking Bad S01E01")
+            val candidate = scrobbler.matchSnapshot(snapshot)
+
+            assertNotNull(candidate)
+            assertFalse(candidate!!.isUnknownShow(), "Library-matched candidate must not be an unknown show")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Unknown-show detection**: Added `ScrobbleCandidate.isUnknownShow()` — returns `true` when `matchedShow` has a TMDB ID but no Trakt ID (the result of the Phase 3 TMDB fallback for shows not yet in any user's library).
- **Force overlay**: `MediaSessionScrobbler.processPlayingMedia` now skips the auto-scrobble path for unknown shows even at ≥ 95% confidence, routing them through the overlay instead.
- **Add-to-library on confirm**: `ScrobbleViewModel.confirmScrobble()` calls `ScrobbleDispatcher.dispatchAddToLibrary(show, episode)` for unknown shows before `autoScrobble`. `TvScrobbleDispatcher` fans the call out to every connected phone in parallel via `POST /shows/add-to-library`. Per-phone failures are logged and do not block other phones.
- **Phone endpoint**: `CompanionHttpServer` handles `POST /shows/add-to-library` — calls `TraktApiService.addToHistory` with a `SyncHistoryBody` targeting the specific season/episode, then invalidates `ShowRepository` so the updated library is reflected immediately.
- **Session dedup**: `TvScrobbleDispatcher` keeps a `ConcurrentHashMap`-backed set of confirmed TMDB IDs; a second confirm for the same show within a session is a no-op.

## Files changed

| File | Change |
|------|--------|
| `core/model/Models.kt` | `isUnknownShow()` on `ScrobbleCandidate`; `PhoneAddToLibraryRequest` data class |
| `core/scrobbler/ScrobbleContracts.kt` | `dispatchAddToLibrary` added to `ScrobbleDispatcher` interface |
| `core/scrobbler/MediaSessionScrobbler.kt` | Force overlay for unknown shows; `processPlayingMedia` visibility → `internal` |
| `tv/scrobbler/TvScrobbleDispatcher.kt` | `dispatchAddToLibrary` implementation with session dedup |
| `tv/discovery/PhoneApiService.kt` | `addShowToLibrary` Retrofit endpoint |
| `tv/ui/scrobble/ScrobbleViewModel.kt` | Wires `ScrobbleDispatcher`; calls `dispatchAddToLibrary` on confirm |
| `phone/server/CompanionHttpServer.kt` | `POST /shows/add-to-library` route |

## Tests

- `MediaSessionScrobblerUnknownShowTest` (new, 8 tests): `isUnknownShow()` edge cases + `processPlayingMedia` routing + TMDB fallback candidate detection
- `TvScrobbleDispatcherTest` — `AddToLibraryTest` nested class (6 tests): fan-out, per-phone failure isolation, session dedup, no-TMDB-id guard, empty-phone-list no-op
- `CompanionHttpServerTest` — `AddToLibraryEndpoint` nested class (5 tests): 401/400/503 errors, success path, `showRepository.invalidateCache()` called
- `ScrobbleViewModelTest` — `UnknownShowConfirmTest` nested class (3 tests): `dispatchAddToLibrary` called for unknown show, not called for known show, `autoScrobble` still called

## Local pre-commit

Gradle checks skipped (no Android SDK in this environment) — CI is the real gate.

Closes #468

https://claude.ai/code/session_01T8BZDfTJ551h1HGnyBPFhA

---
_Generated by [Claude Code](https://claude.ai/code/session_01T8BZDfTJ551h1HGnyBPFhA)_