### PR TITLE
fix(backend): sanitize Trakt error bodies and cap JSON body size

### DIFF
--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -1315,3 +1315,161 @@ describe('Trust proxy', () => {
     expect(res.body.access_token).toBe('acc');
   });
 });
+
+// ── filterErrorResponse — sanitize Trakt error bodies (#551) ───────────────
+
+describe('filterErrorResponse — Trakt error bodies are sanitized before forwarding', () => {
+  let errorSpy;
+  let warnSpy;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('strips non-standard fields from a Trakt 4xx body on token exchange', async () => {
+    const app = buildApp(
+      mockFetch(403, {
+        error: 'invalid_api_key',
+        error_description: 'API key revoked',
+        rate_limit_remaining: 5,
+        account_id: 12345,
+        access_token: 'leaked-token',
+        debug_hint: 'internal-trakt-state',
+      })
+    );
+
+    const res = await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({
+      error: 'invalid_api_key',
+      error_description: 'API key revoked',
+    });
+    expect(res.body).not.toHaveProperty('rate_limit_remaining');
+    expect(res.body).not.toHaveProperty('account_id');
+    expect(res.body).not.toHaveProperty('access_token');
+    expect(res.body).not.toHaveProperty('debug_hint');
+  });
+
+  it('strips non-standard fields from a Trakt 4xx body on token refresh', async () => {
+    const app = buildApp(
+      mockFetch(401, {
+        error: 'invalid_token',
+        error_description: 'expired',
+        user_id: 99,
+        partial_access_token: 'leak',
+      })
+    );
+
+    const res = await request(app)
+      .post('/trakt/token/refresh')
+      .send({ refresh_token: 'expired-token' });
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({
+      error: 'invalid_token',
+      error_description: 'expired',
+    });
+    expect(res.body).not.toHaveProperty('user_id');
+    expect(res.body).not.toHaveProperty('partial_access_token');
+  });
+
+  it('returns an empty body when the Trakt error has no error / error_description', async () => {
+    const app = buildApp(mockFetch(500, { rate_limit_remaining: 0, internal_id: 'x' }));
+    const res = await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({});
+  });
+
+  it('drops non-string error / error_description fields', async () => {
+    const app = buildApp(mockFetch(400, { error: 42, error_description: { nested: 'object' } }));
+    const res = await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({});
+  });
+
+  it('still logs the full Trakt error body server-side at error level', async () => {
+    const app = buildApp(
+      mockFetch(403, {
+        error: 'invalid_api_key',
+        rate_limit_remaining: 5,
+      })
+    );
+    await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
+    // The original body snippet (incl. the field that was stripped from the
+    // client response) is still logged server-side for debugging.
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('rate_limit_remaining'));
+  });
+});
+
+// ── Body parser hardening (#552) ───────────────────────────────────────────
+
+describe('Body parser hardening — content type and size limits', () => {
+  it('rejects POST with non-JSON content-type with 415', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    const res = await request(app)
+      .post('/trakt/token')
+      .set('Content-Type', 'text/plain')
+      .send('code=abc');
+    expect(res.status).toBe(415);
+    expect(res.body).toEqual({ error: 'invalid_content_type' });
+  });
+
+  it('rejects POST with form-urlencoded content-type with 415', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    const res = await request(app)
+      .post('/trakt/token')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send('code=abc');
+    expect(res.status).toBe(415);
+    expect(res.body).toEqual({ error: 'invalid_content_type' });
+  });
+
+  it('rejects oversized JSON body with 413 payload_too_large', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    const oversize = JSON.stringify({ code: 'a'.repeat(8000) });
+    const res = await request(app)
+      .post('/trakt/token')
+      .set('Content-Type', 'application/json')
+      .send(oversize);
+    expect(res.status).toBe(413);
+    expect(res.body).toEqual({ error: 'payload_too_large' });
+  });
+
+  it('rejects malformed JSON with 400 invalid_json', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    const res = await request(app)
+      .post('/trakt/token')
+      .set('Content-Type', 'application/json')
+      .send('{not valid json');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'invalid_json' });
+  });
+
+  it('still accepts well-formed JSON under the 4kb limit', async () => {
+    const app = buildApp(
+      mockFetch(200, {
+        access_token: 'acc',
+        refresh_token: 'ref',
+        expires_in: 7776000,
+        token_type: 'Bearer',
+        scope: 'public',
+      })
+    );
+    const res = await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
+    expect(res.status).toBe(200);
+    expect(res.body.access_token).toBe('acc');
+  });
+
+  it('does not 415 GET /health (only POST is gated)', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    const res = await request(app).get('/health');
+    expect(res.status).not.toBe(415);
+  });
+});

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -123,6 +123,17 @@ export function createApp(config) {
     };
   }
 
