### PR TITLE
fix(tv): make Watch Next permission-denied row open app settings

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -654,6 +654,7 @@ private fun WatchNextSection(countResult: WatchNextMetadataSource.CountResult?) 
             pluralStringResource(R.plurals.tv_diagnostics_value_watch_next_count, countResult.count, countResult.count) to
                 if (countResult.count > 0) Status.OK else Status.WARN
     }
+    val isPermissionDenied = countResult is WatchNextMetadataSource.CountResult.PermissionDenied
     Text(
         text = stringResource(R.string.tv_diagnostics_section_watch_next).uppercase(),
         fontSize = 14.sp,
@@ -664,7 +665,15 @@ private fun WatchNextSection(countResult: WatchNextMetadataSource.CountResult?) 
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
-        onClick = {},
+        onClick = {
+            if (isPermissionDenied) {
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.fromParts("package", context.packageName, null)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                runCatching { context.startActivity(intent) }
+            }
+        },
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
@@ -689,22 +698,14 @@ private fun WatchNextSection(countResult: WatchNextMetadataSource.CountResult?) 
                 }
                 Text(valueStr, fontSize = 13.sp, color = Color.White.copy(alpha = 0.7f))
             }
-            if (countResult is WatchNextMetadataSource.CountResult.PermissionDenied) {
+            if (isPermissionDenied) {
                 Spacer(Modifier.height(8.dp))
-                OutlinedButton(
-                    onClick = {
-                        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                            data = Uri.fromParts("package", context.packageName, null)
-                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                        }
-                        runCatching { context.startActivity(intent) }
-                    },
-                ) {
-                    Text(
-                        stringResource(R.string.tv_diagnostics_action_open_permissions),
-                        fontSize = 13.sp,
-                    )
-                }
+                Text(
+                    text = stringResource(R.string.tv_diagnostics_action_open_permissions),
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF90CAF9),
+                )
             }
         }
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -437,6 +437,8 @@ private fun statusColor(status: Status): Color = when (status) {
     Status.NEUTRAL -> Color.White.copy(alpha = 0.3f)
 }
 
+private val ActionHintColor = Color(0xFF90CAF9)
+
 @Composable
 private fun yesNoStr(value: Boolean): String =
     if (value) stringResource(R.string.tv_diagnostics_value_yes)
@@ -704,7 +706,7 @@ private fun WatchNextSection(countResult: WatchNextMetadataSource.CountResult?) 
                     text = stringResource(R.string.tv_diagnostics_action_open_permissions),
                     fontSize = 13.sp,
                     fontWeight = FontWeight.Bold,
-                    color = Color(0xFF90CAF9),
+                    color = ActionHintColor,
                 )
             }
         }


### PR DESCRIPTION
## Summary

Fixes a TV Diagnostics bug where the "Open app permissions" CTA on the red "Watch Next provider" row did nothing when pressed. Reported by user: *"Im debug screen passiert auch nichts, wenn ich auf die Box versuche zu drücken — da öffnen sich keine app Berechtigungen."*

## Root cause

`WatchNextSection` wrapped the row in an `androidx.tv.material3.Card` with `onClick = {}` and placed an `OutlinedButton` inside. On Compose for TV, a `Card` with a non-null `onClick` becomes the focusable target for that row — D-pad center invokes the empty lambda (no-op) and focus never traverses into the inner button, so the CTA is unreachable.

## Change

In `app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt` (`WatchNextSection`):

- Move the `Settings.ACTION_APPLICATION_DETAILS_SETTINGS` intent into the parent `Card`'s `onClick`, gated on `PermissionDenied`. The whole red Card is now the click target — matching the user's mental model and the standard TV one-focusable-target-per-row pattern.
- Replace the unreachable inner `OutlinedButton` with a styled `Text` line that keeps the localized CTA copy visible as a label inside the focused Card.
- Other Card states stay no-op (consistent with the rest of this informational screen).

Permission request, manifest entry, and `resetPermissionState()` plumbing on `ON_RESUME` already worked — users just couldn't reach the CTA to trigger the system settings flow.

## Out of scope

- The same `Card(onClick = {})` + inner `OutlinedButton` shape exists in `StreamingLinksSection` ("Clear cache"). The branch name and user report scope this PR to Watch Next; the JustWatch button is a separate follow-up.
- On firmware that does not auto-grant `READ_TV_LISTINGS` to user-installed apps (`signature|privileged|appop`), this CTA is the only manual-grant path. If the system permissions screen also hides the toggle, the platform constraint cannot be solved in app code.

## Test plan

- [ ] CI `Test & Build` is green (Gradle scope was skipped locally — no Android SDK in the sandbox, per CLAUDE.md).
- [ ] On a TV device where `READ_TV_LISTINGS` is denied, navigate to Diagnostics → Watch Next provider; the row shows the red FAIL dot and the inline "Open app permissions" label.
- [ ] D-pad center on the focused Card opens the system app-details settings page for `com.justb81.watchbuddy`.
- [ ] After granting (where the system allows it) and pressing Back, `ON_RESUME` re-runs `refreshWatchNextStats()` and the row flips to green / yellow.

Closes the user-reported bug on branch `claude/fix-watch-next-permissions-V1nlb`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WBT7a1qHHu6NPVFSRwHBEr)_