### PR TITLE
fix(release): harden signing-secret hygiene in release workflow

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -32,6 +32,7 @@ jobs:
               - 'app-phone/**'
               - 'app-tv/**'
               - 'core/**'
+              - 'build-logic/**'
               - '*.gradle.kts'
               - 'gradle/**'
               - 'gradle.properties'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ on:
 permissions:
   contents: read
 
+# Prevent concurrent release runs — queues new pushes rather than running them
+# in parallel, which would create conflicting GitHub Releases and Play edits.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
   release-please:
     name: Release Please
@@ -47,6 +53,18 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/setup-android-build
 
+      # -- Re-mask signing secrets so they are redacted even if a Gradle
+      # plugin, stack trace, or diagnostic task echoes environment state.
+      - name: Mask signing secrets
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          echo "::add-mask::$KEYSTORE_PASSWORD"
+          echo "::add-mask::$KEY_ALIAS"
+          echo "::add-mask::$KEY_PASSWORD"
+
       # -- Prepare release signing ----------------------------------------
       - name: Decode Keystore
         id: keystore
@@ -57,6 +75,24 @@ jobs:
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
           fi
+
+      # Write signing credentials to ~/.gradle/gradle.properties (chmod 600)
+      # instead of exporting them as plain environment variables. Gradle reads
+      # project properties from this file without ever printing them.
+      - name: Write signing credentials to Gradle properties
+        if: steps.keystore.outputs.available == 'true'
+        env:
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          mkdir -p ~/.gradle
+          {
+            printf 'watchbuddy.signing.storePassword=%s\n' "$KEYSTORE_PASSWORD"
+            printf 'watchbuddy.signing.keyAlias=%s\n' "$KEY_ALIAS"
+            printf 'watchbuddy.signing.keyPassword=%s\n' "$KEY_PASSWORD"
+          } >> ~/.gradle/gradle.properties
+          chmod 600 ~/.gradle/gradle.properties
 
       # -- Check Play Store credentials -----------------------------------
       - name: Check Play Store credentials
@@ -74,13 +110,14 @@ jobs:
       # -- Signed release builds (APK + AAB) ------------------------------
       # Build phone + TV in a single Gradle invocation so the `core` module
       # compiles once and the task graph is resolved once.
+      # Signing credentials (KEYSTORE_PASSWORD, KEY_ALIAS, KEY_PASSWORD) are
+      # intentionally absent here — they were written to ~/.gradle/gradle.properties
+      # above and Gradle reads them as project properties, keeping them out of
+      # the environment and therefore out of any env-dump diagnostics or logs.
       - name: Build signed Phone + TV release (APK + AAB)
         if: steps.keystore.outputs.available == 'true'
         env:
           KEYSTORE_FILE: /tmp/release.keystore
-          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
-          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
-          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           VERSION_NAME: ${{ needs.release-please.outputs.version }}
           VERSION_CODE: ${{ github.run_number }}
           TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
