### PR TITLE
ci: pin GitHub Actions to commit SHAs and add zizmor enforcement

### DIFF
--- a/.github/actions/setup-android-build/action.yml
+++ b/.github/actions/setup-android-build/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Set up JDK 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -19,4 +19,4 @@ runs:
     # wrapper) via its built-in caching layer keyed on Gradle and build
     # inputs; no supplementary actions/cache step is needed.
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -9,9 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  security-events: write
-  actions: read
 
 jobs:
   changes:
@@ -19,12 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     if: "!startsWith(github.head_ref, 'release-please--')"
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       android: ${{ steps.filter.outputs.android }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |
@@ -43,8 +41,13 @@ jobs:
     needs: changes
     if: needs.changes.outputs.android == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      security-events: write
+      actions: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-android-build
 
       - name: Run unit tests
@@ -80,7 +83,7 @@ jobs:
       - name: Upload app-phone detekt SARIF
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: sarif-reports/app-phone-detekt.sarif
           category: app-phone-detekt
@@ -88,7 +91,7 @@ jobs:
       - name: Upload app-phone lint SARIF
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: sarif-reports/app-phone-lint-results-debug.sarif
           category: app-phone-lint
@@ -96,7 +99,7 @@ jobs:
       - name: Upload app-tv detekt SARIF
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: sarif-reports/app-tv-detekt.sarif
           category: app-tv-detekt
@@ -104,7 +107,7 @@ jobs:
       - name: Upload app-tv lint SARIF
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: sarif-reports/app-tv-lint-results-debug.sarif
           category: app-tv-lint
@@ -112,14 +115,14 @@ jobs:
       - name: Upload core detekt SARIF
         if: always()
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
         with:
           sarif_file: sarif-reports/core-detekt.sarif
           category: core-detekt
 
       - name: Archive analysis reports
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: static-analysis-reports
           path: |
@@ -132,7 +135,7 @@ jobs:
 
       - name: Post PR lint summary
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             const fs = require('fs');
@@ -218,7 +221,7 @@ jobs:
       # UI. See CLAUDE.md § "Monitoring PR checks & accessing build logs".
       - name: Post failing build log
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           MARKER: '<!-- watchbuddy-build-log -->'
           CURRENT_JOB: ${{ github.job }}

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -22,6 +22,8 @@ jobs:
       android: ${{ steps.filter.outputs.android }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
@@ -48,6 +50,8 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-android-build
 
       - name: Run unit tests

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -27,6 +27,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       # `--min-severity=medium` catches `unpinned-uses` (the primary supply-chain
       # gate this workflow exists to enforce, per issue #561) and `excessive-
       # permissions`, while skipping low-severity defense-in-depth nits like

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,35 @@
+name: Lint workflows
+
+# Enforces supply-chain hygiene on every CI workflow file: any third-party
+# action introduced via a floating tag (`@v3`, `@v4`, …) instead of a full
+# 40-char commit SHA fails this job. See issue #561.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # `--min-severity=medium` catches `unpinned-uses` (the primary supply-chain
+      # gate this workflow exists to enforce, per issue #561) and `excessive-
+      # permissions`, while skipping low-severity defense-in-depth nits like
+      # `artipacked` that warrant a separate hardening pass.
+      - name: Run zizmor
+        run: pipx run zizmor --min-severity=medium .github/workflows/ .github/actions/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,13 @@ jobs:
       VERSION: ${{ needs.release-please.outputs.version }}
       TAG: ${{ needs.release-please.outputs.tag_name }}
     steps:
+      # build-release uses `gh release upload` which authenticates via the
+      # `GH_TOKEN` env var, not git-stored credentials, so the persisted
+      # credential is unused — turn it off to satisfy zizmor's `artipacked`
+      # audit and avoid the credential leaking into uploaded artifacts.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-android-build
 
       # -- Prepare release signing ----------------------------------------
@@ -288,7 +294,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      # Persisted credentials are required so the next step can `git push
+      # origin stable --force`. zizmor's `artipacked` audit warns that the
+      # credential could leak via uploaded artifacts — this job uploads none.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 # zizmor: ignore[artipacked]
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,20 +5,22 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
       version: ${{ steps.release.outputs.version }}
       body: ${{ steps.release.outputs.body }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -30,11 +32,13 @@ jobs:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       VERSION: ${{ needs.release-please.outputs.version }}
       TAG: ${{ needs.release-please.outputs.tag_name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-android-build
 
       # -- Prepare release signing ----------------------------------------
@@ -267,7 +271,7 @@ jobs:
         run: ./gradlew :app-phone:publishReleaseBundle -PplayTrack=internal -PplayStatus=${{ steps.play-status.outputs.status }}
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: watchbuddy-release-${{ needs.release-please.outputs.version }}
           path: |
@@ -281,8 +285,10 @@ jobs:
     needs: [release-please, build-release]
     if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -5,7 +5,11 @@ name: Update README stats
 # and the job only fires on the authoritative branch. The resulting commit is
 # tagged with `[skip ci]` to break the workflow_run -> push -> workflow_run loop.
 
-on:
+# `workflow_run` is safe here: triggered only by our own `Build Android APKs`
+# workflow on `main`, gated on success, and the job checks out `ref: main`
+# (never the triggering PR's head). The follow-up commit uses `[skip ci]` to
+# break the loop. No PR-controlled inputs are read.
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: ["Build Android APKs"]
     types: [completed]
@@ -22,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: main
           # Use the built-in token so the follow-up push is authenticated.

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -25,8 +25,12 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
+      # Persisted credentials are required so the final step can `git push
+      # origin main` with the README update. zizmor's `artipacked` audit
+      # warns that the credential could leak via uploaded artifacts — this
+      # job uploads none.
       - name: Checkout main
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6 # zizmor: ignore[artipacked]
         with:
           ref: main
           # Use the built-in token so the follow-up push is authenticated.

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -22,6 +22,8 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
@@ -43,6 +45,8 @@ jobs:
         working-directory: backend
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6

--- a/.github/workflows/test-backend.yml
+++ b/.github/workflows/test-backend.yml
@@ -9,8 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
-  actions: read
 
 jobs:
   changes:
@@ -18,12 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     if: "!startsWith(github.head_ref, 'release-please--')"
     permissions:
+      contents: read
       pull-requests: read
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4
         id: filter
         with:
           filters: |
@@ -35,14 +34,18 @@ jobs:
     needs: changes
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: read
     defaults:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -67,7 +70,7 @@ jobs:
       # logs".
       - name: Post failing backend log
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           MARKER: '<!-- watchbuddy-backend-log -->'
           CURRENT_JOB: ${{ github.job }}


### PR DESCRIPTION
## Summary

Closes #561.

Floating-tag `uses:` references (`@v3`/`@v4`/…) are a supply-chain risk: a hijacked third-party action can publish hostile APKs through this repo's release pipeline (which holds `KEYSTORE_BASE64`, `KEY_ALIAS`, `KEY_PASSWORD`, `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`).

Three of the four parts of the issue's suggested fix are addressed here; part 2 (Dependabot for `github-actions`) is already covered by the existing `.github/dependabot.yml`.

### Changes

1. **Pin every `uses:` line to a 40-char commit SHA + ` # vX` comment** (the comment is load-bearing — Dependabot uses it to track the floating major when rotating SHAs).

   Pinned actions:
   - `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6`
   - `actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5`
   - `actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6`
   - `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7`
   - `actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9`
   - `dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4`
   - `gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6`
   - `github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4` (×5 call-sites — same SHA pins the whole repo)
   - `googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4`

   The local composite reference `./.github/actions/setup-android-build` is intentionally left unpinned — it resolves against the calling workflow's own checked-out SHA.

2. **Add `.github/workflows/lint-workflows.yml`** running `zizmor --min-severity=medium` on every change to `.github/**`. Catches `unpinned-uses` (medium) and `excessive-permissions` (high), skips low-severity defense-in-depth nits like `artipacked` that warrant a separate hardening pass.

3. **Tighten workflow-level `permissions:`** per zizmor's `excessive-permissions` audit:
   - `build-android.yml`, `test-backend.yml`, `release.yml`: top-level dropped to `contents: read`; per-job overrides grant exactly what each job needs.
   - `stats.yml`: workflow already had only `contents: write` and one job — left as-is. The `workflow_run` trigger gets an inline `# zizmor: ignore[dangerous-triggers]` with a comment explaining why this specific use is safe (own workflow, gated on success on `main`, checks out `ref: main` not the triggering PR head, breaks the loop with `[skip ci]`).

### Test plan

- [x] Local `zizmor --min-severity=medium` against `.github/workflows/` and `.github/actions/` reports zero findings (exit 0; 11 ignored, 26 suppressed).
- [x] `./scripts/precommit.sh` passes (workflow YAML syntax). Android SDK is unavailable in the sandbox per CLAUDE.md "Sandboxed environments without the Android SDK", so Gradle scope is skipped — CI is the real gate for the Android build.
- [ ] CI green: `Lint workflows / zizmor` (new), `Build Android APKs / Test & Build`, `Backend Tests / Backend Tests`.
- [ ] Post-merge: trigger Dependabot's `Check for updates` on `github-actions`; confirm SHA-pinned entries are recognized, grouped per existing config, and `googleapis/release-please-action` stays ignored.

https://claude.ai/code/session_01BtEkzYnoTWyPMGbaX1HQic

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtEkzYnoTWyPMGbaX1HQic)_