### PR TITLE
fix(backend): register SIGTERM/SIGINT handlers for clean shutdown (#559)

### DIFF
--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -738,6 +738,75 @@ describe('Credential verification', () => {
   });
 });
 
+// ── Graceful shutdown — clearRetryTimer (#559) ────────────────────────────
+
+describe('Graceful shutdown — clearRetryTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('clearRetryTimer is a no-op when no retry is pending', () => {
+    const app = buildApp(mockFetch(200, {}));
+    // Should not throw when called with no pending timer
+    expect(() => app.clearRetryTimer()).not.toThrow();
+  });
+
+  it('clearRetryTimer cancels a pending retry so it never fires', async () => {
+    const fetchFn = mockFetch(503, {});
+    const app = buildApp(fetchFn);
+
+    await app.verifyCredentials();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // Cancel before the first retry delay (5s) elapses
+    app.clearRetryTimer();
+
+    // Advancing well past all retry windows must not trigger another call
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('clearRetryTimer can be called multiple times safely', async () => {
+    const fetchFn = mockFetch(503, {});
+    const app = buildApp(fetchFn);
+
+    await app.verifyCredentials();
+
+    app.clearRetryTimer();
+    expect(() => app.clearRetryTimer()).not.toThrow();
+    expect(() => app.clearRetryTimer()).not.toThrow();
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('clearRetryTimer stops retries mid-sequence', async () => {
+    const fetchFn = mockFetch(503, {});
+    const app = buildApp(fetchFn);
+
+    await app.verifyCredentials();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+
+    // Let the first retry fire
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+
+    // Cancel before the second retry (15s) fires
+    app.clearRetryTimer();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+});
+
 // ── Credential verification retry ─────────────────────────────────────────
 
 describe('Credential verification retry', () => {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -37,7 +37,7 @@ const app = createApp({
   debug,
 });
 
-app.listen(PORT, () => {
+const server = app.listen(PORT, () => {
   console.log(`WatchBuddy token proxy running on port ${PORT}`);
   if (debug) {
     console.log('Debug mode enabled — request logging is active');
@@ -46,3 +46,11 @@ app.listen(PORT, () => {
   // will report "starting" until this completes.
   app.verifyCredentials();
 });
+
+const shutdown = () => {
+  app.clearRetryTimer();
+  server.close(() => process.exit(0));
+  // Force exit if the server hasn't closed within 10 s (e.g. keep-alive connections).
+  setTimeout(() => process.exit(1), 10_000).unref();
+};
+['SIGTERM', 'SIGINT'].forEach((s) => process.on(s, shutdown));


### PR DESCRIPTION
## Summary

- `index.js` now registers `SIGTERM` and `SIGINT` handlers that call `app.clearRetryTimer()` before closing the HTTP server gracefully
- A forced `process.exit(1)` fires after 10 s (`.unref()`'d) so keep-alive connections can never block orchestrator teardown
- Adds 4 new unit tests covering `clearRetryTimer()` cancel semantics (no-op when idle, cancels mid-sequence, safe to call multiple times)

## Test plan

- [x] `npm --prefix backend test` — 116 tests pass (4 new)
- [x] `npm --prefix backend run lint` — no ESLint warnings
- [x] `npm --prefix backend run format:check` — Prettier clean
- [x] `./scripts/precommit.sh` — all backend checks pass

> **Note:** Gradle/Android scope was skipped (no Android SDK in this environment); CI (`build-android.yml`) is the gate for Kotlin changes. Only backend files were modified in this PR.

Closes #559

https://claude.ai/code/session_01NCpS9feUQVM1ihMscAko6L

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCpS9feUQVM1ihMscAko6L)_