### PR TITLE
fix(tv): surface JustWatch HTTP errors and add browser-like headers

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
@@ -2,6 +2,7 @@ package com.justb81.watchbuddy.tv.data
 
 import com.justb81.watchbuddy.core.justwatch.JustWatchApiService
 import com.justb81.watchbuddy.core.justwatch.JustWatchGraphQlRequest
+import com.justb81.watchbuddy.core.justwatch.JustWatchGraphQlResponse
 import com.justb81.watchbuddy.core.justwatch.JustWatchOffer
 import com.justb81.watchbuddy.core.justwatch.JustWatchPackageMap
 import com.justb81.watchbuddy.core.justwatch.JustWatchTitle
@@ -11,6 +12,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import retrofit2.Response
 import java.util.ArrayDeque
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -21,6 +23,7 @@ private const val TAG = "JustWatchRepo"
 private val COUNTRY_CODE_REGEX = Regex("[A-Z]{2}")
 private const val DEFAULT_MISS_WINDOW_MS = 24L * 60 * 60 * 1_000
 private const val MAX_ERROR_SUMMARY_LENGTH = 200
+private const val MAX_HTTP_ERROR_BODY_LENGTH = 500
 
 /**
  * Resolves JustWatch per-episode deep links with a persistent Room cache.
@@ -54,6 +57,9 @@ class JustWatchDeepLinkRepository @Inject constructor(
 
         /** The API returned a top-level GraphQL errors array. */
         data class GraphQlError(val summary: String) : SearchResult()
