### PR TITLE
fix(backend): add 404 + global error handlers (#553)

### DIFF
--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -515,10 +515,77 @@ describe('POST /trakt/token — server_misconfigured', () => {
 // ── Unknown routes ──────────────────────────────────────────────────────────
 
 describe('Unknown routes', () => {
-  it('returns 404 for unregistered paths', async () => {
+  it('returns 404 with JSON body for unregistered paths', async () => {
     const app = buildApp(mockFetch(200, {}));
     const res = await request(app).get('/does-not-exist');
     expect(res.status).toBe(404);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.body).toEqual({ error: 'not_found' });
+  });
+
+  it('returns 404 JSON for unknown POST paths regardless of method', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    const res = await request(app)
+      .post('/no-such-endpoint')
+      .set('Content-Type', 'application/json')
+      .send({ foo: 'bar' });
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'not_found' });
+  });
+});
+
+describe('Global error handler', () => {
+  let errorSpy;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  // body-parser throws { type: 'encoding.unsupported' } for unrecognised
+  // Content-Encoding values. The dedicated body-parser error handler in
+  // app.js only catches entity.too.large / entity.parse.failed and forwards
+  // every other type, which lands on the global error handler — exactly
+  // the path we want to exercise.
+  it('returns 500 JSON when an unhandled body-parser error reaches it', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    const res = await request(app)
+      .post('/trakt/token')
+      .set('Content-Type', 'application/json')
+      .set('Content-Encoding', 'utterly-invalid-encoding')
+      .send('{"code":"abc"}');
+    expect(res.status).toBe(500);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.body).toEqual({ error: 'internal_error' });
+  });
+
+  it('does not leak the underlying error message in the response body', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    const res = await request(app)
+      .post('/trakt/token')
+      .set('Content-Type', 'application/json')
+      .set('Content-Encoding', 'utterly-invalid-encoding')
+      .send('{"code":"abc"}');
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toMatch(/encoding/i);
+    expect(serialized).not.toMatch(/stack/i);
+    expect(serialized).not.toMatch(/utterly-invalid-encoding/);
+  });
+
+  it('logs the original error so operators can diagnose failures', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    await request(app)
+      .post('/trakt/token')
+      .set('Content-Type', 'application/json')
+      .set('Content-Encoding', 'utterly-invalid-encoding')
+      .send('{"code":"abc"}');
+    const logged = errorSpy.mock.calls.some(([first]) =>
+      typeof first === 'string' ? first.includes('Unhandled error') : false
+    );
+    expect(logged).toBe(true);
   });
 });
 

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -448,6 +448,18 @@ export function createApp(config) {
     });
   });
 
+  // Catch-all 404 — keeps unknown paths off Express's default HTML response.
+  app.use((_req, res) => {
+    res.status(404).json({ error: 'not_found' });
+  });
+
+  // Global error handler — final safety net so unhandled exceptions never
+  // leak stack traces via Express's default error response.
+  app.use((err, _req, res, _next) => {
+    console.error('Unhandled error:', err);
+    res.status(500).json({ error: 'internal_error' });
+  });
+
   app.verifyCredentials = verifyCredentials;
   app.clearRetryTimer = () => {
     if (retryTimer) clearTimeout(retryTimer);


### PR DESCRIPTION
## Summary
- Adds a JSON 404 catch-all to `backend/src/app.js` so unknown paths return `{ "error": "not_found" }` instead of Express's default HTML 404 page.
- Adds a final 4-arg error middleware that logs unhandled exceptions via `console.error` and responds with `500 { "error": "internal_error" }`, eliminating the stack-trace leak from Express's default error handler.

`trust proxy` is already set to `1` (`app.set('trust proxy', 1)`), which is the narrow, safe value the issue recommends — no change needed there.

The existing body-parser error middleware (413 / 400) and content-type guard (415) keep their precise responses; only errors those forward via `next(err)`, plus any unexpected synchronous/async throw, now reach the new handler.

## Test plan
- [x] `npm --prefix backend test` — all 101 tests pass (5 new: JSON-bodied 404 GET, JSON-bodied 404 POST, 500 JSON shape on unhandled body-parser error, no leaked details in 500 body, error logged to `console.error`).
- [x] `./scripts/precommit.sh` — backend ESLint + Prettier + tests all green.

Closes #553

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcAkNscm7opX9gMYyJkoSy)_