### PR TITLE
fix(backend): rate-limit and cache /health to close DoS amplification gap

### DIFF
--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -44,6 +44,7 @@ function buildApp(fetchFn, overrides = {}) {
     clientSecret: 'test-client-secret',
     traktApi: 'https://api.trakt.tv',
     fetchFn,
+    healthCacheTtlMs: 0, // disable caching in tests unless explicitly overridden
     ...overrides,
   });
 }
@@ -1538,5 +1539,130 @@ describe('Body parser hardening — content type and size limits', () => {
     const app = buildApp(mockFetch(200, {}));
     const res = await request(app).get('/health');
     expect(res.status).not.toBe(415);
+  });
+});
+
+// ── Rate limiter — /health (#556) ──────────────────────────────────────────
+
+describe('Rate limiter — /health endpoint (#556)', () => {
+  it('allows up to 10 requests per minute to /health', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    for (let i = 0; i < 10; i++) {
+      const res = await request(app).get('/health');
+      expect(res.status).not.toBe(429);
+    }
+  });
+
+  it('returns 429 on the 11th /health request within a window', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    for (let i = 0; i < 10; i++) {
+      await request(app).get('/health');
+    }
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(429);
+    expect(res.body).toEqual({ error: 'Too many requests, please try again later.' });
+  });
+
+  it('still applies the global rate limiter to /trakt routes', async () => {
+    const app = buildApp(
+      mockFetch(200, {
+        access_token: 'acc',
+        refresh_token: 'ref',
+        expires_in: 7776000,
+        token_type: 'Bearer',
+        scope: 'public',
+      })
+    );
+    // A single /trakt/token request should succeed (well within the 60/min global limit)
+    const res = await request(app).post('/trakt/token').send({ code: 'device-code-abc' });
+    expect(res.status).toBe(200);
+  });
+
+  it('/health rate limit response is JSON', async () => {
+    const app = buildApp(mockFetch(200, {}));
+    for (let i = 0; i < 11; i++) {
+      await request(app).get('/health');
+    }
+    const res = await request(app).get('/health');
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+  });
+});
+
+// ── Health response caching (#556) ─────────────────────────────────────────
+
+describe('Health response caching (#556)', () => {
+  it('returns cached response within TTL', async () => {
+    // Build app with a short TTL and credential state that starts as "pending"
+    const app = buildApp(mockFetch(200, {}), { healthCacheTtlMs: 5_000 });
+
+    // First call — caches "starting / pending"
+    const first = await request(app).get('/health');
+    expect(first.status).toBe(503);
+    expect(first.body.status).toBe('starting');
+
+    // Verify credentials so in-memory state changes to "connected"
+    await app.verifyCredentials();
+
+    // Second call within TTL — should still return cached "starting"
+    const second = await request(app).get('/health');
+    expect(second.status).toBe(503);
+    expect(second.body.status).toBe('starting');
+  });
+
+  it('returns fresh response after TTL expires', async () => {
+    vi.useFakeTimers();
+    try {
+      const app = buildApp(mockFetch(200, {}), { healthCacheTtlMs: 5_000 });
+
+      // First call — caches "starting"
+      await request(app).get('/health');
+
+      // Verify credentials so underlying state is now "connected"
+      await app.verifyCredentials();
+
+      // Advance past the 5s TTL
+      vi.advanceTimersByTime(6_000);
+
+      // Next call should return the fresh "connected" state
+      const res = await request(app).get('/health');
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe('ok');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not cache when healthCacheTtlMs is 0', async () => {
+    // buildApp defaults to healthCacheTtlMs: 0
+    const app = buildApp(mockFetch(200, {}));
+
+    // First call — pending state, not cached
+    const first = await request(app).get('/health');
+    expect(first.body.status).toBe('starting');
+
+    await app.verifyCredentials();
+
+    // Second call — should reflect updated state immediately
+    const second = await request(app).get('/health');
+    expect(second.status).toBe(200);
+    expect(second.body.status).toBe('ok');
+  });
+
+  it('clearHealthCache exposes a way to invalidate the cache', async () => {
+    const app = buildApp(mockFetch(200, {}), { healthCacheTtlMs: 60_000 });
+
+    // Cache "starting" state
+    await request(app).get('/health');
+    await app.verifyCredentials();
+
+    // Without clearing the cache, health still shows "starting"
+    const stale = await request(app).get('/health');
+    expect(stale.body.status).toBe('starting');
+
+    // After clearing, health reflects the real state
+    app.clearHealthCache();
+    const fresh = await request(app).get('/health');
+    expect(fresh.status).toBe(200);
+    expect(fresh.body.status).toBe('ok');
   });
 });

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -52,6 +52,7 @@ function maskSecrets(obj) {
  * @param {Function} [config.fetchFn]  - fetch implementation (default: global fetch)
  * @param {number} [config.fetchTimeoutMs] - Upstream fetch timeout in ms (default: 15000)
  * @param {boolean} [config.debug]     - Enable request debug logging (default: false)
+ * @param {number} [config.healthCacheTtlMs] - TTL for /health response cache in ms (default: 30000, 0 = disabled)
  * @returns {import('express').Express}
  */
 export function createApp(config) {
@@ -63,6 +64,7 @@ export function createApp(config) {
     fetchTimeoutMs = 15_000,
     version = '0.0.0',
     debug = false,
+    healthCacheTtlMs = 30_000,
   } = config;
 
   const traktHeaders = {
@@ -310,13 +312,23 @@ export function createApp(config) {
     });
   }
 
-  // Rate limiting — Trakt allows 1000 calls/5min per app
+  // Rate limiting — Trakt allows 1000 calls/5min per app; apply globally
   const limiter = rateLimit({
     windowMs: 60 * 1000, // 1 minute
     limit: 60, // 60 requests per minute per IP
     message: { error: 'Too many requests, please try again later.' },
   });
-  app.use('/trakt', limiter);
+  app.use(limiter);
+
+  // Stricter limit for /health — 10 requests per minute per IP
+  const healthLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    limit: 10,
+    message: { error: 'Too many requests, please try again later.' },
+  });
+
+  // Cache state for /health — prevents rapid re-evaluation and amplification
+  let healthCache = null; // { body: object, status: number, expiresAt: number }
 
   // ── POST /trakt/token ───────────────────────────────────────────────────────
   // Body: { "code": "<device_code>" }