+
+        /** The API returned a non-2xx HTTP status (typically 422 from JustWatch). */
+        data class HttpError(val code: Int, val bodySummary: String) : SearchResult()
     }
 
     private data class FetchKey(
@@ -192,6 +198,12 @@ class JustWatchDeepLinkRepository @Inject constructor(
         try {
             val language = "en"
             when (val result = searchShowByTmdbId(tmdbShowId, showTitle, countryCode, language)) {
+                is SearchResult.HttpError -> {
+                    val msg = "HTTP ${result.code} searching '$showTitle' (tmdb=$tmdbShowId): ${result.bodySummary}"
+                    DiagnosticLog.error(TAG, msg)
+                    recordError(msg)
+                    return
+                }
                 is SearchResult.GraphQlError -> {
                     val msg = "GraphQL error searching '$showTitle' (tmdb=$tmdbShowId): ${result.summary}"
                     DiagnosticLog.error(TAG, msg)
@@ -238,13 +250,12 @@ class JustWatchDeepLinkRepository @Inject constructor(
                 },
             )
         )
-        if (!seasonsResp.errors.isNullOrEmpty()) {
-            val msg = "GraphQL errors in seasons query for tmdbId=$tmdbShowId"
-            DiagnosticLog.error(TAG, msg)
-            recordError(msg)
-            return
-        }
-        val jwSeasons = seasonsResp.data?.node?.seasons
+        val seasonsBody = unwrapBodyOrLog(
+            seasonsResp,
+            queryName = "seasons",
+            context = "tmdbId=$tmdbShowId",
+        ) ?: return
+        val jwSeasons = seasonsBody.data?.node?.seasons
         if (jwSeasons.isNullOrEmpty()) {
             DiagnosticLog.warn(TAG, "Empty seasons list for tmdbId=$tmdbShowId")
             return
@@ -265,13 +276,12 @@ class JustWatchDeepLinkRepository @Inject constructor(
                 },
             )
         )
-        if (!episodesResp.errors.isNullOrEmpty()) {
-            val msg = "GraphQL errors in episodes query for tmdbId=$tmdbShowId S$season"
-            DiagnosticLog.error(TAG, msg)
-            recordError(msg)
-            return
-        }
-        val jwEpisodes = episodesResp.data?.node?.episodes
+        val episodesBody = unwrapBodyOrLog(
+            episodesResp,
+            queryName = "episodes",
+            context = "tmdbId=$tmdbShowId S$season",
+        ) ?: return
+        val jwEpisodes = episodesBody.data?.node?.episodes
         if (jwEpisodes.isNullOrEmpty()) {
             DiagnosticLog.warn(TAG, "Empty episodes list for tmdbId=$tmdbShowId S$season")
             return
@@ -285,6 +295,43 @@ class JustWatchDeepLinkRepository @Inject constructor(
         }
     }
 
+    /**
+     * Inspects a [Response] for a follow-up GraphQL query (seasons / episodes).
+     *
+     * Logs and records the error for non-2xx HTTP responses (e.g. 422), null bodies,
+     * and top-level GraphQL `errors[]` arrays. Returns the response body on success,
+     * or null when the caller should bail out (the negative-cache policy is unchanged
+     * — these errors do not produce negative entries, so the next visit retries).
+     */
+    private fun unwrapBodyOrLog(
+        response: Response<JustWatchGraphQlResponse>,
+        queryName: String,
+        context: String,
+    ): JustWatchGraphQlResponse? {
+        if (!response.isSuccessful) {
+            val body = readErrorBody(response)
+            val msg = "HTTP ${response.code()} from JustWatch $queryName query ($context): $body"
+            DiagnosticLog.error(TAG, msg)
+            recordError(msg)
+            return null
+        }
+        val body = response.body()
+        if (body == null) {
+            val msg = "Empty $queryName response body from JustWatch ($context)"
+            DiagnosticLog.error(TAG, msg)
+            recordError(msg)
+            return null
+        }
+        if (!body.errors.isNullOrEmpty()) {
+            val summary = body.errors.toString().take(MAX_ERROR_SUMMARY_LENGTH)
+            val msg = "GraphQL errors in $queryName query ($context): $summary"
+            DiagnosticLog.error(TAG, msg)
+            recordError(msg)
+            return null
+        }
+        return body
+    }
+
     private suspend fun fetchAndCacheShowOffers(
         tmdbShowId: Int,
         countryCode: String,
@@ -292,6 +339,11 @@ class JustWatchDeepLinkRepository @Inject constructor(
     ) {
         try {
             when (val result = searchShowByTmdbId(tmdbShowId, showTitle, countryCode, "en")) {
+                is SearchResult.HttpError -> {
+                    val msg = "HTTP ${result.code} searching '$showTitle' (tmdb=$tmdbShowId, show-level): ${result.bodySummary}"
+                    DiagnosticLog.error(TAG, msg)
+                    recordError(msg)
+                }
                 is SearchResult.GraphQlError -> {
                     val msg = "GraphQL error searching '$showTitle' (tmdb=$tmdbShowId): ${result.summary}"
                     DiagnosticLog.error(TAG, msg)
@@ -333,15 +385,27 @@ class JustWatchDeepLinkRepository @Inject constructor(
                 },
             )
         )
-        if (!response.errors.isNullOrEmpty()) {
-            val summary = response.errors.toString().take(MAX_ERROR_SUMMARY_LENGTH)
+        if (!response.isSuccessful) {
+            return SearchResult.HttpError(response.code(), readErrorBody(response))
+        }
+        val body = response.body() ?: return SearchResult.HttpError(response.code(), "Empty response body")
+        if (!body.errors.isNullOrEmpty()) {
+            val summary = body.errors.toString().take(MAX_ERROR_SUMMARY_LENGTH)
             return SearchResult.GraphQlError(summary)
         }
-        val match = response.data?.popularTitles?.edges
+        val match = body.data?.popularTitles?.edges
             ?.map { it.node }
             ?.firstOrNull { node -> node.content?.externalIds?.tmdbId == tmdbShowId.toString() }
         return if (match != null) SearchResult.Found(match) else SearchResult.SearchMiss
     }
+
+    /** Reads up to [MAX_HTTP_ERROR_BODY_LENGTH] chars from a Retrofit error body. */
+    private fun readErrorBody(response: Response<*>): String =
+        try {
+            response.errorBody()?.string()?.take(MAX_HTTP_ERROR_BODY_LENGTH).orEmpty()
+        } catch (e: Exception) {
+            "<failed to read error body: ${e.javaClass.simpleName}>"
+        }
 
     /** Converts JustWatch offer list to Room entries and upserts them. */
     private suspend fun cacheOffers(

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
@@ -320,8 +320,12 @@ class JustWatchDeepLinkRepositoryTest {
         @Test
         fun `records HTTP status and error body on HTTP 422 from search`() = runTest {
             coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
-            coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } returns
+            // `answers { ... }` returns a fresh Response on each invocation: the
+            // episode-level cascade also calls the show-level fallback, and a
+            // single ResponseBody.string() can only be consumed once.
+            coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } answers {
                 makeHttpErrorResponse(422, """{"message":"unauthenticated request"}""")
+            }
 
             repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
 

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
@@ -23,13 +23,17 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @DisplayName("JustWatchDeepLinkRepository")
@@ -53,17 +57,19 @@ class JustWatchDeepLinkRepositoryTest {
         tmdbId: String = "100",
         nodeId: String = "show-123",
         offers: List<JustWatchOffer> = emptyList(),
-    ) = JustWatchGraphQlResponse(
-        data = JustWatchData(
-            popularTitles = JustWatchTitleConnection(
-                edges = listOf(
-                    JustWatchTitleEdge(
-                        node = JustWatchTitle(
-                            id = nodeId,
-                            offers = offers,
-                            content = JustWatchContent(
-                                externalIds = JustWatchExternalIds(tmdbId = tmdbId)
-                            ),
+    ): Response<JustWatchGraphQlResponse> = Response.success(
+        JustWatchGraphQlResponse(
+            data = JustWatchData(
+                popularTitles = JustWatchTitleConnection(
+                    edges = listOf(
+                        JustWatchTitleEdge(
+                            node = JustWatchTitle(
+                                id = nodeId,
+                                offers = offers,
+                                content = JustWatchContent(
+                                    externalIds = JustWatchExternalIds(tmdbId = tmdbId)
+                                ),
+                            )
                         )
                     )
                 )
@@ -71,28 +77,41 @@ class JustWatchDeepLinkRepositoryTest {
         )
     )
 
-    private fun makeGraphQlErrorResponse(message: String = "Field not found") =
-        JustWatchGraphQlResponse(
-            data = null,
-            errors = buildJsonArray {
-                add(buildJsonObject { put("message", message) })
-            },
+    private fun makeGraphQlErrorResponse(message: String = "Field not found"): Response<JustWatchGraphQlResponse> =
+        Response.success(
+            JustWatchGraphQlResponse(
+                data = null,
+                errors = buildJsonArray {
+                    add(buildJsonObject { put("message", message) })
+                },
+            )
         )
 
-    private fun makeSeasonsResponse(seasonIds: List<String> = listOf("season-1-id")) =
+    private fun makeSeasonsResponse(
+        seasonIds: List<String> = listOf("season-1-id"),
+    ): Response<JustWatchGraphQlResponse> = Response.success(
         JustWatchGraphQlResponse(
             data = JustWatchData(
                 node = JustWatchNode(seasons = seasonIds.map { JustWatchSeasonRef(id = it) })
             )
         )
+    )
 
     private fun makeEpisodesResponse(
         episodes: List<JustWatchEpisode>,
-    ) = JustWatchGraphQlResponse(
-        data = JustWatchData(
-            node = JustWatchNode(episodes = episodes)
+    ): Response<JustWatchGraphQlResponse> = Response.success(
+        JustWatchGraphQlResponse(
+            data = JustWatchData(
+                node = JustWatchNode(episodes = episodes)
+            )
         )
     )
+
+    private fun makeHttpErrorResponse(
+        code: Int,
+        bodyJson: String = """{"message":"unauthenticated"}""",
+    ): Response<JustWatchGraphQlResponse> =
+        Response.error(code, bodyJson.toResponseBody("application/json".toMediaType()))
 
     private fun makeOffer(
         url: String = "https://www.netflix.com/watch/99",
@@ -148,7 +167,7 @@ class JustWatchDeepLinkRepositoryTest {
             coEvery { dao.get(100, 0, 0, 8, "US") } returns null
 
             // API returns no results
-            coEvery { api.query(any()) } returns JustWatchGraphQlResponse(data = null)
+            coEvery { api.query(any()) } returns Response.success(JustWatchGraphQlResponse(data = null))
 
             val result = repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
 
@@ -288,6 +307,50 @@ class JustWatchDeepLinkRepositoryTest {
         }
 
         @Test
+        fun `does not cache negatives on HTTP 422 from search`() = runTest {
+            coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
+            coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } returns
+                makeHttpErrorResponse(422, """{"message":"unauthenticated request"}""")
+
+            repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
+
+            coVerify(exactly = 0) { dao.upsert(any()) }
+        }
+
+        @Test
+        fun `records HTTP status and error body on HTTP 422 from search`() = runTest {
+            coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
+            coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } returns
+                makeHttpErrorResponse(422, """{"message":"unauthenticated request"}""")
+
+            repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
+
+            val lastError = repository.lastFetchError()
+            assertNotNull(lastError)
+            assertTrue(lastError!!.contains("422"), "expected '422' in error: $lastError")
+            assertTrue(
+                lastError.contains("unauthenticated"),
+                "expected error body summary in error: $lastError",
+            )
+        }
+
+        @Test
+        fun `does not cache episode-level negatives on HTTP 422 from seasons query`() = runTest {
+            coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
+            coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } returns
+                makeSearchResponse()
+            coEvery { api.query(match { it.query == JustWatchApiService.SEASONS_QUERY }) } returns
+                makeHttpErrorResponse(422)
+
+            repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
+
+            // No episode-level negatives — HTTP error is not a confirmed miss
+            coVerify(exactly = 0) {
+                dao.upsert(match { it.season == 1 && it.episode == 2 && it.standardWebUrl == null })
+            }
+        }
+
+        @Test
         fun `does not cache episode-level negatives on GraphQL errors in seasons response`() = runTest {
             coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
             coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } returns
@@ -369,7 +432,7 @@ class JustWatchDeepLinkRepositoryTest {
             coEvery { dao.get(100, 1, 2, 8, "US") } returns null
             coEvery { dao.get(100, 0, 0, 8, "US") } returns null
 
-            coEvery { api.query(any()) } returns JustWatchGraphQlResponse(data = null)
+            coEvery { api.query(any()) } returns Response.success(JustWatchGraphQlResponse(data = null))
 
             repository.resolveDeepLink(100, 1, 2, 8, "INVALID", "Breaking Bad")
 

--- a/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchApiService.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchApiService.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.core.justwatch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 
@@ -12,11 +13,15 @@ import retrofit2.http.POST
  * Base URL: https://apis.justwatch.com/
  * All requests POST to the single /graphql endpoint.
  * TV-direct — the phone is never involved.
+ *
+ * Returns the raw [Response] so callers can read the error body on non-2xx
+ * responses (JustWatch's GraphQL endpoint frequently returns HTTP 422 with a
+ * descriptive payload when a request looks unidentified or malformed).
  */
 interface JustWatchApiService {
 
     @POST("graphql")
-    suspend fun query(@Body request: JustWatchGraphQlRequest): JustWatchGraphQlResponse
+    suspend fun query(@Body request: JustWatchGraphQlRequest): Response<JustWatchGraphQlResponse>
 
     companion object {
 

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
@@ -19,6 +19,7 @@ import javax.inject.Named
 import javax.inject.Singleton
 
 private const val JUSTWATCH_TIMEOUT_SECONDS = 5L
+private const val JUSTWATCH_USER_AGENT = "Mozilla/5.0 (Linux; Android 14) WatchBuddy"
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -94,6 +95,10 @@ object NetworkModule {
      * TV-direct — the phone is never involved. Short timeout keeps the detail
      * screen from hanging on slow connections; cache absorbs most latency after
      * the first visit.
+     *
+     * Injects browser-like headers because JustWatch's unofficial GraphQL endpoint
+     * returns HTTP 422 for requests that look unidentified (no User-Agent / Origin /
+     * Referer). See issue #511.
      */
     @Provides
     @Singleton
@@ -101,6 +106,16 @@ object NetworkModule {
     fun provideJustWatchOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
         .connectTimeout(JUSTWATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .readTimeout(JUSTWATCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .addInterceptor { chain ->
+            val request = chain.request().newBuilder()
+                .header("User-Agent", JUSTWATCH_USER_AGENT)
+                .header("Accept", "application/json")
+                .header("Accept-Language", "en-US,en;q=0.9")
+                .header("Origin", "https://www.justwatch.com")
+                .header("Referer", "https://www.justwatch.com/")
+                .build()
+            chain.proceed(request)
+        }
         .build()
 
     @Provides


### PR DESCRIPTION
## Summary

Two changes ship together to fix the JustWatch HTTP 422 deep-link blackout reported in #511:

1. **Diagnostics — surface the 422 body.** `JustWatchApiService.query()` now returns `retrofit2.Response<JustWatchGraphQlResponse>`. `JustWatchDeepLinkRepository` inspects `isSuccessful`, reads up to 500 chars of `errorBody()`, logs via `DiagnosticLog.error`, and calls `recordError(...)` so the HTTP status plus body summary surfaces in TV Diagnostics → Streaming Links → "Last fetch error". Non-2xx is treated identically to a top-level GraphQL `errors[]` array — no negative cache entries are written, so the next visit retries.

2. **Fix — browser-like headers.** The dedicated JustWatch `OkHttpClient` in `NetworkModule` now injects `User-Agent`, `Accept`, `Accept-Language`, `Origin`, and `Referer` headers identifying the request as a JustWatch web origin. Prior art with unofficial JustWatch GraphQL clients indicates the 422 status is most often resolved by these headers; if 422 persists post-deploy, the new diagnostics will pinpoint the real cause without another speculative ship.

## Test plan

- [x] Unit tests updated: existing mocks wrapped in `Response.success(...)`; new tests cover `Response.error(422, ...)` on the search query (no negative cached, error message contains status + body) and on the seasons query (no episode-level negative cached).
- [ ] CI: `Test & Build` (`build-android.yml`) — Gradle scope skipped locally (sandbox without Android SDK), CI is the real gate.
- [ ] Real-device verification on Google TV: open Settings → Diagnostics → Streaming Links and confirm a non-zero cached count after browsing 2-3 shows; provider chips deep-link into the streaming app at the correct episode.

Closes #511

https://claude.ai/code/session_019wQop9PDYUVccEGUusivUq

---
_Generated by [Claude Code](https://claude.ai/code/session_019wQop9PDYUVccEGUusivUq)_