+  // Trakt error bodies can include rate-limit hints, account state, or partial
+  // token fields — strip everything except the standard OAuth `error` /
+  // `error_description` so the client never sees information it doesn't need.
+  function filterErrorResponse(data) {
+    if (!data || typeof data !== 'object') return {};
+    const out = {};
+    if (typeof data.error === 'string') out.error = data.error;
+    if (typeof data.error_description === 'string') out.error_description = data.error_description;
+    return out;
+  }
+
   /**
    * Handles a caught fetch error (AbortError / network error) and writes the
    * appropriate HTTP error response.  fetchTimeoutMs is read from the outer closure.
@@ -267,7 +278,23 @@ export function createApp(config) {
   // from X-Forwarded-For instead of treating all traffic as one bucket.
   app.set('trust proxy', 1);
   app.use(helmet());
-  app.use(express.json());
+
+  app.use((req, res, next) => {
+    if (req.method === 'POST' && !req.is('application/json')) {
+      return res.status(415).json({ error: 'invalid_content_type' });
+    }
+    next();
+  });
+  app.use(express.json({ limit: '4kb', strict: true }));
+  app.use((err, _req, res, next) => {
+    if (err?.type === 'entity.too.large') {
+      return res.status(413).json({ error: 'payload_too_large' });
+    }
+    if (err?.type === 'entity.parse.failed') {
+      return res.status(400).json({ error: 'invalid_json' });
+    }
+    return next(err);
+  });
 
   if (debug) {
     app.use((req, res, next) => {
@@ -343,7 +370,7 @@ export function createApp(config) {
             );
           }
         }
-        return res.status(traktRes.status).json(data);
+        return res.status(traktRes.status).json(filterErrorResponse(data));
       }
 
       return res.json(filterTokenResponse(data));
@@ -390,7 +417,7 @@ export function createApp(config) {
             'Hint: HTTP 403 from Trakt usually means TRAKT_CLIENT_ID is invalid or revoked.'
           );
         }
-        return res.status(traktRes.status).json(data);
+        return res.status(traktRes.status).json(filterErrorResponse(data));
       }
 
       return res.json(filterTokenResponse(data));


### PR DESCRIPTION
## Summary

Fixes two security issues in the Trakt token proxy:

- **#551 (Critical, security):** Trakt 4xx/5xx error bodies were forwarded raw to the client. They can include rate-limit hints, account state, or partial token fields. Now filtered through a new `filterErrorResponse(data)` that returns only the standard OAuth `error` / `error_description` fields. The full upstream body is still logged server-side at `error` / `warn` level for debugging.
- **#552 (High, DoS):** `express.json()` had no `limit` option (Express defaults to 100 KB) and no content-type guard, so any client could POST oversized JSON or non-JSON payloads to the unauthenticated `/health` route or before the per-IP rate limiter caught up. Now caps requests at 4 KB and rejects non-`application/json` POSTs with HTTP 415 before parsing. Body-parser errors return stable JSON: `413 payload_too_large` and `400 invalid_json`.

## Changes

- `backend/src/app.js`
  - Add `filterErrorResponse(data)` next to the existing `filterTokenResponse(data)`.
  - Apply it on both non-OK branches of `/trakt/token` and `/trakt/token/refresh`.
  - Add a content-type guard middleware (`POST` requires `application/json`, else 415).
  - Tighten `express.json({ limit: '4kb', strict: true })`.
  - Add a body-parser error handler that maps `entity.too.large` → 413 and `entity.parse.failed` → 400.
- `backend/src/__tests__/app.test.js`
  - 5 new tests for `filterErrorResponse` (sanitization, error_description preservation, non-string drops, server-side logging unaffected).
  - 6 new tests for body parser hardening (415 on text/plain and form-urlencoded, 413 on oversized JSON, 400 on malformed JSON, well-formed under 4 KB still works, GET /health unaffected).
  - All 97 tests pass; existing tests stay green because their error fixtures only contained the `error` field.

## Test plan

- [x] `npm --prefix backend test` — 97/97 pass
- [x] `npm --prefix backend run lint && npm --prefix backend run format:check` — clean
- [x] `./scripts/precommit.sh` — backend scope passes; Gradle scope auto-skipped (no Android SDK in sandbox), so CI's `Test & Build` is the gate for any Kotlin impact (none here)
- [ ] CI green on this PR

Closes #551
Closes #552

https://claude.ai/code/session_01JCkp6NJPGCTm6KSqSjs9WK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCkp6NJPGCTm6KSqSjs9WK)_