@@ -427,25 +439,35 @@ export function createApp(config) {
   });
 
   // ── GET /health ─────────────────────────────────────────────────────────────
-  app.get('/health', (_req, res) => {
+  app.get('/health', healthLimiter, (_req, res) => {
+    const now = Date.now();
+    if (healthCache && healthCache.expiresAt > now) {
+      return res.status(healthCache.status).json(healthCache.body);
+    }
+
+    let status, body;
     if (serverMisconfigured && traktStatus === 'pending') {
-      return res.status(503).json({
+      status = 503;
+      body = {
         status: 'misconfigured',
         trakt: 'missing_client_secret',
         error: 'TRAKT_CLIENT_SECRET is not set — token exchange is disabled.',
-      });
+      };
+    } else if (traktStatus === 'pending') {
+      status = 503;
+      body = { status: 'starting', trakt: 'pending' };
+    } else if (credentialsVerified) {
+      status = 200;
+      body = { status: 'ok', trakt: 'connected', validated: 'client_id_via_oauth' };
+    } else {
+      status = 503;
+      body = { status: 'unhealthy', trakt: traktStatus, error: traktError };
     }
-    if (traktStatus === 'pending') {
-      return res.status(503).json({ status: 'starting', trakt: 'pending' });
+
+    if (healthCacheTtlMs > 0) {
+      healthCache = { body, status, expiresAt: now + healthCacheTtlMs };
     }
-    if (credentialsVerified) {
-      return res.json({ status: 'ok', trakt: 'connected', validated: 'client_id_via_oauth' });
-    }
-    return res.status(503).json({
-      status: 'unhealthy',
-      trakt: traktStatus,
-      error: traktError,
-    });
+    return res.status(status).json(body);
   });
 
   // Catch-all 404 — keeps unknown paths off Express's default HTML response.
@@ -463,6 +485,9 @@ export function createApp(config) {
   app.verifyCredentials = verifyCredentials;
   app.clearRetryTimer = () => {
     if (retryTimer) clearTimeout(retryTimer);
+  };
+  app.clearHealthCache = () => {
+    healthCache = null;
   };
 
   return app;


### PR DESCRIPTION
## Summary

- Apply the global rate limiter to **all routes** (previously only `/trakt`), so `/health` and the 404 catch-all are also covered by the 60 req/min per-IP limit
- Add a **stricter 10 req/min per-IP rate limiter** specifically on `GET /health`, preventing amplification of info-gathering or upstream Trakt calls
- Add **30-second response caching** for `/health` via an in-memory cache; the TTL is configurable (`healthCacheTtlMs`, default 30 000 ms) for testability, and `app.clearHealthCache()` is exposed so tests can invalidate it on demand

> **Note:** The Gradle scope was skipped locally (no Android SDK in this environment). CI (`build-android.yml`) is the gate for Kotlin/Android changes; this PR only modifies `backend/` so that scope does not apply.

## Test plan

- [x] New test suite `Rate limiter — /health endpoint (#556)`: verifies 429 on the 11th request within a window, JSON error body, and that `/trakt` routes still succeed
- [x] New test suite `Health response caching (#556)`: verifies cached response within TTL, fresh response after TTL expiry (using fake timers), no caching when TTL is 0, and `clearHealthCache()` invalidation
- [x] All 109 existing tests continue to pass (`healthCacheTtlMs: 0` in the `buildApp` test helper disables caching for all pre-existing tests)
- [x] ESLint + Prettier pass
- [x] Pre-commit hook passes

Closes #556

https://claude.ai/code/session_0125qp4CRa8vWWcs2T7cyhDL

---
_Generated by [Claude Code](https://claude.ai/code/session_0125qp4CRa8vWWcs2T7cyhDL)_