@@ -285,6 +322,17 @@ jobs:
             release-assets/*.aab
             release-assets/*-native-debug-symbols.zip
             release-assets/*-mapping.txt
+
+      # -- Clean up sensitive files on disk ----------------------------------
+      # Runs unconditionally (even on failure) so secrets are never left on a
+      # potentially-reused runner between jobs.
+      - name: Clean up signing credentials
+        if: always()
+        run: |
+          rm -f /tmp/release.keystore /tmp/gpp-sa.json
+          if [ -f ~/.gradle/gradle.properties ]; then
+            sed -i '/^watchbuddy\.signing\./d' ~/.gradle/gradle.properties
+          fi
 
   update-stable:
     name: Update stable branch

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,8 +85,9 @@ watchbuddy/
 │       ├── stats.yml           CI: refreshes the README "Code Statistics" table after a green main build
 │       └── test-backend.yml    CI: tests for the Node.js backend
 ├── scripts/
-│   ├── precommit.sh            Scoped local mirror of CI checks (see "Local pre-commit checks")
-│   └── update-readme-stats.sh  Regenerates the README "Code Statistics" block (cloc + JUnit + Jest)
+│   ├── precommit.sh                  Scoped local mirror of CI checks (see "Local pre-commit checks")
+│   ├── validate-release-security.py  Validates release.yml signing-secret hygiene (run by precommit.sh when release.yml is staged)
+│   └── update-readme-stats.sh        Regenerates the README "Code Statistics" block (cloc + JUnit + Jest)
 └── gradle/
     └── libs.versions.toml  Version catalog (single source of truth for dependencies)
 ```
@@ -154,6 +155,14 @@ The only exceptions are **localization string resources** (`values-de/`, `values
 - `./gradlew :app-tv:assembleDebug` — TV only
 - Secrets via `local.properties` (not checked in) or environment variables for CI
 - Convention plugins live in `build-logic/convention/`. `watchbuddy.android.library` is applied by `core`; `watchbuddy.android.application` is applied by `app-phone` and `app-tv`. Both plugins centralise `compileSdk`, Java/Kotlin 17 options, Hilt/KSP wiring, and test dependencies so module `build.gradle.kts` files declare only what is unique to that module.
+
+**Release signing credentials** are passed via Gradle project properties, not environment variables, so they never appear in env-var dumps or third-party plugin logs. CI writes them to `~/.gradle/gradle.properties` (chmod 600) in the `release.yml` workflow. For local release builds, add them to your personal `~/.gradle/gradle.properties`:
+```
+watchbuddy.signing.storePassword=<your keystore password>
+watchbuddy.signing.keyAlias=<your key alias>
+watchbuddy.signing.keyPassword=<your key password>
+```
+The keystore file path is still supplied via the `KEYSTORE_FILE` environment variable (it is not a secret). The convention plugin (`watchbuddy.android.application.gradle.kts`) reads the Gradle properties via `providers.gradleProperty("watchbuddy.signing.*")`.
 
 ### Static analysis
 - `./gradlew detektAll` — runs detekt (Kotlin static analysis) on every module. Config: `config/detekt/detekt.yml`. Baselines: `<module>/detekt-baseline.xml`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ Once enabled, `.githooks/pre-commit` delegates to `scripts/precommit.sh` on ever
 
 **Scoping rules** (must match the CI `paths-filter` sets exactly):
 
-- `app-phone/**`, `app-tv/**`, `core/**`, `*.gradle.kts`, `gradle/**`, `gradle.properties`, `config/detekt/**`, `.github/actions/**` → `./gradlew test detektAll :app-phone:lintDebug :app-tv:lintDebug`
+- `app-phone/**`, `app-tv/**`, `core/**`, `build-logic/**`, `*.gradle.kts`, `gradle/**`, `gradle.properties`, `config/detekt/**`, `.github/actions/**` → `./gradlew test detektAll :app-phone:lintDebug :app-tv:lintDebug`
 - `backend/**` → `npm --prefix backend run lint && npm --prefix backend run format:check && npm --prefix backend test`
 - `.github/workflows/*.y?ml` → `python3 yaml.safe_load` on each changed file + `actionlint` when installed
 

--- a/build-logic/convention/src/main/kotlin/watchbuddy.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/watchbuddy.android.application.gradle.kts
@@ -12,7 +12,9 @@ plugins {
 
 val libs = the<LibrariesForLibs>()
 
-// CI signing: keystore path + credentials via environment variables.
+// CI signing: keystore path via environment variable; credentials via Gradle
+// properties (watchbuddy.signing.*) written to ~/.gradle/gradle.properties by
+// the workflow with chmod 600, so they never appear in env-var dumps or logs.
 // takeIf guards against KEYSTORE_FILE being set to an empty string (e.g. when
 // the secret is absent and the workflow sets the variable to '' as a fallback).
 val keystoreFile = providers.environmentVariable("KEYSTORE_FILE").orNull?.takeIf { it.isNotBlank() }
@@ -34,9 +36,9 @@ android {
         signingConfigs {
             create("release") {
                 storeFile = file(keystoreFile)
-                storePassword = providers.environmentVariable("KEYSTORE_PASSWORD").orNull
-                keyAlias = providers.environmentVariable("KEY_ALIAS").orNull
-                keyPassword = providers.environmentVariable("KEY_PASSWORD").orNull
+                storePassword = providers.gradleProperty("watchbuddy.signing.storePassword").orNull
+                keyAlias = providers.gradleProperty("watchbuddy.signing.keyAlias").orNull
+                keyPassword = providers.gradleProperty("watchbuddy.signing.keyPassword").orNull
             }
         }
     }

--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -49,7 +49,7 @@ ran_any=0
 skipped_android=0
 
 # --- Android / Kotlin scope (mirrors build-android.yml `android:` filter) ---
-if match '^(app-phone|app-tv|core)/' \
+if match '^(app-phone|app-tv|core|build-logic)/' \
    || match '\.gradle\.kts$' \
    || match '^gradle/' \
    || match '^gradle\.properties$' \

--- a/scripts/precommit.sh
+++ b/scripts/precommit.sh
@@ -97,6 +97,12 @@ if match '^\.github/workflows/.*\.ya?ml$'; then
   else
     echo "precommit: actionlint not installed — skipping (install via 'go install github.com/rhysd/actionlint/cmd/actionlint@latest' or 'brew install actionlint')"
   fi
+
+  # Security check: verify release.yml does not expose signing secrets as plain env vars.
+  if printf '%s\n' "$STAGED" | grep -q '^\.github/workflows/release\.yml$'; then
+    section "Release workflow security check"
+    python3 scripts/validate-release-security.py
+  fi
 fi
 
 if [ "$ran_any" = "0" ] && [ "$skipped_android" = "0" ]; then

--- a/scripts/validate-release-security.py
+++ b/scripts/validate-release-security.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Validates security properties of .github/workflows/release.yml.
+
+Checks that signing credentials are not exposed as plain env vars in the
+Gradle build step, that secrets are re-masked, that a cleanup step exists,
+and that concurrency is configured to prevent overlapping releases.
+"""
+
+import sys
+import yaml
+
+WORKFLOW_PATH = ".github/workflows/release.yml"
+SIGNING_SECRET_KEYS = {"KEYSTORE_PASSWORD", "KEY_ALIAS", "KEY_PASSWORD"}
+
+
+def fail(msg: str) -> None:
+    print(f"FAIL: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def find_steps(workflow: dict) -> list[dict]:
+    steps = []
+    for job in workflow.get("jobs", {}).values():
+        steps.extend(job.get("steps", []))
+    return steps
+
+
+def main() -> None:
+    with open(WORKFLOW_PATH) as f:
+        workflow = yaml.safe_load(f)
+
+    # 1. Workflow-level concurrency must be configured.
+    concurrency = workflow.get("concurrency")
+    if not concurrency:
+        fail("release.yml is missing a top-level 'concurrency:' group — overlapping releases can corrupt GitHub Releases and Play edits.")
+    if concurrency.get("cancel-in-progress", True) is True:
+        fail("release.yml concurrency.cancel-in-progress must be false — cancelling an in-progress release can leave artifacts in an inconsistent state.")
+
+    steps = find_steps(workflow)
+
+    # 2. A masking step must emit ::add-mask:: for every signing secret.
+    mask_steps = [
+        s for s in steps
+        if s.get("run") and "add-mask" in s.get("run", "")
+    ]
+    if not mask_steps:
+        fail("No '::add-mask::' step found — signing secrets must be re-masked before any Gradle invocation.")
+    for key in SIGNING_SECRET_KEYS:
+        if not any(key in s.get("run", "") for s in mask_steps):
+            fail(f"Signing secret {key!r} is not masked via '::add-mask::' in any step.")
+
+    # 3. Signing secrets must NOT appear in env of the Gradle build step.
+    build_steps = [
+        s for s in steps
+        if s.get("run") and "gradlew" in s.get("run", "") and "assembleRelease" in s.get("run", "")
+    ]
+    if not build_steps:
+        fail("Could not locate the Gradle release build step — check validate-release-security.py if the step name changed.")
+    for build_step in build_steps:
+        env = build_step.get("env") or {}
+        leaked = SIGNING_SECRET_KEYS & set(env.keys())
+        if leaked:
+            fail(
+                f"Signing secret(s) {leaked} are set as plain env vars on the Gradle build step. "
+                "Write them to ~/.gradle/gradle.properties instead."
+            )
+
+    # 4. A cleanup step must run with `if: always()`.
+    cleanup_steps = [
+        s for s in steps
+        if s.get("if") == "always()" and s.get("run") and "release.keystore" in s.get("run", "")
+    ]
+    if not cleanup_steps:
+        fail("No cleanup step found with 'if: always()' that removes /tmp/release.keystore — secrets may persist on a reused runner.")
+
+    # 5. Signing credentials must be written to ~/.gradle/gradle.properties.
+    props_steps = [
+        s for s in steps
+        if s.get("run") and "gradle.properties" in s.get("run", "") and "watchbuddy.signing" in s.get("run", "")
+    ]
+    if not props_steps:
+        fail("No step found that writes 'watchbuddy.signing.*' properties to gradle.properties — signing credentials must not travel as env vars.")
+
+    print(f"OK: {WORKFLOW_PATH} passes all signing-security checks.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Addresses the critical secret-handling issue reported in #562. Signing credentials (`KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`) were passed as plain environment variables to `./gradlew`, risking exposure in build logs if any Gradle plugin, stack trace, or diagnostic task echoes the environment.

- **Re-mask secrets** via `::add-mask::` immediately before any Gradle invocation, so the values are redacted from logs even if a plugin or stack trace echoes environment state.
- **Write credentials to `~/.gradle/gradle.properties`** (chmod 600) instead of exporting them as env vars. The `watchbuddy.android.application` convention plugin now reads them via `providers.gradleProperty("watchbuddy.signing.{storePassword,keyAlias,keyPassword}")`.
- **Add a cleanup step** (`if: always()`) that removes `/tmp/release.keystore`, `/tmp/gpp-sa.json`, and the `watchbuddy.signing.*` entries from `gradle.properties` so secrets are not left on a potentially-reused runner.
- **Add `concurrency: group: release / cancel-in-progress: false`** to prevent parallel release runs from creating conflicting GitHub Releases or Play Store edits.
- **Add `scripts/validate-release-security.py`** — a test script that asserts the signing-secret hygiene properties (no secrets in build-step env, masking present, cleanup present, concurrency configured). Integrated into `precommit.sh` so it runs whenever `release.yml` is staged.

## Note on Gradle SDK skip

The Android SDK is not available in this environment so the Gradle checks (tests / detekt / Android Lint) were skipped locally. CI (`build-android.yml`) is the real gate for the convention-plugin change.

## Test plan

- [x] `scripts/validate-release-security.py` passes against the updated `release.yml`
- [x] Precommit YAML syntax check passes
- [x] Convention plugin updated to use `providers.gradleProperty()` for all three credentials
- [ ] CI `Test & Build` check on this PR (covers the convention-plugin Kotlin change)

Closes #562

https://claude.ai/code/session_01P7TXhR1TP4cyVUuAEjDogG

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7TXhR1TP4cyVUuAEjDogG)_