### PR TITLE
fix(tv): make Streaming Links "Clear cache" D-pad accessible

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -568,7 +568,7 @@ private fun StreamingDeepLinksSection(
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
-        onClick = {},
+        onClick = onClearCache,
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             listOf(
@@ -610,9 +610,12 @@ private fun StreamingDeepLinksSection(
                 }
             }
             Spacer(Modifier.height(8.dp))
-            OutlinedButton(onClick = onClearCache) {
-                Text(stringResource(R.string.tv_diagnostics_action_clear_streaming_cache), fontSize = 13.sp)
-            }
+            Text(
+                text = stringResource(R.string.tv_diagnostics_action_clear_streaming_cache),
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Bold,
+                color = ActionHintColor,
+            )
         }
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModelTest.kt
@@ -57,6 +57,9 @@ class TvDiagnosticsViewModelTest {
         coEvery { justWatchRepo.count() } returns 0
         coEvery { justWatchRepo.negativeCount() } returns 0
         coEvery { justWatchRepo.lastFetchedAt() } returns null
+        coEvery { justWatchRepo.clearAll() } returns Unit
+        every { justWatchRepo.lastFetchError() } returns null
+        every { justWatchRepo.searchMissCount() } returns 0
         every { watchNextSource.countPublishingApps() } returns WatchNextMetadataSource.CountResult.Success(0)
     }
 
@@ -172,5 +175,21 @@ class TvDiagnosticsViewModelTest {
         advanceUntilIdle()
 
         assertEquals(1, vm.uiState.value.notificationTrackedCount)
+    }
+
+    @Test
+    fun `clearJustWatchCache clears repo and resets cache stats to zero`() = runTest {
+        coEvery { justWatchRepo.count() } returnsMany listOf(5, 0)
+        coEvery { justWatchRepo.negativeCount() } returnsMany listOf(3, 0)
+        val vm = TvDiagnosticsViewModel(
+            application, phoneDiscovery, scrobbler, justWatchRepo, watchNextSource, notificationSource, NoOpPlaybackIntentProvider(),
+        )
+        advanceUntilIdle()
+
+        vm.clearJustWatchCache()
+        advanceUntilIdle()
+
+        assertEquals(0, vm.uiState.value.cachedDeepLinkCount)
+        assertEquals(0, vm.uiState.value.negativeDeepLinkCount)
     }
 }


### PR DESCRIPTION
## Summary

- Moves `clearJustWatchCache()` into the parent `Card`'s `onClick`, making the entire row the D-pad click target (consistent with the TV one-focusable-target-per-row pattern).
- Replaces the unreachable inner `OutlinedButton` with a styled `Text` using the existing `ActionHintColor` constant, keeping the "Clear cache" label visible inside the focused Card.
- Adds a unit test in `TvDiagnosticsViewModelTest` verifying that `clearJustWatchCache()` calls the repository and resets `cachedDeepLinkCount` / `negativeDeepLinkCount` to zero.

This is the identical bug class fixed for the Watch Next "Open app permissions" CTA in #512.

> **Note:** Android SDK not available in this sandbox — Gradle checks (tests / detekt / lint) were skipped locally. CI (`build-android.yml`) is the real gate.

## Test plan

- [ ] On a TV device, populate the JustWatch deep-link cache by opening a few show detail screens.
- [ ] Open Settings → Diagnostics → Streaming Links section.
- [ ] D-pad center on the focused Card clears the cache (`cachedCount` and `negativeCount` drop to 0; `Last fetch` resets).
- [ ] Focus traversal works: the Card shows the standard TV focus glow.
- [ ] Unit test `clearJustWatchCache clears repo and resets cache stats to zero` passes.

Closes #514

https://claude.ai/code/session_01Jm3bFZ4iCKuLeMzVVsyrFq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jm3bFZ4iCKuLeMzVVsyrFq)_