### PR TITLE
fix(backend): set NODE_ENV=production in Dockerfile and modernise npm ci flag

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ FROM node:25-alpine
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-RUN npm ci --production
+RUN npm ci --omit=dev
 
 COPY src/ ./src/
 
@@ -11,5 +11,7 @@ COPY src/ ./src/
 USER node
 
 EXPOSE 3000
+
+ENV NODE_ENV=production
 
 CMD ["node", "src/index.js"]

--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -1239,6 +1239,51 @@ describe('Debug logging — Trakt API call details (debug: true)', () => {
   });
 });
 
+// ── Production-mode safety ─────────────────────────────────────────────────
+
+describe('Production-mode safety — no internal details in responses', () => {
+  let errorSpy;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('does not include a stack trace in the error response body', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    const res = await request(app)
+      .post('/trakt/token')
+      .set('Content-Type', 'application/json')
+      .set('Content-Encoding', 'utterly-invalid-encoding')
+      .send('{"code":"abc"}');
+    expect(res.status).toBe(500);
+    const body = JSON.stringify(res.body);
+    expect(body).not.toMatch(/at\s+\w+\s+\(.*:\d+:\d+\)/); // stack frame pattern
+    expect(body).not.toMatch(/Error:/);
+  });
+
+  it('does not include Express internal error HTML in any response body', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    const res = await request(app).get('/does-not-exist');
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.text).not.toMatch(/<html/i);
+  });
+
+  it('global error handler returns JSON, not HTML, for unhandled errors', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    const res = await request(app)
+      .post('/trakt/token')
+      .set('Content-Type', 'application/json')
+      .set('Content-Encoding', 'utterly-invalid-encoding')
+      .send('{"code":"abc"}');
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.body).toEqual({ error: 'internal_error' });
+  });
+});
+
 // ── filterTokenResponse (shared helper) ────────────────────────────────────
 
 describe('filterTokenResponse — extra Trakt fields are stripped', () => {


### PR DESCRIPTION
## Summary

- Adds `ENV NODE_ENV=production` to `backend/Dockerfile` before `CMD` so Express runs in production mode: compact error responses (no stack traces), stricter helmet defaults, and faster middleware paths
- Updates `RUN npm ci --production` → `RUN npm ci --omit=dev` — same behaviour, but `--production` is deprecated in npm v9+ and `--omit=dev` is the canonical replacement
- Adds three tests covering production-mode safety: no stack-trace pattern in error bodies, no Express HTML fallback on unknown routes, and the global error handler always returns `application/json`

## Test plan

- [x] `npm --prefix backend test` — all 104 tests pass (101 existing + 3 new)
- [x] `npm --prefix backend run lint` — no ESLint warnings
- [x] `npm --prefix backend run format:check` — Prettier clean
- [x] `./scripts/precommit.sh` — all relevant checks passed

## Notes for reviewers

The Gradle scope was skipped (no Android SDK in this environment). CI (`build-android.yml`) is the gate for Kotlin/Android changes; this PR only touches `backend/`.

Closes #554

https://claude.ai/code/session_01FRLNchQnk3tViQtVoVoxBD

---
_Generated by [Claude Code](https://claude.ai/code/session_01FRLNchQnk3tViQtVoVoxBD)_