### PR TITLE
fix(tv): restore focus to previously-selected show on back from detail

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -163,6 +164,95 @@ private fun TvHomeShelves(
     val cwRequesters = remember(continueWatching) { mutableMapOf<String, FocusRequester>() }
     val allRequesters = remember(allOthers) { mutableMapOf<String, FocusRequester>() }
 
+    RestoreShelfFocusEffect(
+        focusedShowKey = focusedShowKey,
+        continueWatching = continueWatching,
+        allOthers = allOthers,
+        allShowsExpanded = allShowsExpanded,
+        continueWatchingState = continueWatchingState,
+        allShowsState = allShowsState,
+        cwRequesters = cwRequesters,
+        allRequesters = allRequesters
+    )
+
+    LazyColumn(
+        contentPadding = PaddingValues(horizontal = 48.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        if (continueWatching.isNotEmpty()) {
+            item {
+                Text(
+                    text = stringResource(R.string.tv_continue_watching),
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onBackground
+                )
+            }
+            item {
+                TvShowShelfRow(
+                    shows = continueWatching,
+                    state = state,
+                    listState = continueWatchingState,
+                    requesters = cwRequesters,
+                    onShowClick = onShowClick,
+                    onFocused = { focusedShowKey = it }
+                )
+            }
+        }
+
+        item {
+            TvAllShowsHeader(
+                count = allOthers.size,
+                expanded = allShowsExpanded,
+                onToggle = { allShowsExpanded = !allShowsExpanded }
+            )
+        }
+
+        if (allShowsExpanded) {
+            item {
+                TvShowShelfRow(
+                    shows = allOthers,
+                    state = state,
+                    listState = allShowsState,
+                    requesters = allRequesters,
+                    onShowClick = onShowClick,
+                    onFocused = { focusedShowKey = it }
+                )
+            }
+            if (state.canLoadMore) {
+                item { AllShowsLoadMoreTrigger(state, onLoadMore) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AllShowsLoadMoreTrigger(state: TvHomeUiState, onLoadMore: () -> Unit) {
+    LaunchedEffect(Unit) { onLoadMore() }
+    if (state.isLoadingMore) {
+        Box(Modifier.fillMaxWidth().padding(8.dp), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.size(32.dp)
+            )
+        }
+    }
+}
+
+private fun EnrichedShowEntry.focusKey(): String =
+    entry.show.ids.trakt?.toString() ?: entry.show.title
+
+@Composable
+private fun RestoreShelfFocusEffect(
+    focusedShowKey: String?,
+    continueWatching: List<EnrichedShowEntry>,
+    allOthers: List<EnrichedShowEntry>,
+    allShowsExpanded: Boolean,
+    continueWatchingState: LazyListState,
+    allShowsState: LazyListState,
+    cwRequesters: Map<String, FocusRequester>,
+    allRequesters: Map<String, FocusRequester>
+) {
     LaunchedEffect(continueWatching, allOthers, allShowsExpanded) {
         val key = focusedShowKey ?: return@LaunchedEffect
         val cwIndex = continueWatching.indexOfFirst { it.focusKey() == key }
@@ -179,93 +269,38 @@ private fun TvHomeShelves(
             }
         }
     }
+}
 
-    LazyColumn(
-        contentPadding = PaddingValues(horizontal = 48.dp, vertical = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(20.dp)
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun TvShowShelfRow(
+    shows: List<EnrichedShowEntry>,
+    state: TvHomeUiState,
+    listState: LazyListState,
+    requesters: MutableMap<String, FocusRequester>,
+    onShowClick: (EnrichedShowEntry) -> Unit,
+    onFocused: (String) -> Unit
+) {
+    LazyRow(
+        state = listState,
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        contentPadding = PaddingValues(horizontal = 4.dp)
     ) {
-        if (continueWatching.isNotEmpty()) {
-            item {
-                Text(
-                    text = stringResource(R.string.tv_continue_watching),
-                    fontSize = 20.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.onBackground
-                )
-            }
-            item {
-                LazyRow(
-                    state = continueWatchingState,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    contentPadding = PaddingValues(horizontal = 4.dp)
-                ) {
-                    items(continueWatching, key = { it.focusKey() }) { enriched ->
-                        val key = enriched.focusKey()
-                        val requester = cwRequesters.getOrPut(key) { FocusRequester() }
-                        TvShowCard(
-                            enriched = enriched,
-                            progress = enriched.entry.show.ids.trakt?.let { state.progress[it] },
-                            hasNewSeason = enriched.entry.show.ids.trakt?.let { state.hasNewSeason[it] } == true,
-                            onClick = { onShowClick(enriched) },
-                            modifier = Modifier
-                                .focusRequester(requester)
-                                .onFocusChanged { if (it.isFocused) focusedShowKey = key }
-                        )
-                    }
-                }
-            }
-        }
-
-        item {
-            TvAllShowsHeader(
-                count = allOthers.size,
-                expanded = allShowsExpanded,
-                onToggle = { allShowsExpanded = !allShowsExpanded }
+        items(shows, key = { it.focusKey() }) { enriched ->
+            val key = enriched.focusKey()
+            val requester = requesters.getOrPut(key) { FocusRequester() }
+            TvShowCard(
+                enriched = enriched,
+                progress = enriched.entry.show.ids.trakt?.let { state.progress[it] },
+                hasNewSeason = enriched.entry.show.ids.trakt?.let { state.hasNewSeason[it] } == true,
+                onClick = { onShowClick(enriched) },
+                modifier = Modifier
+                    .focusRequester(requester)
+                    .onFocusChanged { if (it.isFocused) onFocused(key) }
             )
-        }
-
-        if (allShowsExpanded) {
-            item {
-                LazyRow(
-                    state = allShowsState,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp),
-                    contentPadding = PaddingValues(horizontal = 4.dp)
-                ) {
-                    items(allOthers, key = { it.focusKey() }) { enriched ->
-                        val key = enriched.focusKey()
-                        val requester = allRequesters.getOrPut(key) { FocusRequester() }
-                        TvShowCard(
-                            enriched = enriched,
-                            progress = enriched.entry.show.ids.trakt?.let { state.progress[it] },
-                            hasNewSeason = enriched.entry.show.ids.trakt?.let { state.hasNewSeason[it] } == true,
-                            onClick = { onShowClick(enriched) },
-                            modifier = Modifier
-                                .focusRequester(requester)
-                                .onFocusChanged { if (it.isFocused) focusedShowKey = key }
-                        )
-                    }
-                }
-            }
-            // Trigger load-more when the All shows section is expanded.
-            if (state.canLoadMore) {
-                item {
-                    LaunchedEffect(allShowsExpanded) { if (allShowsExpanded) onLoadMore() }
-                    if (state.isLoadingMore) {
-                        Box(Modifier.fillMaxWidth().padding(8.dp), contentAlignment = Alignment.Center) {
-                            CircularProgressIndicator(
-                                color = MaterialTheme.colorScheme.primary,
-                                modifier = Modifier.size(32.dp)
-                            )
-                        }
-                    }
-                }
-            }
         }
     }
 }
-
-private fun EnrichedShowEntry.focusKey(): String =
-    entry.show.ids.trakt?.toString() ?: entry.show.title
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -283,7 +283,11 @@ private fun TvShowShelfRow(
     ) {
         items(shows, key = { it.focusKey() }) { enriched ->
             val key = enriched.focusKey()
-            val requester = requesters.getOrPut(key) { FocusRequester() }
+            val requester = remember(key) { FocusRequester() }
+            DisposableEffect(key, requester) {
+                requesters[key] = requester
+                onDispose { requesters.remove(key, requester) }
+            }
             TvShowCard(
                 enriched = enriched,
                 progress = enriched.entry.show.ids.trakt?.let { state.progress[it] },

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -164,16 +164,9 @@ private fun TvHomeShelves(
     val cwRequesters = remember(continueWatching) { mutableMapOf<String, FocusRequester>() }
     val allRequesters = remember(allOthers) { mutableMapOf<String, FocusRequester>() }
 
-    RestoreShelfFocusEffect(
-        focusedShowKey = focusedShowKey,
-        continueWatching = continueWatching,
-        allOthers = allOthers,
-        allShowsExpanded = allShowsExpanded,
-        continueWatchingState = continueWatchingState,
-        allShowsState = allShowsState,
-        cwRequesters = cwRequesters,
-        allRequesters = allRequesters
-    )
+    val cwShelf = ShelfFocusContext(continueWatching, continueWatchingState, cwRequesters)
+    val allShelf = ShelfFocusContext(allOthers, allShowsState, allRequesters)
+    RestoreShelfFocusEffect(focusedShowKey, cwShelf, allShelf, allShowsExpanded)
 
     LazyColumn(
         contentPadding = PaddingValues(horizontal = 48.dp, vertical = 16.dp),
@@ -242,30 +235,32 @@ private fun AllShowsLoadMoreTrigger(state: TvHomeUiState, onLoadMore: () -> Unit
 private fun EnrichedShowEntry.focusKey(): String =
     entry.show.ids.trakt?.toString() ?: entry.show.title
 
+private class ShelfFocusContext(
+    val shows: List<EnrichedShowEntry>,
+    val listState: LazyListState,
+    val requesters: Map<String, FocusRequester>
+)
+
 @Composable
 private fun RestoreShelfFocusEffect(
     focusedShowKey: String?,
-    continueWatching: List<EnrichedShowEntry>,
-    allOthers: List<EnrichedShowEntry>,
-    allShowsExpanded: Boolean,
-    continueWatchingState: LazyListState,
-    allShowsState: LazyListState,
-    cwRequesters: Map<String, FocusRequester>,
-    allRequesters: Map<String, FocusRequester>
+    continueWatching: ShelfFocusContext,
+    allShows: ShelfFocusContext,
+    allShowsExpanded: Boolean
 ) {
-    LaunchedEffect(continueWatching, allOthers, allShowsExpanded) {
+    LaunchedEffect(continueWatching.shows, allShows.shows, allShowsExpanded) {
         val key = focusedShowKey ?: return@LaunchedEffect
-        val cwIndex = continueWatching.indexOfFirst { it.focusKey() == key }
+        val cwIndex = continueWatching.shows.indexOfFirst { it.focusKey() == key }
         if (cwIndex >= 0) {
-            continueWatchingState.scrollToItem(cwIndex)
-            cwRequesters[key]?.requestFocus()
+            continueWatching.listState.scrollToItem(cwIndex)
+            continueWatching.requesters[key]?.requestFocus()
             return@LaunchedEffect
         }
         if (allShowsExpanded) {
-            val allIndex = allOthers.indexOfFirst { it.focusKey() == key }
+            val allIndex = allShows.shows.indexOfFirst { it.focusKey() == key }
             if (allIndex >= 0) {
-                allShowsState.scrollToItem(allIndex)
-                allRequesters[key]?.requestFocus()
+                allShows.listState.scrollToItem(allIndex)
+                allShows.requesters[key]?.requestFocus()
             }
         }
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
@@ -20,6 +21,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -153,6 +157,29 @@ private fun TvHomeShelves(
     val allOthers = state.allShows
     var allShowsExpanded by rememberSaveable { mutableStateOf(false) }
 
+    var focusedShowKey by rememberSaveable { mutableStateOf<String?>(null) }
+    val continueWatchingState = rememberLazyListState()
+    val allShowsState = rememberLazyListState()
+    val cwRequesters = remember(continueWatching) { mutableMapOf<String, FocusRequester>() }
+    val allRequesters = remember(allOthers) { mutableMapOf<String, FocusRequester>() }
+
+    LaunchedEffect(continueWatching, allOthers, allShowsExpanded) {
+        val key = focusedShowKey ?: return@LaunchedEffect
+        val cwIndex = continueWatching.indexOfFirst { it.focusKey() == key }
+        if (cwIndex >= 0) {
+            continueWatchingState.scrollToItem(cwIndex)
+            cwRequesters[key]?.requestFocus()
+            return@LaunchedEffect
+        }
+        if (allShowsExpanded) {
+            val allIndex = allOthers.indexOfFirst { it.focusKey() == key }
+            if (allIndex >= 0) {
+                allShowsState.scrollToItem(allIndex)
+                allRequesters[key]?.requestFocus()
+            }
+        }
+    }
+
     LazyColumn(
         contentPadding = PaddingValues(horizontal = 48.dp, vertical = 16.dp),
         verticalArrangement = Arrangement.spacedBy(20.dp)
@@ -168,15 +195,21 @@ private fun TvHomeShelves(
             }
             item {
                 LazyRow(
+                    state = continueWatchingState,
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                     contentPadding = PaddingValues(horizontal = 4.dp)
                 ) {
-                    items(continueWatching, key = { it.entry.show.ids.trakt ?: it.entry.show.title }) { enriched ->
+                    items(continueWatching, key = { it.focusKey() }) { enriched ->
+                        val key = enriched.focusKey()
+                        val requester = cwRequesters.getOrPut(key) { FocusRequester() }
                         TvShowCard(
                             enriched = enriched,
                             progress = enriched.entry.show.ids.trakt?.let { state.progress[it] },
                             hasNewSeason = enriched.entry.show.ids.trakt?.let { state.hasNewSeason[it] } == true,
-                            onClick = { onShowClick(enriched) }
+                            onClick = { onShowClick(enriched) },
+                            modifier = Modifier
+                                .focusRequester(requester)
+                                .onFocusChanged { if (it.isFocused) focusedShowKey = key }
                         )
                     }
                 }
@@ -194,15 +227,21 @@ private fun TvHomeShelves(
         if (allShowsExpanded) {
             item {
                 LazyRow(
+                    state = allShowsState,
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
                     contentPadding = PaddingValues(horizontal = 4.dp)
                 ) {
-                    items(allOthers, key = { it.entry.show.ids.trakt ?: it.entry.show.title }) { enriched ->
+                    items(allOthers, key = { it.focusKey() }) { enriched ->
+                        val key = enriched.focusKey()
+                        val requester = allRequesters.getOrPut(key) { FocusRequester() }
                         TvShowCard(
                             enriched = enriched,
                             progress = enriched.entry.show.ids.trakt?.let { state.progress[it] },
                             hasNewSeason = enriched.entry.show.ids.trakt?.let { state.hasNewSeason[it] } == true,
-                            onClick = { onShowClick(enriched) }
+                            onClick = { onShowClick(enriched) },
+                            modifier = Modifier
+                                .focusRequester(requester)
+                                .onFocusChanged { if (it.isFocused) focusedShowKey = key }
                         )
                     }
                 }
@@ -224,6 +263,9 @@ private fun TvHomeShelves(
         }
     }
 }
+
+private fun EnrichedShowEntry.focusKey(): String =
+    entry.show.ids.trakt?.toString() ?: entry.show.title
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -342,7 +384,8 @@ private fun TvShowCard(
     enriched: EnrichedShowEntry,
     progress: ShowProgress?,
     hasNewSeason: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
     val entry = enriched.entry
     val posterUrl = TmdbImageHelper.poster(enriched.posterPath, 500)
@@ -353,7 +396,7 @@ private fun TvShowCard(
 
     Card(
         onClick = onClick,
-        modifier = Modifier
+        modifier = modifier
             .width(180.dp)
             .aspectRatio(2f / 3f)
             .semantics { contentDescription = cardDescription },


### PR DESCRIPTION
## Summary

When navigating from `TvHomeScreen` → `ShowDetailScreen` and pressing **Back** on Android TV, D-pad focus did not return to the show the user opened — it dropped to the first card in the grid. On a 10-foot UI with no touch fallback this is disorienting.

`TvHomeShelves` had no focus-restoration infrastructure at all (no `FocusRequester`, no remembered focused-item id, no saved `LazyListState`). Compose for TV's `Modifier.focusRestorer()` would not have helped here either — it uses plain `remember`, which doesn't survive the home composable being torn down and recomposed when the detail screen is popped off the nav back stack.

## Changes

`app-tv/.../tv/ui/home/TvHomeScreen.kt` only:

- Track the focused show's stable id (`trakt?.toString() ?: title`) in `rememberSaveable`, scoped to the home destination's `SaveableStateHolder` so it survives nav pop.
- `rememberLazyListState()` for both "Continue Watching" and "All Shows" `LazyRow`s so scroll position is restored too.
- Per-card `FocusRequester`s held in a `remember(list)` map so they're rebuilt when the show list changes (no leaks for shows that disappear).
- `Modifier.onFocusChanged { if (it.isFocused) focusedShowKey = key }` on each `TvShowCard` to keep the saved id in sync as the user moves focus.
- A `LaunchedEffect(continueWatching, allOthers, allShowsExpanded)` finds the matching card after the list is composed, scrolls to it, and `requestFocus()`. No-ops cleanly if the show was removed from the list (e.g. fully watched) or lives in a now-collapsed section.
- `TvShowCard` gains an optional `modifier: Modifier = Modifier` parameter for the call-site modifiers — no behaviour change for any other caller.

No changes to `TvNavGraph`, `TvHomeViewModel`, or `ShowDetailScreen` — the focus state is fully encapsulated in the home composition.

## Test plan

- [ ] D-pad to the 3rd card in "Continue Watching", press OK → enters detail; press Back → focus lands on the same 3rd card.
- [ ] Repeat with a card in "All Shows" that requires horizontal scrolling → focus and scroll position both restored.
- [ ] Open a card, then while in detail mark all episodes watched so the show falls out of the list (#362), press Back → no crash; default focus applies.
- [ ] Collapse "All Shows" before navigating → behaviour unchanged for cards opened from "Continue Watching".
- [ ] Background the app and resume → focused card is still selected (saveable survives process death within the back-stack entry).

## Notes for reviewer

- `scripts/precommit.sh` ran but the **Gradle scope was skipped** — this sandbox has no Android SDK (per `CLAUDE.md`'s sandbox carve-out). Backend / workflow scopes did not apply (no relevant changes). CI's `Test & Build` job is the real gate for this PR.

https://claude.ai/code/session_01M94HphdWhH2Tedn74NKHJM

---
_Generated by [Claude Code](https://claude.ai/code/session_01M94HphdWhH2Tedn74NKHJM)_