### PR TITLE
fix(tv): prevent duplicate ambiguous scrobble overlays on transient phone failure

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
@@ -21,7 +21,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import retrofit2.HttpException
 import java.io.IOException
-import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -62,6 +61,8 @@ class TvScrobbleDispatcher(
         private const val TAG = "TvScrobbleDispatcher"
         internal const val QUEUE_MAX_SIZE = 16
         internal const val QUEUE_TTL_MS = 5 * 60 * 1_000L
+        /** At-most-once delivery window for ambiguous prompts. Keys older than this are evicted. */
+        internal const val AMBIGUOUS_KEY_TTL_MS = 30 * 60 * 1_000L
     }
 
     internal enum class ScrobbleAction { START, PAUSE, STOP }
@@ -77,17 +78,23 @@ class TvScrobbleDispatcher(
     private val queueMutex = Mutex()
     private val pendingQueue = ArrayDeque<QueuedScrobble>()
 
-    /** Session keys for which an ambiguous prompt has already been dispatched. Cleared on resolution. */
-    private val dispatchedAmbiguousKeys: MutableSet<String> =
-        Collections.newSetFromMap(ConcurrentHashMap())
+    /**
+     * Session keys for which an ambiguous prompt has already been dispatched, mapped to the
+     * timestamp (ms) at which the key was first registered.
+     *
+     * At-most-once semantics: the key is kept even when no phones are available so a transient
+     * phone outage never causes the same overlay to appear twice. Entries are evicted lazily
+     * after [AMBIGUOUS_KEY_TTL_MS] (30 min) so the map does not grow without bound.
+     * Explicit removal happens via [clearResolvedPrompt] once the phone confirms resolution.
+     */
+    private val dispatchedAmbiguousKeys: ConcurrentHashMap<String, Long> = ConcurrentHashMap()
 
     /**
      * TMDB IDs for which the user has already confirmed an add-to-library this session.
      * Prevents duplicate Trakt history writes when the overlay is confirmed more than once
      * for the same unknown show. Cleared on service restart.
      */
-    private val confirmedUnknownTmdbIds: MutableSet<Int> =
-        Collections.newSetFromMap(ConcurrentHashMap())
+    private val confirmedUnknownTmdbIds: MutableSet<Int> = ConcurrentHashMap.newKeySet()
 
     init {
         replayScope.launch {
@@ -245,13 +252,23 @@ class TvScrobbleDispatcher(
      * Fans [event] to every reachable phone in parallel. Idempotent on [AmbiguousScrobbleEvent.sessionKey]:
      * if the same session key has been dispatched already (and not yet resolved via
      * [clearResolvedPrompt]), this is a no-op so repeated poll cycles don't stack notifications.
+     *
+     * At-most-once delivery: the key is kept even when no phones are reachable at dispatch time.
+     * A transient outage must not cause the phone to display the same overlay again when it
+     * reconnects. Stale keys are evicted lazily after [AMBIGUOUS_KEY_TTL_MS].
      */
     suspend fun dispatchAmbiguous(event: AmbiguousScrobbleEvent) {
-        if (!dispatchedAmbiguousKeys.add(event.sessionKey)) return
+        val now = clock()
+        // Lazily evict keys whose TTL has elapsed so the map does not grow without bound.
+        dispatchedAmbiguousKeys.entries.removeIf { (_, registeredAtMs) ->
+            now - registeredAtMs > AMBIGUOUS_KEY_TTL_MS
+        }
+        // putIfAbsent returns null when the key is new (successfully inserted) and the
+        // existing timestamp when the key was already present.
+        if (dispatchedAmbiguousKeys.putIfAbsent(event.sessionKey, now) != null) return
         val phones = availablePhones()
         if (phones.isEmpty()) {
-            DiagnosticLog.warn(TAG, "ambiguous prompt dropped — no phones reachable for '${event.sessionKey}'")
-            dispatchedAmbiguousKeys.remove(event.sessionKey)
+            DiagnosticLog.warn(TAG, "ambiguous prompt held — no phones reachable for '${event.sessionKey}', will not retry")
             return
         }
         coroutineScope {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
@@ -61,6 +61,7 @@ class TvScrobbleDispatcher(
         private const val TAG = "TvScrobbleDispatcher"
         internal const val QUEUE_MAX_SIZE = 16
         internal const val QUEUE_TTL_MS = 5 * 60 * 1_000L
+
         /** At-most-once delivery window for ambiguous prompts. Keys older than this are evicted. */
         internal const val AMBIGUOUS_KEY_TTL_MS = 30 * 60 * 1_000L
     }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
@@ -1,7 +1,10 @@
 package com.justb81.watchbuddy.tv.scrobbler
 
 import android.net.nsd.NsdServiceInfo
+import com.justb81.watchbuddy.core.model.AmbiguousCandidate
+import com.justb81.watchbuddy.core.model.AmbiguousScrobbleEvent
 import com.justb81.watchbuddy.core.model.LlmBackend
+import com.justb81.watchbuddy.core.model.PlaybackTick
 import com.justb81.watchbuddy.tv.TestFixtures
 import com.justb81.watchbuddy.tv.discovery.DiscoveryConstants
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
@@ -528,5 +531,158 @@ class TvScrobbleDispatcherTest {
 
             coVerify(exactly = 0) { phoneApiClientFactory.createClient(any()) }
         }
+    }
+
+    // ── dispatchAmbiguous (#542) ───────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("dispatchAmbiguous — at-most-once delivery (#542)")
+    inner class DispatchAmbiguousTest {
+
+        private fun makeEvent(sessionKey: String = "session-abc") = AmbiguousScrobbleEvent(
+            sessionKey = sessionKey,
+            packageName = "com.netflix.mediaclient",
+            candidates = listOf(
+                AmbiguousCandidate(
+                    show = TestFixtures.traktShow(),
+                    episode = TestFixtures.traktEpisode(),
+                    score = 0.65f,
+                    sourceLabel = "library",
+                )
+            ),
+            tick = PlaybackTick(
+                state = PlaybackTick.STATE_PLAYING,
+                positionMs = 600_000L,
+                durationMs = 2_700_000L,
+                capturedAtMs = fakeNow,
+            ),
+            capturedAtMs = fakeNow,
+        )
+
+        @Test
+        fun `dispatches event to all available phones`() = runTest(UnconfinedTestDispatcher()) {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+            val apiService1: PhoneApiService = mockk()
+            val apiService2: PhoneApiService = mockk()
+            val phone1 = makePhone(baseUrl = "http://phone1:8765/", name = "phone1")
+            val phone2 = makePhone(baseUrl = "http://phone2:8765/", name = "phone2")
+            phonesFlow.value = listOf(phone1, phone2)
+            coEvery { phoneApiClientFactory.createClient("http://phone1:8765/") } returns apiService1
+            coEvery { phoneApiClientFactory.createClient("http://phone2:8765/") } returns apiService2
+            coEvery { apiService1.scrobblePrompt(any()) } returns mockk()
+            coEvery { apiService2.scrobblePrompt(any()) } returns mockk()
+
+            dispatcher.dispatchAmbiguous(makeEvent())
+
+            coVerify { apiService1.scrobblePrompt(any()) }
+            coVerify { apiService2.scrobblePrompt(any()) }
+        }
+
+        @Test
+        fun `second call with same key is no-op even when phones are available`() = runTest(UnconfinedTestDispatcher()) {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+            val phone = makePhone()
+            phonesFlow.value = listOf(phone)
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobblePrompt(any()) } returns mockk()
+
+            val event = makeEvent()
+            dispatcher.dispatchAmbiguous(event)
+            dispatcher.dispatchAmbiguous(event)
+
+            coVerify(exactly = 1) { phoneApiService.scrobblePrompt(any()) }
+        }
+
+        @Test
+        fun `key is NOT removed when no phones available — transient failure does not allow re-dispatch`() =
+            runTest(UnconfinedTestDispatcher()) {
+                dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+                // First call: no phones available — key is registered but nothing is sent.
+                phonesFlow.value = emptyList()
+                val event = makeEvent()
+                dispatcher.dispatchAmbiguous(event)
+
+                // Phone becomes available — but the key is still registered so re-dispatch is blocked.
+                phonesFlow.value = listOf(makePhone())
+                coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+                coEvery { phoneApiService.scrobblePrompt(any()) } returns mockk()
+                dispatcher.dispatchAmbiguous(event)
+
+                coVerify(exactly = 0) { phoneApiService.scrobblePrompt(any()) }
+            }
+
+        @Test
+        fun `clearResolvedPrompt removes key and allows a fresh dispatch`() = runTest(UnconfinedTestDispatcher()) {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+            val phone = makePhone()
+            phonesFlow.value = listOf(phone)
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobblePrompt(any()) } returns mockk()
+
+            val event = makeEvent()
+            dispatcher.dispatchAmbiguous(event)
+            coVerify(exactly = 1) { phoneApiService.scrobblePrompt(any()) }
+
+            dispatcher.clearResolvedPrompt(event.sessionKey)
+            dispatcher.dispatchAmbiguous(event)
+
+            coVerify(exactly = 2) { phoneApiService.scrobblePrompt(any()) }
+        }
+
+        @Test
+        fun `expired key (past AMBIGUOUS_KEY_TTL_MS) is evicted and allows re-dispatch`() =
+            runTest(UnconfinedTestDispatcher()) {
+                dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+                val phone = makePhone()
+                phonesFlow.value = listOf(phone)
+                coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+                coEvery { phoneApiService.scrobblePrompt(any()) } returns mockk()
+
+                val event = makeEvent()
+                dispatcher.dispatchAmbiguous(event)
+                coVerify(exactly = 1) { phoneApiService.scrobblePrompt(any()) }
+
+                // Advance clock past TTL — the key should be evicted on next call.
+                fakeNow += TvScrobbleDispatcher.AMBIGUOUS_KEY_TTL_MS + 1_000L
+                // Update the phone's lastSuccessfulCheck so it stays fresh at the new clock time.
+                phonesFlow.value = listOf(makePhone(lastSuccessfulCheck = fakeNow))
+
+                dispatcher.dispatchAmbiguous(event)
+
+                coVerify(exactly = 2) { phoneApiService.scrobblePrompt(any()) }
+            }
+
+        @Test
+        fun `different session keys are dispatched independently`() = runTest(UnconfinedTestDispatcher()) {
+            dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+            val phone = makePhone()
+            phonesFlow.value = listOf(phone)
+            coEvery { phoneApiClientFactory.createClient(any()) } returns phoneApiService
+            coEvery { phoneApiService.scrobblePrompt(any()) } returns mockk()
+
+            dispatcher.dispatchAmbiguous(makeEvent(sessionKey = "session-1"))
+            dispatcher.dispatchAmbiguous(makeEvent(sessionKey = "session-2"))
+
+            coVerify(exactly = 2) { phoneApiService.scrobblePrompt(any()) }
+        }
+
+        @Test
+        fun `IOException on one phone does not prevent dispatch to other phones`() =
+            runTest(UnconfinedTestDispatcher()) {
+                dispatcher = TvScrobbleDispatcher(phoneDiscovery, phoneApiClientFactory, backgroundScope) { fakeNow }
+                val apiService1: PhoneApiService = mockk()
+                val apiService2: PhoneApiService = mockk()
+                val phone1 = makePhone(baseUrl = "http://phone1:8765/", name = "phone1")
+                val phone2 = makePhone(baseUrl = "http://phone2:8765/", name = "phone2")
+                phonesFlow.value = listOf(phone1, phone2)
+                coEvery { phoneApiClientFactory.createClient("http://phone1:8765/") } returns apiService1
+                coEvery { phoneApiClientFactory.createClient("http://phone2:8765/") } returns apiService2
+                coEvery { apiService1.scrobblePrompt(any()) } throws IOException("connection refused")
+                coEvery { apiService2.scrobblePrompt(any()) } returns mockk()
+
+                dispatcher.dispatchAmbiguous(makeEvent())
+
+                coVerify { apiService2.scrobblePrompt(any()) }
+            }
     }
 }


### PR DESCRIPTION
## Summary

- **Root cause (#542):** `dispatchAmbiguous()` removed `event.sessionKey` from `dispatchedAmbiguousKeys` when no phones were reachable. If a phone had already received and displayed the prompt before going temporarily stale, it would receive — and show — the same overlay again on the next successful dispatch cycle.
- **Fix:** The key is now kept in the map even when no phones are reachable at dispatch time (at-most-once semantics). A transient outage cannot re-trigger a prompt the user has already seen.
- **TTL:** `dispatchedAmbiguousKeys` changed from `Set<String>` to `ConcurrentHashMap<String, Long>` (key → registration timestamp). Entries are evicted lazily after `AMBIGUOUS_KEY_TTL_MS` (30 min) so long-running sessions don't accumulate stale keys. Explicit removal still happens via `clearResolvedPrompt` once the phone confirms resolution.
- **Cleanup:** `confirmedUnknownTmdbIds` switched from `Collections.newSetFromMap(ConcurrentHashMap())` to the simpler `ConcurrentHashMap.newKeySet()`.

## Test plan

- [x] `dispatchAmbiguous` fans out to all available phones
- [x] Second call with same session key is a no-op (at-most-once)
- [x] Key is **not** removed when no phones available — second call after phones return is still blocked
- [x] `clearResolvedPrompt` removes the key and re-enables dispatch for that session
- [x] Key expired past `AMBIGUOUS_KEY_TTL_MS` is evicted and allows a fresh dispatch
- [x] Different session keys are dispatched independently
- [x] `IOException` on one phone does not prevent dispatch to other phones

> **Note:** Android SDK not present in this environment — Gradle checks were skipped locally. CI is the real gate for Kotlin/Android correctness.

Closes #542

https://claude.ai/code/session_01BRYMz8SeM4uXsqauTMQz2N

---
_Generated by [Claude Code](https://claude.ai/code/session_01BRYMz8SeM4uXsqauTMQz2N)_