### PR TITLE
fix(phone): harden AEAD token storage against Keystore failure, key-rename AAD mismatch, and silent decrypt errors

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/AuthUnavailableException.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/AuthUnavailableException.kt
@@ -1,0 +1,9 @@
+package com.justb81.watchbuddy.phone.auth
+
+/**
+ * Thrown when the Android Keystore is unavailable (locked, compromised, or unsupported
+ * hardware) so callers can distinguish a hard hardware failure from a normal
+ * "no token stored" result. The UI layer translates this into a user-facing
+ * "Your device's secure storage is unavailable" message.
+ */
+class AuthUnavailableException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenAeadModule.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenAeadModule.kt
@@ -20,6 +20,12 @@ import javax.inject.Singleton
  * encrypted with a KEK that lives in the Android Keystore. Isolating this plumbing
  * in a Hilt provider keeps [TokenRepository] free of Keystore-specific init logic
  * so it can be unit-tested against a plain [Aead] mock.
+ *
+ * If the Keystore is unavailable (locked, hardware failure, compromised device) the
+ * provider returns a [BrokenAead] sentinel instead of throwing, so the Hilt graph
+ * still builds and the app can show a meaningful error before the first UI frame.
+ * Any call to [BrokenAead.encrypt] or [BrokenAead.decrypt] throws
+ * [AuthUnavailableException], which [TokenRepository] propagates to callers.
  */
 @Module
 @InstallIn(SingletonComponent::class)
