### PR TITLE
fix(tv): restore D-pad scroll on Diagnostics screen

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -4,6 +4,10 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -163,7 +167,9 @@ fun TvDiagnosticsScreen(
             if (uiState.phones.isEmpty()) {
                 item {
                     Surface(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .diagnosticsFocusable(),
                         shape = RoundedCornerShape(12.dp),
                         colors = SurfaceDefaults.colors(
                             containerColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -247,7 +253,9 @@ fun TvDiagnosticsScreen(
             if (uiState.recentEvents.isEmpty()) {
                 item {
                     Surface(
-                        modifier = Modifier.fillMaxWidth(),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .diagnosticsFocusable(),
                         shape = RoundedCornerShape(12.dp),
                         colors = SurfaceDefaults.colors(
                             containerColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -280,7 +288,9 @@ fun TvDiagnosticsScreen(
 @Composable
 private fun PhoneDiagnosticsCard(phone: PhoneDiscoveryManager.DiscoveredPhone) {
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .diagnosticsFocusable(),
         shape = RoundedCornerShape(12.dp),
         colors = SurfaceDefaults.colors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -353,7 +363,9 @@ private fun RecentEventRow(entry: DiagnosticLog.Entry) {
     }
     val message = entry.throwableSummary?.let { "${entry.message} → $it" } ?: entry.message
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .diagnosticsFocusable(),
         shape = RoundedCornerShape(12.dp),
         colors = SurfaceDefaults.colors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -404,7 +416,9 @@ private fun DiagnosticsSection(title: String, rows: List<DiagRow>) {
         modifier = Modifier.padding(top = 8.dp, bottom = 4.dp, start = 4.dp),
     )
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .diagnosticsFocusable(),
         shape = RoundedCornerShape(12.dp),
         colors = SurfaceDefaults.colors(
             containerColor = MaterialTheme.colorScheme.surfaceVariant,
@@ -445,6 +459,16 @@ private fun statusColor(status: Status): Color = when (status) {
     Status.WARN -> Color(0xFFF9A825)
     Status.FAIL -> Color(0xFFC62828)
     Status.NEUTRAL -> Color.White.copy(alpha = 0.3f)
+}
+
+@Composable
+private fun Modifier.diagnosticsFocusable(): Modifier {
+    val interaction = remember { MutableInteractionSource() }
+    val focused by interaction.collectIsFocusedAsState()
+    val borderColor = if (focused) MaterialTheme.colorScheme.primary else Color.Transparent
+    return this
+        .border(2.dp, borderColor, RoundedCornerShape(12.dp))
+        .focusable(interactionSource = interaction)
 }
 
 private val ActionHintColor = Color(0xFF90CAF9)
@@ -730,7 +754,7 @@ private fun WatchNextSection(countResult: WatchNextMetadataSource.CountResult?) 
         ) { cardContent() }
     } else {
         Surface(
-            modifier = cardModifier,
+            modifier = cardModifier.diagnosticsFocusable(),
             shape = cardShape,
             colors = SurfaceDefaults.colors(
                 containerColor = MaterialTheme.colorScheme.surfaceVariant,


### PR DESCRIPTION
## Summary

- After #517 swapped the read-only Diagnostics sections from clickable `Card`s to non-clickable `Surface`s (to stop the focus-scale animation from clipping past the 48dp screen padding), the wrapping `LazyColumn` lost almost all of its D-pad focus targets — only the Streaming Deep Links card and the Back button stayed focusable, so the screen no longer scrolled and most sections became unreachable.
- Add a `Modifier.diagnosticsFocusable()` helper that pairs `foundation.focusable()` with a focus-driven 2dp primary border (mirrors the border idiom in `TvSettingsScreen.SettingsCard`). `foundation.focusable` does not introduce scaling, so #517's clipping fix stays intact while the `LazyColumn` regains focus targets to scroll between.
- Apply the helper to all six read-only Surface containers — `DiagnosticsSection`, `PhoneDiagnosticsCard`, `RecentEventRow`, both empty placeholders, and the `WatchNextSection` else-branch. The two genuinely actionable Cards (Streaming Deep Links, WatchNext permission-denied) keep their existing `onClick`-driven focus and are untouched. The phone `DiagnosticsScreen` (touch-only `verticalScroll`) is also untouched.

## Test plan

- [ ] On a Google TV / Android TV device or emulator, open Settings → Diagnostics. Press D-pad DOWN repeatedly from the top: every section gains a primary-color border in turn (Discovery → BLE → Scrobble → NowPlaying → MediaSession → phone cards → Build → WatchNext → MediaNotifications → AppProfiles → AmbiguousPromptStats → Intent → StreamingLinks → recent events → Back), and the `LazyColumn` scrolls so the focused row stays on-screen.
- [ ] No focused row clips past the 48dp horizontal padding (no scale, no bezel collision — #517 still holds).
- [ ] Pressing D-pad UP from the Back button retraces the path.
- [ ] Touch behaviour on the phone `DiagnosticsScreen` is unchanged (still scrolls, no visual regression).

> Local pre-commit was run (`scripts/precommit.sh`); the Gradle scope was skipped because no Android SDK is available in the sandbox. CI's `Test & Build` is the real gate for the Kotlin change.

Fixes the regression introduced in #517 (`d272971`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYw1wAGMzzzwUp7PMd8Gp9)_