### PR TITLE
fix(tv): stop diagnostics cards from clipping on D-pad focus

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -162,10 +162,12 @@ fun TvDiagnosticsScreen(
 
             if (uiState.phones.isEmpty()) {
                 item {
-                    Card(
+                    Surface(
                         modifier = Modifier.fillMaxWidth(),
-                        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
-                        onClick = {},
+                        shape = RoundedCornerShape(12.dp),
+                        colors = SurfaceDefaults.colors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        ),
                     ) {
                         Text(
                             text = stringResource(R.string.tv_diagnostics_value_no_phones),
@@ -244,10 +246,12 @@ fun TvDiagnosticsScreen(
 
             if (uiState.recentEvents.isEmpty()) {
                 item {
-                    Card(
+                    Surface(
                         modifier = Modifier.fillMaxWidth(),
-                        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
-                        onClick = {},
+                        shape = RoundedCornerShape(12.dp),
+                        colors = SurfaceDefaults.colors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                        ),
                     ) {
                         Text(
                             text = stringResource(R.string.tv_diagnostics_value_no_events),
@@ -275,10 +279,12 @@ fun TvDiagnosticsScreen(
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
 private fun PhoneDiagnosticsCard(phone: PhoneDiscoveryManager.DiscoveredPhone) {
-    Card(
+    Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
-        onClick = {},
+        shape = RoundedCornerShape(12.dp),
+        colors = SurfaceDefaults.colors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
@@ -346,10 +352,12 @@ private fun RecentEventRow(entry: DiagnosticLog.Entry) {
         DiagnosticLog.Level.ERROR -> Status.FAIL
     }
     val message = entry.throwableSummary?.let { "${entry.message} → $it" } ?: entry.message
-    Card(
+    Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
-        onClick = {},
+        shape = RoundedCornerShape(12.dp),
+        colors = SurfaceDefaults.colors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
     ) {
         Row(
             modifier = Modifier
@@ -395,10 +403,12 @@ private fun DiagnosticsSection(title: String, rows: List<DiagRow>) {
         color = Color.White.copy(alpha = 0.7f),
         modifier = Modifier.padding(top = 8.dp, bottom = 4.dp, start = 4.dp),
     )
-    Card(
+    Surface(
         modifier = Modifier.fillMaxWidth(),
-        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
-        onClick = {},
+        shape = RoundedCornerShape(12.dp),
+        colors = SurfaceDefaults.colors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+        ),
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             rows.forEach { row ->
@@ -568,6 +578,7 @@ private fun StreamingDeepLinksSection(
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
+        scale = CardDefaults.scale(focusedScale = 1.02f),
         onClick = onClearCache,
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
@@ -667,19 +678,9 @@ private fun WatchNextSection(countResult: WatchNextMetadataSource.CountResult?) 
         color = Color.White.copy(alpha = 0.7f),
         modifier = Modifier.padding(top = 8.dp, bottom = 4.dp, start = 4.dp),
     )
-    Card(
-        modifier = Modifier.fillMaxWidth(),
-        shape = CardDefaults.shape(RoundedCornerShape(12.dp)),
-        onClick = {
-            if (isPermissionDenied) {
-                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-                    data = Uri.fromParts("package", context.packageName, null)
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
-                runCatching { context.startActivity(intent) }
-            }
-        },
-    ) {
+    val cardModifier = Modifier.fillMaxWidth()
+    val cardShape = RoundedCornerShape(12.dp)
+    val cardContent: @Composable () -> Unit = {
         Column(modifier = Modifier.padding(16.dp)) {
             Row(
                 modifier = Modifier
@@ -713,6 +714,28 @@ private fun WatchNextSection(countResult: WatchNextMetadataSource.CountResult?) 
                 )
             }
         }
+    }
+    if (isPermissionDenied) {
+        Card(
+            modifier = cardModifier,
+            shape = CardDefaults.shape(cardShape),
+            scale = CardDefaults.scale(focusedScale = 1.02f),
+            onClick = {
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.fromParts("package", context.packageName, null)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                }
+                runCatching { context.startActivity(intent) }
+            },
+        ) { cardContent() }
+    } else {
+        Surface(
+            modifier = cardModifier,
+            shape = cardShape,
+            colors = SurfaceDefaults.colors(
+                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+            ),
+        ) { cardContent() }
     }
 }
 


### PR DESCRIPTION
## Summary

- The TV Diagnostics sections were rendered as `Card(onClick = {})` (no-op clicks) purely to get a rounded-corner container. Every informational row therefore became D-pad focusable and ran the default `CardDefaults.scale()` focus animation (~1.1×), which overshoots the screen's 48 dp horizontal padding and clips the focused card past the TV bezel.
- The five purely-informational containers (`DiagnosticsSection`, `PhoneDiagnosticsCard`, `RecentEventRow`, empty placeholders) now use a non-clickable `Surface` — they no longer take focus, can't scale, and can't clip. `surfaceVariant` is set explicitly so the rendered color matches the previous Card.
- The two genuinely actionable cards (`StreamingDeepLinksSection` "Clear cache", `WatchNextSection` permission-denied row that opens app-details settings) keep `Card(onClick = …)` but now cap the focus scale to `1.02f`, matching `TvSettingsScreen.kt:313`. `WatchNextSection` becomes a passive `Surface` when the permission is already granted — no focusable target without an action.

Reproduction (de-DE): Settings → Diagnose → D-pad over "Jetzt läuft" — the highlighted card visibly grew past the TV's left/right edges. After the fix, those rows don't focus at all; only `Streaming Links` and (when permission is denied) `Watch Next` focus, and they scale subtly within the safe area.

Pre-commit note: ran in a sandboxed Claude Code environment without the Android SDK, so `scripts/precommit.sh` skipped the Gradle scope (per `CLAUDE.md`'s documented behavior). CI's `Test & Build` is the real gate.

## Test plan

- [ ] CI `Test & Build` (detekt + Android Lint + unit tests) passes green
- [ ] On a Google TV / Android TV device or emulator, open Settings → Diagnostics and D-pad through every section in `en` and `de` locales
- [ ] Confirm the informational sections (Discovery, BLE, Scrobble, Now Playing, Media Session, Build, Media Notifications, App Profiles, Ambiguous Prompts, Intent Stats, Recent Events, phone status) no longer take focus and don't visually grow
- [ ] Confirm `Streaming Links` still focuses, scales subtly, and triggers Clear cache on D-pad center
- [ ] Confirm `Watch Next` only focuses when `READ_TV_LISTINGS` is denied and activating it opens the system app-details screen; when granted it is passive

https://claude.ai/code/session_017NAkSj8eHWdDS4Zkvgr8rC

---
_Generated by [Claude Code](https://claude.ai/code/session_017NAkSj8eHWdDS4Zkvgr8rC)_