### PR TITLE
fix(tv): disable Watch Now button when no streaming provider is available

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -55,6 +55,7 @@ fun ShowDetailScreen(
     val nextEpisodeUi by viewModel.nextEpisode.collectAsState()
     val providerState by viewModel.providers.collectAsState()
     val deepLinks by viewModel.deepLinks.collectAsState()
+    val watchNowState by viewModel.watchNowState.collectAsState()
     val watchNowFocus = remember { FocusRequester() }
 
     LaunchedEffect(entry.show.ids.trakt) {
@@ -72,11 +73,6 @@ fun ShowDetailScreen(
 
     val imageUrl = nextEpisodeUi.stillUrl ?: TmdbImageHelper.poster(enriched.posterPath, TMDB_POSTER_WIDTH)
 
-    val topProviderDeepLink = viewModel.resolveTopProviderDeepLink()
-    val topProviderState = (providerState as? ProviderListUiState.Success)
-        ?.providers?.firstOrNull()
-        ?.let { deepLinks[it.providerId] }
-
     Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
         ShowDetailImagePanel(imageUrl, modifier = Modifier.align(Alignment.CenterStart))
         ShowDetailGradient()
@@ -85,13 +81,16 @@ fun ShowDetailScreen(
             nextEpisode = nextEpisodeUi,
             providerState = providerState,
             deepLinks = deepLinks,
-            topProviderDeepLinkState = topProviderState,
+            watchNowState = watchNowState,
             watchNowFocus = watchNowFocus,
             actions = ShowDetailActions(
                 onWatchNow = {
-                    val firstProvider = (providerState as? ProviderListUiState.Success)
-                        ?.providers?.firstOrNull()
-                    launchProvider(context, firstProvider, topProviderDeepLink)
+                    val state = watchNowState
+                    if (state is WatchNowState.Available) {
+                        val firstProvider = (providerState as? ProviderListUiState.Success)
+                            ?.providers?.firstOrNull()
+                        launchProvider(context, firstProvider, state.url)
+                    }
                 },
                 onProviderClick = { provider ->
                     val link = viewModel.onProviderSelected(provider, enriched)
@@ -195,7 +194,7 @@ private fun ShowDetailContent(
     nextEpisode: NextEpisodeUiState,
     providerState: ProviderListUiState,
     deepLinks: Map<Int, DeepLinkState>,
-    topProviderDeepLinkState: DeepLinkState?,
+    watchNowState: WatchNowState,
     watchNowFocus: FocusRequester,
     actions: ShowDetailActions,
     modifier: Modifier = Modifier,
@@ -240,7 +239,7 @@ private fun ShowDetailContent(
         Spacer(Modifier.height(8.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
             WatchNowButton(
-                deepLinkState = topProviderDeepLinkState,
+                state = watchNowState,
                 onClick = actions.onWatchNow,
                 focusRequester = watchNowFocus,
             )
@@ -259,12 +258,12 @@ private fun ShowDetailContent(
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun WatchNowButton(
-    deepLinkState: DeepLinkState?,
+    state: WatchNowState,
     onClick: () -> Unit,
     focusRequester: FocusRequester,
 ) {
-    when (deepLinkState) {
-        is DeepLinkState.Loading -> {
+    when (state) {
+        is WatchNowState.Loading -> {
             Button(
                 onClick = {},
                 enabled = false,
@@ -280,7 +279,7 @@ private fun WatchNowButton(
                 Text(text = stringResource(R.string.tv_watch_now), fontWeight = FontWeight.Bold)
             }
         }
-        is DeepLinkState.Available -> {
+        is WatchNowState.Available -> {
             Button(
                 onClick = onClick,
                 modifier = Modifier.focusRequester(focusRequester),
@@ -289,7 +288,7 @@ private fun WatchNowButton(
                 Text(text = stringResource(R.string.tv_watch_now), fontWeight = FontWeight.Bold)
             }
         }
-        is DeepLinkState.Unavailable -> {
+        is WatchNowState.Unavailable -> {
             Button(
                 onClick = {},
                 enabled = false,
@@ -299,13 +298,14 @@ private fun WatchNowButton(
                 Text(text = stringResource(R.string.tv_watch_now_unavailable), fontWeight = FontWeight.Bold)
             }
         }
-        null -> {
+        is WatchNowState.NoProvider -> {
             Button(
-                onClick = onClick,
+                onClick = {},
+                enabled = false,
                 modifier = Modifier.focusRequester(focusRequester),
                 colors = ButtonDefaults.colors(containerColor = MaterialTheme.colorScheme.primary),
             ) {
-                Text(text = stringResource(R.string.tv_watch_now), fontWeight = FontWeight.Bold)
+                Text(text = stringResource(R.string.tv_watch_now_no_provider), fontWeight = FontWeight.Bold)
             }
         }
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModel.kt
@@ -275,5 +275,4 @@ class ShowDetailViewModel @Inject constructor(
             else -> provider.tmdbPageUrl
         }
     }
-
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModel.kt
@@ -19,8 +19,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.Locale
 import javax.inject.Inject
@@ -43,6 +46,24 @@ sealed interface ProviderListUiState {
 
     /** Network or API error — the user can retry. */
     object Error : ProviderListUiState
+}
+
+/**
+ * Aggregated state for the "Watch Now" button derived from [ProviderListUiState] and
+ * the per-provider [DeepLinkState] map.
+ */
+sealed class WatchNowState {
+    /** Providers are still loading or the top provider's deep link is still resolving. */
+    object Loading : WatchNowState()
+
+    /** A usable JustWatch deep-link URL is available for the top provider. */
+    data class Available(val url: String) : WatchNowState()
+
+    /** The top provider resolved but JustWatch has no offer for this show/region. */
+    object Unavailable : WatchNowState()
+
+    /** No streaming providers are available (Empty or Error state). */
+    object NoProvider : WatchNowState()
 }
 
 /** Per-provider JustWatch deep link resolution state. */
@@ -84,6 +105,27 @@ class ShowDetailViewModel @Inject constructor(
 
     private val _deepLinks = MutableStateFlow<Map<Int, DeepLinkState>>(emptyMap())
     val deepLinks: StateFlow<Map<Int, DeepLinkState>> = _deepLinks.asStateFlow()
+
+    /**
+     * Aggregated "Watch Now" button state derived from [providers] and [deepLinks].
+     * Computed reactively — the UI observes this instead of deriving state from nullable fields.
+     */
+    val watchNowState: StateFlow<WatchNowState> = combine(_providers, _deepLinks) { providerState, deepLinks ->
+        when (providerState) {
+            is ProviderListUiState.Loading -> WatchNowState.Loading
+            is ProviderListUiState.Empty -> WatchNowState.NoProvider
+            is ProviderListUiState.Error -> WatchNowState.NoProvider
+            is ProviderListUiState.Success -> {
+                val topProvider = providerState.providers.firstOrNull()
+                    ?: return@combine WatchNowState.NoProvider
+                when (val linkState = deepLinks[topProvider.providerId]) {
+                    is DeepLinkState.Loading, null -> WatchNowState.Loading
+                    is DeepLinkState.Available -> WatchNowState.Available(linkState.url)
+                    is DeepLinkState.Unavailable -> WatchNowState.Unavailable
+                }
+            }
+        }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, WatchNowState.Loading)
 
     private val inFlight = mutableMapOf<DeepLinkKey, Deferred<String?>>()
 
@@ -234,14 +276,4 @@ class ShowDetailViewModel @Inject constructor(
         }
     }
 
-    /**
-     * Returns the JustWatch URL for the top-ranked provider (used by the "Watch now" button),
-     * or null when no deep link is resolved yet.
-     */
-    fun resolveTopProviderDeepLink(): String? {
-        val providerState = _providers.value as? ProviderListUiState.Success ?: return null
-        val topProvider = providerState.providers.firstOrNull() ?: return null
-        val linkState = _deepLinks.value[topProvider.providerId]
-        return (linkState as? DeepLinkState.Available)?.url
-    }
 }

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -64,6 +64,7 @@
     <!-- JustWatch deep links (#476) -->
     <string name="tv_provider_no_deep_link">Kein Deep Link</string>
     <string name="tv_watch_now_unavailable">Deep Link nicht verfügbar</string>
+    <string name="tv_watch_now_no_provider">Kein Anbieter verfügbar</string>
     <string name="tv_justwatch_attribution">Streaming-Daten von JustWatch</string>
     <!-- Diagnostics — streaming deep links (#476) -->
     <string name="tv_diagnostics_section_streaming_links">Streaming-Deep-Links</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -67,6 +67,7 @@
     <!-- JustWatch deep links (#476) -->
     <string name="tv_provider_no_deep_link">Sin enlace directo</string>
     <string name="tv_watch_now_unavailable">Enlace directo no disponible</string>
+    <string name="tv_watch_now_no_provider">Ningún proveedor disponible</string>
     <string name="tv_justwatch_attribution">Datos de streaming por JustWatch</string>
     <!-- Diagnostics — streaming deep links (#476) -->
     <string name="tv_diagnostics_section_streaming_links">Enlaces directos de streaming</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -67,6 +67,7 @@
     <!-- JustWatch deep links (#476) -->
     <string name="tv_provider_no_deep_link">Pas de lien direct</string>
     <string name="tv_watch_now_unavailable">Lien direct indisponible</string>
+    <string name="tv_watch_now_no_provider">Aucun fournisseur disponible</string>
     <string name="tv_justwatch_attribution">Données streaming par JustWatch</string>
     <!-- Diagnostics — streaming deep links (#476) -->
     <string name="tv_diagnostics_section_streaming_links">Liens directs streaming</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -64,6 +64,7 @@
     <!-- JustWatch deep links (#476) -->
     <string name="tv_provider_no_deep_link">No deep link</string>
     <string name="tv_watch_now_unavailable">Deep link unavailable</string>
+    <string name="tv_watch_now_no_provider">No provider available</string>
     <string name="tv_justwatch_attribution">Streaming data by JustWatch</string>
     <!-- Diagnostics — streaming deep links (#476) -->
     <string name="tv_diagnostics_section_streaming_links">Streaming deep links</string>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModelTest.kt
@@ -383,14 +383,75 @@ class ShowDetailViewModelTest {
     }
 
     @Nested
-    @DisplayName("resolveTopProviderDeepLink")
-    inner class ResolveTopProviderDeepLinkTest {
+    @DisplayName("watchNowState")
+    inner class WatchNowStateTest {
 
         @Test
-        fun `returns JustWatch URL for first provider in Success state`() = runTest {
+        fun `is Loading initially`() {
+            assertEquals(WatchNowState.Loading, viewModel.watchNowState.value)
+        }
+
+        @Test
+        fun `is Loading while providers are loading`() = runTest {
+            // providers StateFlow starts as Loading — no additional calls needed
+            assertEquals(WatchNowState.Loading, viewModel.watchNowState.value)
+        }
+
+        @Test
+        fun `is NoProvider when providers are Empty`() = runTest {
+            every { phoneDiscovery.getBestPhone() } returns makePhone("api-key")
+            coEvery {
+                watchProviders.getResolvedProviders(any(), any(), any(), any())
+            } returns (emptyList<ResolvedProvider>() to null)
+
+            viewModel.loadProviders(makeEntry())
+
+            assertEquals(WatchNowState.NoProvider, viewModel.watchNowState.value)
+        }
+
+        @Test
+        fun `is NoProvider when providers are Error`() = runTest {
+            every { phoneDiscovery.getBestPhone() } returns null
+
+            viewModel.loadProviders(makeEntry())
+
+            assertEquals(WatchNowState.NoProvider, viewModel.watchNowState.value)
+        }
+
+        @Test
+        fun `is NoProvider when provider list is empty after Success`() = runTest {
+            every { phoneDiscovery.getBestPhone() } returns makePhone("api-key")
+            coEvery {
+                watchProviders.getResolvedProviders(any(), any(), any(), any())
+            } returns (emptyList<ResolvedProvider>() to null)
+
+            viewModel.loadProviders(makeEntry())
+
+            assertEquals(WatchNowState.NoProvider, viewModel.watchNowState.value)
+        }
+
+        @Test
+        fun `is Loading when top provider deep link is still loading`() = runTest {
             val provider = makeProvider(providerId = 8)
             every { phoneDiscovery.getBestPhone() } returns makePhone("api-key")
-            coEvery { watchProviders.getResolvedProviders(100, any(), "api-key", false) } returns (listOf(provider) to null)
+            coEvery {
+                watchProviders.getResolvedProviders(100, any(), "api-key", false)
+            } returns (listOf(provider) to null)
+            // resolveDeepLink hangs so deep link stays Loading — don't call loadDeepLinks here
+
+            viewModel.loadProviders(makeEntry())
+
+            // providers = Success but deepLinks is empty → top provider has no entry → Loading
+            assertEquals(WatchNowState.Loading, viewModel.watchNowState.value)
+        }
+
+        @Test
+        fun `is Available when top provider deep link resolves`() = runTest {
+            val provider = makeProvider(providerId = 8)
+            every { phoneDiscovery.getBestPhone() } returns makePhone("api-key")
+            coEvery {
+                watchProviders.getResolvedProviders(100, any(), "api-key", false)
+            } returns (listOf(provider) to null)
             coEvery {
                 justWatchRepo.resolveDeepLink(100, 1, 2, 8, any(), "Test Show")
             } returns "https://www.netflix.com/watch/99"
@@ -398,25 +459,49 @@ class ShowDetailViewModelTest {
             viewModel.loadProviders(makeEntry())
             viewModel.loadDeepLinks(makeEntry())
 
-            assertEquals("https://www.netflix.com/watch/99", viewModel.resolveTopProviderDeepLink())
+            val state = viewModel.watchNowState.value
+            assertInstanceOf(WatchNowState.Available::class.java, state)
+            assertEquals("https://www.netflix.com/watch/99", (state as WatchNowState.Available).url)
         }
 
         @Test
-        fun `returns null when providers not in Success state`() {
-            assertNull(viewModel.resolveTopProviderDeepLink())
-        }
-
-        @Test
-        fun `returns null when deep link is Unavailable`() = runTest {
+        fun `is Unavailable when top provider deep link is Unavailable`() = runTest {
             val provider = makeProvider(providerId = 8)
             every { phoneDiscovery.getBestPhone() } returns makePhone("api-key")
-            coEvery { watchProviders.getResolvedProviders(100, any(), "api-key", false) } returns (listOf(provider) to null)
-            coEvery { justWatchRepo.resolveDeepLink(any(), any(), any(), any(), any(), any()) } returns null
+            coEvery {
+                watchProviders.getResolvedProviders(100, any(), "api-key", false)
+            } returns (listOf(provider) to null)
+            coEvery {
+                justWatchRepo.resolveDeepLink(any(), any(), any(), any(), any(), any())
+            } returns null
 
             viewModel.loadProviders(makeEntry())
             viewModel.loadDeepLinks(makeEntry())
 
-            assertNull(viewModel.resolveTopProviderDeepLink())
+            assertEquals(WatchNowState.Unavailable, viewModel.watchNowState.value)
+        }
+
+        @Test
+        fun `uses first provider when multiple providers exist`() = runTest {
+            val first = makeProvider(providerId = 8, name = "Netflix")
+            val second = makeProvider(providerId = 9, name = "Disney+")
+            every { phoneDiscovery.getBestPhone() } returns makePhone("api-key")
+            coEvery {
+                watchProviders.getResolvedProviders(100, any(), "api-key", false)
+            } returns (listOf(first, second) to null)
+            coEvery {
+                justWatchRepo.resolveDeepLink(100, 1, 2, 8, any(), "Test Show")
+            } returns "https://netflix.com/watch/1"
+            coEvery {
+                justWatchRepo.resolveDeepLink(100, 1, 2, 9, any(), "Test Show")
+            } returns "https://disneyplus.com/watch/1"
+
+            viewModel.loadProviders(makeEntry())
+            viewModel.loadDeepLinks(makeEntry())
+
+            val state = viewModel.watchNowState.value
+            assertInstanceOf(WatchNowState.Available::class.java, state)
+            assertEquals("https://netflix.com/watch/1", (state as WatchNowState.Available).url)
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the nullable `DeepLinkState?` parameter in `WatchNowButton` with a new `WatchNowState` sealed class (`Loading` / `Available` / `Unavailable` / `NoProvider`) derived reactively in `ShowDetailViewModel` via `combine(providers, deepLinks)`.
- The `null` catch-all that rendered the button enabled with no reachable URL is eliminated.
- New `NoProvider` state disables the button and shows a "No provider available" label when `ProviderListUiState` is `Empty` or `Error`.
- New string `tv_watch_now_no_provider` added to all 4 locale files (EN / DE / FR / ES).
- `ShowDetailContent` now accepts a non-nullable `WatchNowState`; `onWatchNow` only fires `launchProvider` when state is `Available`.
- `resolveTopProviderDeepLink()` removed — replaced by `watchNowState: StateFlow<WatchNowState>`.
- Unit tests added for all `WatchNowState` permutations in `ShowDetailViewModelTest`.

## Test plan

- [ ] ViewModel unit tests: `./gradlew :app-tv:testDebugUnitTest` — all `WatchNowState` permutations pass.
- [ ] Manual: open a niche show with no `flatrate` providers → button shows "No provider available" and is disabled/unfocusable.
- [ ] Manual: open a popular show on first load → button shows spinner during `Loading`, then enables once `Available`.
- [ ] Manual: show with providers but no JustWatch offers → button shows "Deep link unavailable" and is disabled.

> ⚠️ Gradle checks skipped locally (no Android SDK in this environment). CI (`Test & Build`) is the real gate.

Closes #496

https://claude.ai/code/session_01GrRJ7x4FhRPKffKXhivEDa

---
_Generated by [Claude Code](https://claude.ai/code/session_01GrRJ7x4FhRPKffKXhivEDa)_