### PR TITLE
fix(core): redact sensitive headers in HttpLoggingInterceptor (Level.BODY → Level.HEADERS)

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,28 @@
+# core
+
+Shared Kotlin library module consumed by `app-phone` and `app-tv`.
+
+## HTTP Logging Policy
+
+`NetworkModule` attaches an `HttpLoggingInterceptor` to the shared `OkHttpClient`:
+
+| Build type | Log level | Body logged |
+|------------|-----------|-------------|
+| DEBUG      | `HEADERS` | No          |
+| Release    | `NONE`    | No          |
+
+### Redacted headers
+
+In DEBUG builds the following headers are replaced with `██` in logcat so that secrets never appear in plain text:
+
+| Header          | Contains                              |
+|-----------------|---------------------------------------|
+| `Authorization` | Trakt Bearer access / refresh tokens  |
+| `trakt-api-key` | Trakt client ID                       |
+| `X-API-Key`     | Generic API key used by future routes |
+
+**Do not change the log level to `BODY` in any build type** — `/oauth/token` responses carry plaintext `access_token` and `refresh_token` fields that would be broadcast to any process that reads logcat (e.g. Firebase Crashlytics, crash-reporting SDKs, testers with `adb logcat`).
+
+### Adding new sensitive headers
+
+If a new endpoint requires an additional secret header (e.g. a TMDB `X-Auth-Token`), add a corresponding `redactHeader("X-Auth-Token")` call inside the `HttpLoggingInterceptor.apply { }` block in `NetworkModule.provideOkHttpClient` **before** landing the change. The list of redacted headers is the authoritative registry; keep it in sync with this table.

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
@@ -40,8 +40,14 @@ object NetworkModule {
             chain.proceed(builder.build())
         }
         .addInterceptor(HttpLoggingInterceptor().apply {
-            level = if (com.justb81.watchbuddy.core.BuildConfig.DEBUG) HttpLoggingInterceptor.Level.BODY
-                    else HttpLoggingInterceptor.Level.NONE
+            if (com.justb81.watchbuddy.core.BuildConfig.DEBUG) {
+                level = HttpLoggingInterceptor.Level.HEADERS
+                redactHeader("Authorization")
+                redactHeader("trakt-api-key")
+                redactHeader("X-API-Key")
+            } else {
+                level = HttpLoggingInterceptor.Level.NONE
+            }
         })
         .build()
 

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
@@ -79,17 +79,57 @@ class NetworkModuleTest {
         }
 
         @Test
-        fun `logging interceptor level matches BuildConfig DEBUG`() {
+        fun `logging interceptor uses HEADERS level in DEBUG and NONE in release`() {
             val client = NetworkModule.provideOkHttpClient(traktClientId = "test-id")
             val loggingInterceptor = client.interceptors
                 .filterIsInstance<HttpLoggingInterceptor>()
                 .firstOrNull()
             assertNotNull(loggingInterceptor, "HttpLoggingInterceptor should be present")
             val expectedLevel = if (com.justb81.watchbuddy.core.BuildConfig.DEBUG)
-                HttpLoggingInterceptor.Level.BODY
+                HttpLoggingInterceptor.Level.HEADERS
             else
                 HttpLoggingInterceptor.Level.NONE
             assertEquals(expectedLevel, loggingInterceptor!!.level)
+        }
+
+        @Test
+        fun `logging interceptor never logs body in any build type`() {
+            val client = NetworkModule.provideOkHttpClient(traktClientId = "test-id")
+            val loggingInterceptor = client.interceptors
+                .filterIsInstance<HttpLoggingInterceptor>()
+                .firstOrNull()
+            assertNotNull(loggingInterceptor)
+            assertNotEquals(HttpLoggingInterceptor.Level.BODY, loggingInterceptor!!.level)
+        }
+
+        @Test
+        fun `logging interceptor redacts Authorization header in DEBUG builds`() {
+            if (!com.justb81.watchbuddy.core.BuildConfig.DEBUG) return
+            server.enqueue(MockResponse().setBody("{}"))
+            val logLines = mutableListOf<String>()
+            val client = NetworkModule.provideOkHttpClient(traktClientId = "test-id").newBuilder()
+                .also { builder ->
+                    val interceptor = HttpLoggingInterceptor { logLines.add(it) }.apply {
+                        level = HttpLoggingInterceptor.Level.HEADERS
+                        redactHeader("Authorization")
+                        redactHeader("trakt-api-key")
+                        redactHeader("X-API-Key")
+                    }
+                    builder.addInterceptor(interceptor)
+                }
+                .build()
+            client.newCall(
+                Request.Builder()
+                    .url(server.url("/test"))
+                    .addHeader("Authorization", "Bearer secret-token")
+                    .build()
+            ).execute()
+            val authLines = logLines.filter { it.contains("Authorization", ignoreCase = true) }
+            assertTrue(authLines.isNotEmpty(), "Authorization header should appear in logs")
+            assertTrue(
+                authLines.all { !it.contains("secret-token") },
+                "Authorization header value must not appear in logs: $authLines"
+            )
         }
     }
 

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
@@ -85,10 +85,11 @@ class NetworkModuleTest {
                 .filterIsInstance<HttpLoggingInterceptor>()
                 .firstOrNull()
             assertNotNull(loggingInterceptor, "HttpLoggingInterceptor should be present")
-            val expectedLevel = if (com.justb81.watchbuddy.core.BuildConfig.DEBUG)
+            val expectedLevel = if (com.justb81.watchbuddy.core.BuildConfig.DEBUG) {
                 HttpLoggingInterceptor.Level.HEADERS
-            else
+            } else {
                 HttpLoggingInterceptor.Level.NONE
+            }
             assertEquals(expectedLevel, loggingInterceptor!!.level)
         }
 


### PR DESCRIPTION
## Summary

- Replaces `HttpLoggingInterceptor.Level.BODY` with `Level.HEADERS` in `NetworkModule.provideOkHttpClient` so HTTP response bodies are never written to logcat in any build type.
- Adds `redactHeader("Authorization")`, `redactHeader("trakt-api-key")`, and `redactHeader("X-API-Key")` so bearer tokens and API keys are masked with `██` even in header-level logs.
- Adds `core/README.md` with an HTTP Logging Policy section that documents the log level table, the set of redacted headers, and the rule for adding new secret headers in future.
- Updates `NetworkModuleTest`: replaces the old `Level.BODY` assertion with `Level.HEADERS`, adds a test that `Level.BODY` is never used in any build type, and adds a test verifying the Authorization header value is not captured in log output.

> **Note:** Gradle checks (detekt / Android Lint / unit tests) were skipped locally — no Android SDK in this sandboxed environment. CI (`build-android.yml`) is the real gate for Kotlin/Android changes.

## Test plan

- [ ] `./gradlew :core:test` — all `NetworkModuleTest` cases green, including the three new logging assertions.
- [ ] `./gradlew detektAll` — no new findings beyond baseline.
- [ ] `./gradlew :app-phone:lintDebug :app-tv:lintDebug` — no new findings.
- [ ] Manual smoke test on a DEBUG build: `adb logcat | grep -i "bearer\|access_token\|refresh_token"` — no matches while the app makes network calls.

Closes #565

https://claude.ai/code/session_01Su63DSvvUyQwVVSx3CCw5L

---
_Generated by [Claude Code](https://claude.ai/code/session_01Su63DSvvUyQwVVSx3CCw5L)_