@@ -33,16 +39,30 @@ object TokenAeadModule {
     @Provides
     @Singleton
     fun provideTokenAead(@ApplicationContext context: Context): Aead {
-        DiagnosticLog.event(TAG, "registering Tink AEAD config")
-        AeadConfig.register()
+        return try {
+            DiagnosticLog.event(TAG, "registering Tink AEAD config")
+            AeadConfig.register()
+            DiagnosticLog.event(TAG, "opening Keystore-wrapped Tink keyset")
+            AndroidKeysetManager.Builder()
+                .withSharedPref(context, KEYSET_NAME, KEYSET_PREFS_NAME)
+                .withKeyTemplate(KeyTemplates.get("AES256_GCM"))
+                .withMasterKeyUri(KEYSTORE_URI)
+                .build()
+                .keysetHandle
+                .getPrimitive(Aead::class.java)
+        } catch (e: Exception) {
+            DiagnosticLog.error(TAG, "Keystore AEAD init failed — auth storage unavailable", e)
+            BrokenAead(AuthUnavailableException("Keystore unavailable: ${e.message}", e))
+        }
+    }
 
-        DiagnosticLog.event(TAG, "opening Keystore-wrapped Tink keyset")
-        return AndroidKeysetManager.Builder()
-            .withSharedPref(context, KEYSET_NAME, KEYSET_PREFS_NAME)
-            .withKeyTemplate(KeyTemplates.get("AES256_GCM"))
-            .withMasterKeyUri(KEYSTORE_URI)
-            .build()
-            .keysetHandle
-            .getPrimitive(Aead::class.java)
+    /**
+     * Sentinel returned when the Keystore fails to initialise. Every operation
+     * rethrows the original failure as [AuthUnavailableException] so the Hilt
+     * graph builds and the UI can present a typed error instead of crashing.
+     */
+    private class BrokenAead(private val reason: AuthUnavailableException) : Aead {
+        override fun encrypt(plaintext: ByteArray, associatedData: ByteArray): ByteArray = throw reason
+        override fun decrypt(ciphertext: ByteArray, associatedData: ByteArray): ByteArray = throw reason
     }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRepository.kt
@@ -16,8 +16,22 @@ import javax.inject.Singleton
  *
  * Storage is implemented with Tink's AEAD primitive (AES-256-GCM) keyed by a Tink keyset
  * that is itself wrapped by an Android Keystore master key. The keyset + master-key
- * plumbing lives in [TokenAeadFactory]; this class consumes the primitive via
+ * plumbing lives in [TokenAeadModule]; this class consumes the primitive via
  * dependency injection so unit tests can inject a fake.
+ *
+ * ## Ciphertext versioning
+ * All new encryptions write a `v1:` prefix before the Base64 ciphertext and use a
+ * fixed AAD constant ([AEAD_FIXED_AAD]) independent of the storage key name. Values
+ * written by earlier builds (no prefix, key-name AAD) are detected and transparently
+ * re-encrypted on first read so the fleet self-migrates without a forced re-auth.
+ *
+ * ## Error handling
+ * - AEAD primitive unavailable (Keystore locked / hardware failure): every call that
+ *   touches the primitive throws [AuthUnavailableException]. Callers **must not** swallow
+ *   this — it propagates to the UI, which shows a typed error message.
+ * - Ciphertext corruption / AAD mismatch: [hadDecryptionFailure] is set to `true`, an
+ *   ERROR-level breadcrumb is emitted via [DiagnosticLog], and the affected getter
+ *   returns `null` so the app falls back to the sign-in screen with an informative banner.
  *
  * On first launch after an upgrade from a build that used
  * `androidx.security:security-crypto` (deprecated, #430) the legacy
@@ -33,6 +47,15 @@ class TokenRepository @Inject constructor(
 
     private val prefs: SharedPreferences
 
+    /**
+     * Set to `true` the first time a stored ciphertext cannot be decrypted (excluding
+     * the case where no value is stored at all). The UI layer reads this flag on the
+     * sign-in screen to show an explanatory snackbar.
+     */
+    @Volatile
+    var hadDecryptionFailure: Boolean = false
+        private set
+
     init {
         migrateLegacyStoreIfPresent(context)
         prefs = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
@@ -42,9 +65,9 @@ class TokenRepository @Inject constructor(
     fun saveTokens(accessToken: String, refreshToken: String, expiresIn: Int) {
         val expiresAt = System.currentTimeMillis() + expiresIn * 1_000L
         prefs.edit {
-            putString(KEY_ACCESS_TOKEN, encrypt(KEY_ACCESS_TOKEN, accessToken))
-            putString(KEY_REFRESH_TOKEN, encrypt(KEY_REFRESH_TOKEN, refreshToken))
-            putString(KEY_EXPIRES_AT, encrypt(KEY_EXPIRES_AT, expiresAt.toString()))
+            putString(KEY_ACCESS_TOKEN, encrypt(accessToken))
+            putString(KEY_REFRESH_TOKEN, encrypt(refreshToken))
+            putString(KEY_EXPIRES_AT, encrypt(expiresAt.toString()))
         }
     }
 
@@ -61,8 +84,8 @@ class TokenRepository @Inject constructor(
 
     /**
      * Returns `true` when the access token is missing, blank, already expired, or will
-     * expire within [bufferMs] milliseconds. Used by [TokenRefreshManager] to trigger a
-     * proactive refresh before the token actually expires.
+     * expire within [bufferMs] milliseconds. Used by [com.justb81.watchbuddy.phone.auth.TokenRefreshManager]
+     * to trigger a proactive refresh before the token actually expires.
      */
     fun isTokenExpiredOrExpiringSoon(bufferMs: Long): Boolean {
         val token = getAccessToken()
@@ -82,24 +105,74 @@ class TokenRepository @Inject constructor(
     fun getClientSecret(): String = decrypt(KEY_CLIENT_SECRET, prefs.getString(KEY_CLIENT_SECRET, null)) ?: ""
 
     fun saveClientSecret(secret: String) {
-        prefs.edit { putString(KEY_CLIENT_SECRET, encrypt(KEY_CLIENT_SECRET, secret)) }
+        prefs.edit { putString(KEY_CLIENT_SECRET, encrypt(secret)) }
     }
 
     private fun readExpiresAt(): Long =
         decrypt(KEY_EXPIRES_AT, prefs.getString(KEY_EXPIRES_AT, null))?.toLongOrNull() ?: 0L
 
-    private fun encrypt(key: String, value: String): String {
-        val ciphertext = aead.encrypt(value.toByteArray(StandardCharsets.UTF_8), key.toByteArray(StandardCharsets.UTF_8))
-        return Base64.getEncoder().encodeToString(ciphertext)
+    /**
+     * Encrypts [plaintext] with the fixed AAD constant and returns a versioned
+     * storage string: `"v1:" + Base64(ciphertext)`.
+     *
+     * Throws [AuthUnavailableException] if the underlying AEAD primitive is
+     * unavailable (propagated from [TokenAeadModule.BrokenAead]).
+     */
+    private fun encrypt(plaintext: String): String {
+        val ciphertext = aead.encrypt(
+            plaintext.toByteArray(StandardCharsets.UTF_8),
+            AEAD_FIXED_AAD.toByteArray(StandardCharsets.UTF_8),
+        )
+        return V1_PREFIX + Base64.getEncoder().encodeToString(ciphertext)
     }
 
-    private fun decrypt(key: String, encoded: String?): String? {
+    /**
+     * Decrypts a stored value, handling both the current v1 format and the legacy
+     * key-name-AAD format written by earlier builds.
+     *
+     * - `v1:` prefix → strip prefix, Base64-decode, decrypt with [AEAD_FIXED_AAD].
+     * - No prefix → Base64-decode, decrypt with [storageKey] as AAD (legacy), then
+     *   immediately re-encrypt in v1 format so the value self-migrates.
+     *
+     * Returns `null` when [encoded] is `null` (nothing stored) or when decryption
+     * fails due to ciphertext corruption — in the latter case [hadDecryptionFailure]
+     * is set and an ERROR breadcrumb is logged.
+     *
+     * Throws [AuthUnavailableException] if the Keystore is unavailable.
+     */
+    private fun decrypt(storageKey: String, encoded: String?): String? {
         if (encoded == null) return null
-        return runCatching {
-            val ciphertext = Base64.getDecoder().decode(encoded)
-            aead.decrypt(ciphertext, key.toByteArray(StandardCharsets.UTF_8)).toString(StandardCharsets.UTF_8)
-        }.getOrElse {
-            DiagnosticLog.event(TAG, "decrypt failed for key=$key (${it.javaClass.simpleName})")
+        return try {
+            if (encoded.startsWith(V1_PREFIX)) {
+                val b64 = encoded.removePrefix(V1_PREFIX)
+                val ciphertext = Base64.getDecoder().decode(b64)
+                aead.decrypt(ciphertext, AEAD_FIXED_AAD.toByteArray(StandardCharsets.UTF_8))
+                    .toString(StandardCharsets.UTF_8)
+            } else {
+                // Legacy format: no prefix, AAD was the storage key name.
+                val ciphertext = Base64.getDecoder().decode(encoded)
+                val plaintext = aead.decrypt(
+                    ciphertext,
+                    storageKey.toByteArray(StandardCharsets.UTF_8),
+                ).toString(StandardCharsets.UTF_8)
+                // Re-encrypt in v1 format (best-effort; failure is non-fatal here).
+                runCatching {
+                    prefs.edit { putString(storageKey, encrypt(plaintext)) }
+                    DiagnosticLog.event(TAG, "migrated key=$storageKey to v1 AAD format")
+                }.onFailure { e ->
+                    DiagnosticLog.warn(TAG, "re-encrypt migration failed for key=$storageKey", e)
+                }
+                plaintext
+            }
+        } catch (e: AuthUnavailableException) {
+            throw e
+        } catch (e: Exception) {
+            hadDecryptionFailure = true
+            DiagnosticLog.error(
+                TAG,
+                "decrypt failed for key=$storageKey — re-auth required (${e.javaClass.simpleName})",
+                e,
+            )
             null
         }
     }
@@ -128,5 +201,14 @@ class TokenRepository @Inject constructor(
 
         const val PREFS_FILE = "watchbuddy_tokens_v2"
         const val LEGACY_PREFS_FILE = "watchbuddy_tokens"
+
+        /** Prefix prepended to all v1-format stored ciphertexts. */
+        const val V1_PREFIX = "v1:"
+
+        /**
+         * Fixed AAD used for all new encryptions. Independent of the storage key name
+         * so key renames never invalidate existing ciphertext.
+         */
+        const val AEAD_FIXED_AAD = "watchbuddy_aead_v1"
     }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
@@ -13,6 +13,7 @@ import com.justb81.watchbuddy.core.progress.ShowProgress
 import com.justb81.watchbuddy.core.progress.ShowProgressCalculator
 import com.justb81.watchbuddy.core.trakt.ScrobbleBody
 import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.phone.auth.AuthUnavailableException
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.auth.TokenRepository
 import com.justb81.watchbuddy.phone.network.WifiStateProvider
@@ -100,12 +101,13 @@ class HomeViewModel @Inject constructor(
     private fun assertTokenAccessible() {
         runCatching { tokenRepository.getAccessToken() }
             .onFailure { e ->
-                _uiState.update {
-                    it.copy(
-                        isLoading = false,
-                        error = getApplication<Application>().getString(R.string.home_sync_failed, e.message)
-                    )
+                val message = when (e) {
+                    is AuthUnavailableException ->
+                        getApplication<Application>().getString(R.string.auth_keystore_unavailable)
+                    else ->
+                        getApplication<Application>().getString(R.string.home_sync_failed, e.message)
                 }
+                _uiState.update { it.copy(isLoading = false, error = message) }
             }
     }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingScreen.kt
@@ -41,6 +41,8 @@ fun OnboardingScreen(
     viewModel: OnboardingViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val decryptFailedMessage = stringResource(R.string.onboarding_decrypt_failed_banner)
 
     LaunchedEffect(state) {
         if (state is OnboardingState.Success) onSuccess()
@@ -50,98 +52,113 @@ fun OnboardingScreen(
         viewModel.requestDeviceCode()
     }
 
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background),
-        contentAlignment = Alignment.Center
-    ) {
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(24.dp),
+    LaunchedEffect(Unit) {
+        if (viewModel.hadDecryptionFailure) {
+            snackbarHostState.showSnackbar(
+                message = decryptFailedMessage,
+                withDismissAction = true,
+                duration = SnackbarDuration.Long,
+            )
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        containerColor = MaterialTheme.colorScheme.background,
+    ) { innerPadding ->
+        Box(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 32.dp)
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
         ) {
-            // Logo / Title
-            Text(
-                text = if (isReconnect) stringResource(R.string.onboarding_reconnect_title)
-                       else stringResource(R.string.app_name),
-                style = MaterialTheme.typography.displaySmall,
-                color = MaterialTheme.colorScheme.primary,
-                fontWeight = FontWeight.Bold
-            )
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(24.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp)
+            ) {
+                // Logo / Title
+                Text(
+                    text = if (isReconnect) stringResource(R.string.onboarding_reconnect_title)
+                           else stringResource(R.string.app_name),
+                    style = MaterialTheme.typography.displaySmall,
+                    color = MaterialTheme.colorScheme.primary,
+                    fontWeight = FontWeight.Bold
+                )
 
-            Text(
-                text = stringResource(R.string.onboarding_subtitle),
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
-                textAlign = TextAlign.Center
-            )
+                Text(
+                    text = stringResource(R.string.onboarding_subtitle),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+                    textAlign = TextAlign.Center
+                )
 
-            Spacer(Modifier.height(8.dp))
+                Spacer(Modifier.height(8.dp))
 
-            AnimatedContent(
-                targetState = state,
-                transitionSpec = { fadeIn() togetherWith fadeOut() }
-            ) { currentState ->
-                when (currentState) {
-                    is OnboardingState.LoadingCode -> {
-                        CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
-                    }
-
-                    is OnboardingState.WaitingForPin -> {
-                        PinCard(
-                            userCode        = currentState.userCode,
-                            verificationUrl = currentState.verificationUrl,
-                            expiresIn       = currentState.expiresInSeconds
-                        )
-                    }
-
-                    is OnboardingState.Polling -> {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                AnimatedContent(
+                    targetState = state,
+                    transitionSpec = { fadeIn() togetherWith fadeOut() }
+                ) { currentState ->
+                    when (currentState) {
+                        is OnboardingState.LoadingCode -> {
                             CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
-                            Spacer(Modifier.height(12.dp))
-                            Text(
-                                stringResource(R.string.onboarding_waiting),
-                                color = MaterialTheme.colorScheme.onBackground
+                        }
+
+                        is OnboardingState.WaitingForPin -> {
+                            PinCard(
+                                userCode        = currentState.userCode,
+                                verificationUrl = currentState.verificationUrl,
+                                expiresIn       = currentState.expiresInSeconds
                             )
                         }
-                    }
 
-                    is OnboardingState.Error -> {
-                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                            Text(
-                                text  = currentState.message,
-                                color = MaterialTheme.colorScheme.error,
-                                textAlign = TextAlign.Center
-                            )
-                            Spacer(Modifier.height(16.dp))
-                            Button(onClick = { viewModel.requestDeviceCode() }) {
-                                Text(stringResource(R.string.onboarding_retry))
+                        is OnboardingState.Polling -> {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+                                Spacer(Modifier.height(12.dp))
+                                Text(
+                                    stringResource(R.string.onboarding_waiting),
+                                    color = MaterialTheme.colorScheme.onBackground
+                                )
                             }
                         }
-                    }
 
-                    is OnboardingState.NotConfigured -> {
-                        NotConfiguredCard(
-                            reason = currentState.reason,
-                            onOpenSettings = onOpenSettings
-                        )
-                    }
+                        is OnboardingState.Error -> {
+                            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                Text(
+                                    text  = currentState.message,
+                                    color = MaterialTheme.colorScheme.error,
+                                    textAlign = TextAlign.Center
+                                )
+                                Spacer(Modifier.height(16.dp))
+                                Button(onClick = { viewModel.requestDeviceCode() }) {
+                                    Text(stringResource(R.string.onboarding_retry))
+                                }
+                            }
+                        }
 
-                    else -> {}
+                        is OnboardingState.NotConfigured -> {
+                            NotConfiguredCard(
+                                reason = currentState.reason,
+                                onOpenSettings = onOpenSettings
+                            )
+                        }
+
+                        else -> {}
+                    }
                 }
-            }
 
-            TextButton(onClick = onSkip) {
-                Text(
-                    stringResource(
-                        if (isReconnect) R.string.settings_cancel
-                        else R.string.onboarding_skip
-                    ),
-                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
-                )
+                TextButton(onClick = onSkip) {
+                    Text(
+                        stringResource(
+                            if (isReconnect) R.string.settings_cancel
+                            else R.string.onboarding_skip
+                        ),
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+                    )
+                }
             }
         }
     }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/onboarding/OnboardingViewModel.kt
@@ -69,6 +69,16 @@ class OnboardingViewModel @Inject constructor(
     @param:Named("managedBackendAvailable") private val managedBackendAvailable: Boolean
 ) : AndroidViewModel(application) {
 
+    /**
+     * `true` when the previous sign-in session was evicted because stored tokens
+     * could not be decrypted (ciphertext corruption or AAD mismatch). The
+     * [com.justb81.watchbuddy.phone.ui.onboarding.OnboardingScreen] reads this once
+     * on launch to show an explanatory snackbar so users know why they are being
+     * asked to sign in again.
+     */
+    val hadDecryptionFailure: Boolean
+        get() = tokenRepository.hadDecryptionFailure
+
     private val _state = MutableStateFlow<OnboardingState>(OnboardingState.Idle)
     val state: StateFlow<OnboardingState> = _state.asStateFlow()
 

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -28,6 +28,8 @@
     <string name="onboarding_error_server_misconfigured">Der Authentifizierungsserver ist falsch konfiguriert. Bitte versuche es später erneut oder kontaktiere den Wartungsverantwortlichen.</string>
     <string name="onboarding_skip">Jetzt überspringen</string>
     <string name="onboarding_reconnect_title">Mit Trakt verbinden</string>
+    <string name="onboarding_decrypt_failed_banner">Deine vorherige Anmeldung konnte nicht gelesen werden. Bitte melde dich erneut an.</string>
+    <string name="auth_keystore_unavailable">Der sichere Speicher deines Geräts ist nicht verfügbar. Der Token-Schutz ist deaktiviert — bitte starte die App neu oder überprüfe die Sicherheitseinstellungen deines Geräts.</string>
 
     <!-- Home -->
     <string name="home_title">Meine Serien</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -29,6 +29,8 @@
     <string name="onboarding_error_server_misconfigured">El servidor de autenticación está mal configurado. Por favor, inténtalo más tarde o contacta al mantenedor.</string>
     <string name="onboarding_skip">Omitir por ahora</string>
     <string name="onboarding_reconnect_title">Conectar con Trakt</string>
+    <string name="onboarding_decrypt_failed_banner">Tu inicio de sesión anterior no pudo leerse. Por favor, inicia sesión de nuevo.</string>
+    <string name="auth_keystore_unavailable">El almacenamiento seguro de tu dispositivo no está disponible. La protección de tokens está desactivada — reinicia la app o comprueba los ajustes de seguridad de tu dispositivo.</string>
 
     <!-- Home -->
     <string name="home_title">Mis series</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -29,8 +29,8 @@
     <string name="onboarding_error_server_misconfigured">Le serveur d\'authentification est mal configuré. Veuillez réessayer plus tard ou contacter le mainteneur.</string>
     <string name="onboarding_skip">Ignorer pour le moment</string>
     <string name="onboarding_reconnect_title">Se connecter à Trakt</string>
-    <string name="onboarding_decrypt_failed_banner">Votre connexion précédente n'a pas pu être lue. Veuillez vous reconnecter.</string>
-    <string name="auth_keystore_unavailable">Le stockage sécurisé de votre appareil est indisponible. La protection des jetons est désactivée — veuillez redémarrer l'application ou vérifier les paramètres de sécurité de votre appareil.</string>
+    <string name="onboarding_decrypt_failed_banner">Votre connexion précédente n\'a pas pu être lue. Veuillez vous reconnecter.</string>
+    <string name="auth_keystore_unavailable">Le stockage sécurisé de votre appareil est indisponible. La protection des jetons est désactivée — veuillez redémarrer l\'application ou vérifier les paramètres de sécurité de votre appareil.</string>
 
     <!-- Home -->
     <string name="home_title">Mes séries</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -29,6 +29,8 @@
     <string name="onboarding_error_server_misconfigured">Le serveur d\'authentification est mal configuré. Veuillez réessayer plus tard ou contacter le mainteneur.</string>
     <string name="onboarding_skip">Ignorer pour le moment</string>
     <string name="onboarding_reconnect_title">Se connecter à Trakt</string>
+    <string name="onboarding_decrypt_failed_banner">Votre connexion précédente n'a pas pu être lue. Veuillez vous reconnecter.</string>
+    <string name="auth_keystore_unavailable">Le stockage sécurisé de votre appareil est indisponible. La protection des jetons est désactivée — veuillez redémarrer l'application ou vérifier les paramètres de sécurité de votre appareil.</string>
 
     <!-- Home -->
     <string name="home_title">Mes séries</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -28,6 +28,8 @@
     <string name="onboarding_error_server_misconfigured">The authentication server is misconfigured. Please try again later or contact the maintainer.</string>
     <string name="onboarding_skip">Skip for now</string>
     <string name="onboarding_reconnect_title">Connect to Trakt</string>
+    <string name="onboarding_decrypt_failed_banner">Your previous sign-in could not be read. Please sign in again.</string>
+    <string name="auth_keystore_unavailable">Your device\'s secure storage is unavailable. Token protection is disabled — please restart the app or check your device security settings.</string>
 
     <!-- Home -->
     <string name="home_title">My Shows</string>

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRepositoryTest.kt
@@ -98,7 +98,7 @@ class TokenRepositoryTest {
     inner class V1Format {
 
         @Test
-        fun `encrypt produces v1: prefix`() {
+        fun `encrypt produces v1 version prefix`() {
             val capturedValues = mutableMapOf<String, String>()
             every { mockEditor.putString(any(), any()) } answers {
                 capturedValues[firstArg()] = secondArg()

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRepositoryTest.kt
@@ -391,8 +391,9 @@ class TokenRepositoryTest {
         @Test
         fun `getAccessToken propagates AuthUnavailableException`() {
             val brokenRepo = TokenRepository(context, makeUnvailableAead())
-            // Store a non-null value so decrypt is attempted
-            every { mockPrefs.getString("access_token", null) } returns "v1:anyciphertext"
+            // Use valid Base64 so Base64.decode succeeds and aead.decrypt() gets to throw
+            val validV1 = "v1:" + Base64.getEncoder().encodeToString("placeholder".toByteArray())
+            every { mockPrefs.getString("access_token", null) } returns validV1
 
             assertThrows(AuthUnavailableException::class.java) {
                 brokenRepo.getAccessToken()
@@ -402,7 +403,8 @@ class TokenRepositoryTest {
         @Test
         fun `AuthUnavailableException does NOT set hadDecryptionFailure`() {
             val brokenRepo = TokenRepository(context, makeUnvailableAead())
-            every { mockPrefs.getString("access_token", null) } returns "v1:anyciphertext"
+            val validV1 = "v1:" + Base64.getEncoder().encodeToString("placeholder".toByteArray())
+            every { mockPrefs.getString("access_token", null) } returns validV1
 
             runCatching { brokenRepo.getAccessToken() }
 
@@ -416,7 +418,8 @@ class TokenRepositoryTest {
             every { brokenAead.encrypt(any(), any()) } throws AuthUnavailableException("locked")
             every { brokenAead.decrypt(any(), any()) } throws AuthUnavailableException("locked")
             val brokenRepo = TokenRepository(context, brokenAead)
-            every { mockPrefs.getString("access_token", null) } returns "v1:data"
+            val validV1 = "v1:" + Base64.getEncoder().encodeToString("placeholder".toByteArray())
+            every { mockPrefs.getString("access_token", null) } returns validV1
 
             // MainActivity wraps isTokenValid() in try/catch — simulate that
             val result = runCatching { brokenRepo.isTokenValid() }.getOrDefault(false)

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRepositoryTest.kt
@@ -10,6 +10,7 @@ import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
@@ -37,8 +38,8 @@ class TokenRepositoryTest {
         every { mockEditor.putString(any(), any()) } returns mockEditor
         every { mockEditor.remove(any()) } returns mockEditor
 
-        // Deterministic AEAD: the ciphertext layout is "enc($aad):$plaintext" so the
-        // tests can round-trip through Base64 without a real crypto backend.
+        // Fixed-AAD AEAD: ciphertext layout is "enc(FIXED_AAD):$plaintext" for v1 format.
+        // Supports both the new fixed-AAD and the legacy key-name AAD for migration tests.
         val plaintextSlot = slot<ByteArray>()
         val encryptAssociatedSlot = slot<ByteArray>()
         every { aead.encrypt(capture(plaintextSlot), capture(encryptAssociatedSlot)) } answers {
@@ -52,20 +53,28 @@ class TokenRepositoryTest {
             val raw = String(cipherSlot.captured, Charsets.UTF_8)
             val aad = String(decryptAssociatedSlot.captured, Charsets.UTF_8)
             val prefix = "enc($aad):"
-            require(raw.startsWith(prefix)) { "aad mismatch" }
+            require(raw.startsWith(prefix)) { "aad mismatch: expected prefix '$prefix' in '$raw'" }
             raw.removePrefix(prefix).toByteArray(Charsets.UTF_8)
         }
 
         repository = TokenRepository(context, aead)
     }
 
-    private fun storedCiphertext(key: String, plaintext: String): String {
+    /** Builds a v1-format storage string using the fixed AAD. */
+    private fun v1Ciphertext(plaintext: String): String {
+        val fixed = "watchbuddy_aead_v1"
+        val raw = "enc($fixed):$plaintext".toByteArray(Charsets.UTF_8)
+        return "v1:" + Base64.getEncoder().encodeToString(raw)
+    }
+
+    /** Builds a legacy-format storage string using the key name as AAD. */
+    private fun legacyCiphertext(key: String, plaintext: String): String {
         val bytes = "enc($key):$plaintext".toByteArray(Charsets.UTF_8)
         return Base64.getEncoder().encodeToString(bytes)
     }
 
     @Nested
-    @DisplayName("legacy migration")
+    @DisplayName("legacy migration (EncryptedSharedPreferences)")
     inner class LegacyMigration {
 
         @Test
@@ -85,6 +94,119 @@ class TokenRepositoryTest {
     }
 
     @Nested
+    @DisplayName("v1 ciphertext format (fixed AAD)")
+    inner class V1Format {
+
+        @Test
+        fun `encrypt produces v1: prefix`() {
+            val capturedValues = mutableMapOf<String, String>()
+            every { mockEditor.putString(any(), any()) } answers {
+                capturedValues[firstArg()] = secondArg()
+                mockEditor
+            }
+
+            repository.saveTokens("access-123", "refresh-456", 3600)
+
+            assertTrue(capturedValues["access_token"]!!.startsWith("v1:"), "access_token should have v1: prefix")
+            assertTrue(capturedValues["refresh_token"]!!.startsWith("v1:"), "refresh_token should have v1: prefix")
+            assertTrue(capturedValues["expires_at"]!!.startsWith("v1:"), "expires_at should have v1: prefix")
+        }
+
+        @Test
+        fun `encrypt uses fixed AAD (not key name)`() {
+            val capturedAads = mutableListOf<ByteArray>()
+            every { aead.encrypt(any(), any()) } answers {
+                capturedAads.add(secondArg())
+                "enc(watchbuddy_aead_v1):placeholder".toByteArray(Charsets.UTF_8)
+            }
+
+            repository.saveTokens("access", "refresh", 3600)
+
+            assertTrue(capturedAads.isNotEmpty())
+            capturedAads.forEach { aadBytes ->
+                assertEquals("watchbuddy_aead_v1", String(aadBytes, Charsets.UTF_8))
+            }
+        }
+
+        @Test
+        fun `decrypt reads v1-format ciphertext with fixed AAD`() {
+            every { mockPrefs.getString("access_token", null) } returns v1Ciphertext("my-access-token")
+            assertEquals("my-access-token", repository.getAccessToken())
+        }
+
+        @Test
+        fun `getRefreshToken decrypts v1-format ciphertext`() {
+            every { mockPrefs.getString("refresh_token", null) } returns v1Ciphertext("my-refresh-token")
+            assertEquals("my-refresh-token", repository.getRefreshToken())
+        }
+
+        @Test
+        fun `getClientSecret decrypts v1-format ciphertext`() {
+            every { mockPrefs.getString("trakt_client_secret", null) } returns v1Ciphertext("stored-secret")
+            assertEquals("stored-secret", repository.getClientSecret())
+        }
+
+        @Test
+        fun `getClientSecret returns empty string when nothing stored`() {
+            every { mockPrefs.getString("trakt_client_secret", null) } returns null
+            assertEquals("", repository.getClientSecret())
+        }
+    }
+
+    @Nested
+    @DisplayName("legacy AAD migration (key-name to fixed AAD)")
+    inner class LegacyAadMigration {
+
+        @Test
+        fun `decrypts legacy access_token and re-encrypts in v1 format`() {
+            every { mockPrefs.getString("access_token", null) } returns
+                legacyCiphertext("access_token", "legacy-access")
+
+            val result = repository.getAccessToken()
+
+            assertEquals("legacy-access", result)
+            // Verify re-encryption was triggered (putString called with v1: prefix)
+            verify { mockEditor.putString(eq("access_token"), match { it.startsWith("v1:") }) }
+        }
+
+        @Test
+        fun `decrypts legacy refresh_token and re-encrypts in v1 format`() {
+            every { mockPrefs.getString("refresh_token", null) } returns
+                legacyCiphertext("refresh_token", "legacy-refresh")
+
+            val result = repository.getRefreshToken()
+
+            assertEquals("legacy-refresh", result)
+            verify { mockEditor.putString(eq("refresh_token"), match { it.startsWith("v1:") }) }
+        }
+
+        @Test
+        fun `decrypts legacy client_secret and re-encrypts in v1 format`() {
+            every { mockPrefs.getString("trakt_client_secret", null) } returns
+                legacyCiphertext("trakt_client_secret", "old-secret")
+
+            val result = repository.getClientSecret()
+
+            assertEquals("old-secret", result)
+            verify { mockEditor.putString(eq("trakt_client_secret"), match { it.startsWith("v1:") }) }
+        }
+
+        @Test
+        fun `legacy format with wrong key-name AAD fails and sets hadDecryptionFailure`() {
+            // Simulate a ciphertext with AAD "wrong_key" stored under "access_token".
+            // Decrypt with key-name "access_token" will fail due to AAD mismatch.
+            val wrongAad = "enc(wrong_key):bad-plaintext".toByteArray(Charsets.UTF_8)
+            val encoded = Base64.getEncoder().encodeToString(wrongAad)
+            every { mockPrefs.getString("access_token", null) } returns encoded
+
+            val result = repository.getAccessToken()
+
+            assertNull(result)
+            assertTrue(repository.hadDecryptionFailure)
+        }
+    }
+
+    @Nested
     @DisplayName("isTokenValid")
     inner class IsTokenValid {
 
@@ -96,23 +218,23 @@ class TokenRepositoryTest {
 
         @Test
         fun `returns false when access token decrypts to blank`() {
-            every { mockPrefs.getString("access_token", null) } returns storedCiphertext("access_token", "")
+            every { mockPrefs.getString("access_token", null) } returns v1Ciphertext("")
             assertFalse(repository.isTokenValid())
         }
 
         @Test
         fun `returns true when token is present and not expired`() {
-            every { mockPrefs.getString("access_token", null) } returns storedCiphertext("access_token", "valid-token")
+            every { mockPrefs.getString("access_token", null) } returns v1Ciphertext("valid-token")
             every { mockPrefs.getString("expires_at", null) } returns
-                storedCiphertext("expires_at", (System.currentTimeMillis() + 60_000L).toString())
+                v1Ciphertext((System.currentTimeMillis() + 60_000L).toString())
             assertTrue(repository.isTokenValid())
         }
 
         @Test
         fun `returns false when token has expired`() {
-            every { mockPrefs.getString("access_token", null) } returns storedCiphertext("access_token", "expired")
+            every { mockPrefs.getString("access_token", null) } returns v1Ciphertext("expired")
             every { mockPrefs.getString("expires_at", null) } returns
-                storedCiphertext("expires_at", (System.currentTimeMillis() - 1_000L).toString())
+                v1Ciphertext((System.currentTimeMillis() - 1_000L).toString())
             assertFalse(repository.isTokenValid())
         }
     }
@@ -129,23 +251,23 @@ class TokenRepositoryTest {
 
         @Test
         fun `returns true when token decrypts to blank`() {
-            every { mockPrefs.getString("access_token", null) } returns storedCiphertext("access_token", "")
+            every { mockPrefs.getString("access_token", null) } returns v1Ciphertext("")
             assertTrue(repository.isTokenExpiredOrExpiringSoon(5 * 60_000L))
         }
 
         @Test
         fun `returns true when token expires within the buffer window`() {
-            every { mockPrefs.getString("access_token", null) } returns storedCiphertext("access_token", "token")
+            every { mockPrefs.getString("access_token", null) } returns v1Ciphertext("token")
             every { mockPrefs.getString("expires_at", null) } returns
-                storedCiphertext("expires_at", (System.currentTimeMillis() + 1_000L).toString())
+                v1Ciphertext((System.currentTimeMillis() + 1_000L).toString())
             assertTrue(repository.isTokenExpiredOrExpiringSoon(5 * 60_000L))
         }
 
         @Test
         fun `returns false when token expires well beyond the buffer`() {
-            every { mockPrefs.getString("access_token", null) } returns storedCiphertext("access_token", "token")
+            every { mockPrefs.getString("access_token", null) } returns v1Ciphertext("token")
             every { mockPrefs.getString("expires_at", null) } returns
-                storedCiphertext("expires_at", (System.currentTimeMillis() + 10 * 60_000L).toString())
+                v1Ciphertext((System.currentTimeMillis() + 10 * 60_000L).toString())
             assertFalse(repository.isTokenExpiredOrExpiringSoon(5 * 60_000L))
         }
     }
@@ -155,17 +277,23 @@ class TokenRepositoryTest {
     inner class TokenStorage {
 
         @Test
-        fun `saveTokens writes ciphertext for each key`() {
+        fun `saveTokens writes v1-format ciphertext for each key`() {
+            val capturedValues = mutableMapOf<String, String>()
+            every { mockEditor.putString(any(), any()) } answers {
+                capturedValues[firstArg()] = secondArg()
+                mockEditor
+            }
+
             repository.saveTokens("access-123", "refresh-456", 3600)
 
-            verify { mockEditor.putString("access_token", storedCiphertext("access_token", "access-123")) }
-            verify { mockEditor.putString("refresh_token", storedCiphertext("refresh_token", "refresh-456")) }
-            verify { mockEditor.putString(eq("expires_at"), any()) }
+            assertTrue(capturedValues["access_token"]!!.startsWith("v1:"))
+            assertTrue(capturedValues["refresh_token"]!!.startsWith("v1:"))
+            assertTrue(capturedValues["expires_at"]!!.startsWith("v1:"))
         }
 
         @Test
-        fun `getAccessToken decrypts the stored ciphertext`() {
-            every { mockPrefs.getString("access_token", null) } returns storedCiphertext("access_token", "my-access-token")
+        fun `getAccessToken decrypts the stored v1 ciphertext`() {
+            every { mockPrefs.getString("access_token", null) } returns v1Ciphertext("my-access-token")
             assertEquals("my-access-token", repository.getAccessToken())
         }
 
@@ -176,15 +304,39 @@ class TokenRepositoryTest {
         }
 
         @Test
-        fun `getRefreshToken decrypts the stored ciphertext`() {
-            every { mockPrefs.getString("refresh_token", null) } returns storedCiphertext("refresh_token", "my-refresh-token")
+        fun `getRefreshToken decrypts the stored v1 ciphertext`() {
+            every { mockPrefs.getString("refresh_token", null) } returns v1Ciphertext("my-refresh-token")
             assertEquals("my-refresh-token", repository.getRefreshToken())
         }
 
         @Test
-        fun `getAccessToken returns null on ciphertext corruption`() {
+        fun `getAccessToken returns null on corrupted ciphertext and sets hadDecryptionFailure`() {
             every { mockPrefs.getString("access_token", null) } returns "not-base64-or-valid-ciphertext"
             assertNull(repository.getAccessToken())
+            assertTrue(repository.hadDecryptionFailure)
+        }
+
+        @Test
+        fun `getAccessToken returns null on v1 ciphertext with wrong AAD and sets hadDecryptionFailure`() {
+            // Build a v1: blob whose inner ciphertext uses the WRONG AAD.
+            val wrongAad = "enc(wrong_aad):secret".toByteArray(Charsets.UTF_8)
+            val b64 = Base64.getEncoder().encodeToString(wrongAad)
+            every { mockPrefs.getString("access_token", null) } returns "v1:$b64"
+
+            assertNull(repository.getAccessToken())
+            assertTrue(repository.hadDecryptionFailure)
+        }
+
+        @Test
+        fun `hadDecryptionFailure starts false`() {
+            assertFalse(repository.hadDecryptionFailure)
+        }
+
+        @Test
+        fun `hadDecryptionFailure not set when stored value is null`() {
+            every { mockPrefs.getString("access_token", null) } returns null
+            repository.getAccessToken()
+            assertFalse(repository.hadDecryptionFailure)
         }
 
         @Test
@@ -202,21 +354,18 @@ class TokenRepositoryTest {
     inner class ClientSecret {
 
         @Test
-        fun `saveClientSecret writes ciphertext`() {
+        fun `saveClientSecret writes v1-format ciphertext`() {
+            val capturedValue = slot<String>()
+            every { mockEditor.putString(eq("trakt_client_secret"), capture(capturedValue)) } returns mockEditor
+
             repository.saveClientSecret("super-secret")
 
-            verify {
-                mockEditor.putString(
-                    "trakt_client_secret",
-                    storedCiphertext("trakt_client_secret", "super-secret"),
-                )
-            }
+            assertTrue(capturedValue.captured.startsWith("v1:"))
         }
 
         @Test
         fun `getClientSecret decrypts the stored value`() {
-            every { mockPrefs.getString("trakt_client_secret", null) } returns
-                storedCiphertext("trakt_client_secret", "stored-secret")
+            every { mockPrefs.getString("trakt_client_secret", null) } returns v1Ciphertext("stored-secret")
             assertEquals("stored-secret", repository.getClientSecret())
         }
 
@@ -224,6 +373,54 @@ class TokenRepositoryTest {
         fun `getClientSecret returns empty string when prefs returns null`() {
             every { mockPrefs.getString("trakt_client_secret", null) } returns null
             assertEquals("", repository.getClientSecret())
+        }
+    }
+
+    @Nested
+    @DisplayName("AuthUnavailableException propagation")
+    inner class AuthUnavailableExceptionPropagation {
+
+        private fun makeUnvailableAead(): Aead {
+            val brokenAead: Aead = mockk()
+            val reason = AuthUnavailableException("Keystore locked")
+            every { brokenAead.encrypt(any(), any()) } throws reason
+            every { brokenAead.decrypt(any(), any()) } throws reason
+            return brokenAead
+        }
+
+        @Test
+        fun `getAccessToken propagates AuthUnavailableException`() {
+            val brokenRepo = TokenRepository(context, makeUnvailableAead())
+            // Store a non-null value so decrypt is attempted
+            every { mockPrefs.getString("access_token", null) } returns "v1:anyciphertext"
+
+            assertThrows(AuthUnavailableException::class.java) {
+                brokenRepo.getAccessToken()
+            }
+        }
+
+        @Test
+        fun `AuthUnavailableException does NOT set hadDecryptionFailure`() {
+            val brokenRepo = TokenRepository(context, makeUnvailableAead())
+            every { mockPrefs.getString("access_token", null) } returns "v1:anyciphertext"
+
+            runCatching { brokenRepo.getAccessToken() }
+
+            assertFalse(brokenRepo.hadDecryptionFailure,
+                "hadDecryptionFailure must not be set for Keystore-unavailable failures")
+        }
+
+        @Test
+        fun `isTokenValid returns false and swallows AuthUnavailableException in MainActivity catch block`() {
+            val brokenAead: Aead = mockk()
+            every { brokenAead.encrypt(any(), any()) } throws AuthUnavailableException("locked")
+            every { brokenAead.decrypt(any(), any()) } throws AuthUnavailableException("locked")
+            val brokenRepo = TokenRepository(context, brokenAead)
+            every { mockPrefs.getString("access_token", null) } returns "v1:data"
+
+            // MainActivity wraps isTokenValid() in try/catch — simulate that
+            val result = runCatching { brokenRepo.isTokenValid() }.getOrDefault(false)
+            assertFalse(result)
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #531 — token decryption was silently returning `null` on AAD/key-name mismatch and Keystore failures, leading to unexplained silent logouts with no user-facing explanation.

- **`AuthUnavailableException`** — new typed exception distinguishing a hard Keystore hardware failure from a normal "no token stored" `null` return. The UI layer maps it to a specific error message instead of a generic one.
- **`TokenAeadModule`** — wraps the entire AEAD construction in `try/catch`; on failure returns a `BrokenAead` sentinel that throws `AuthUnavailableException` on every call. This prevents the Hilt graph from crashing before any UI appears, while still surfacing a typed error that reaches the UI.
- **`TokenRepository`** — four changes:
  1. **Fixed AAD** (`watchbuddy_aead_v1`) used for all new encryptions, independent of storage key names. Renames of `KEY_ACCESS_TOKEN` etc. can never silently invalidate existing ciphertext.
  2. **`v1:` version prefix** on all stored ciphertext for staged future rotation.
  3. **Transparent migration** — legacy blobs (no `v1:` prefix, key-name AAD) are detected on first read, decrypted with the old AAD, and immediately re-written in `v1:` format. No forced re-auth.
  4. **Better error reporting** — decryption failures now log `DiagnosticLog.error(...)` (was INFO) and set `hadDecryptionFailure = true`. `AuthUnavailableException` propagates to callers without touching the flag.
- **`HomeViewModel`** — `assertTokenAccessible()` maps `AuthUnavailableException` to the new `auth_keystore_unavailable` string instead of the generic `home_sync_failed`.
- **`OnboardingScreen`** — shows a `SnackbarDuration.Long` banner on launch when `viewModel.hadDecryptionFailure` is `true`, so users understand why they are being asked to sign in again.
- **Locale strings** — `onboarding_decrypt_failed_banner` and `auth_keystore_unavailable` added in EN / DE / FR / ES.
- **`TokenRepositoryTest`** — extended with tests for v1 format, fixed-AAD enforcement, legacy AAD migration + re-encryption, `hadDecryptionFailure` flag logic, and `AuthUnavailableException` propagation / flag isolation.

## Test plan

- [ ] `TokenRepositoryTest` — all unit tests pass, including new coverage for fixed AAD, v1: prefix, migration, `hadDecryptionFailure`, and `AuthUnavailableException` propagation
- [ ] CI `Test & Build` green — no new detekt / Android Lint findings
- [ ] Manual: install over existing build → legacy tokens auto-migrated to v1 format (verify via DiagnosticLog `"migrated key=… to v1 AAD format"` breadcrumb in Diagnostics share)
- [ ] Manual: corrupt a stored ciphertext in a debugger → OnboardingScreen shows the "previous sign-in could not be read" snackbar on next launch
- [ ] Manual: on a device where Keystore is unavailable/locked → app opens to Onboarding with `auth_keystore_unavailable` error instead of crashing

> **Note:** Android SDK not present in this environment — Gradle checks were skipped locally. CI is the real gate for Kotlin/Android correctness.

https://claude.ai/code/session_01Vigoc6hegNTKHm2fMFWDBS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vigoc6hegNTKHm2fMFWDBS)_