### PR TITLE
fix(core): add explicit OkHttpClient timeouts and fix TokenProxyServiceFactory client reuse

### DIFF
--- a/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
@@ -18,6 +18,9 @@ import java.util.concurrent.TimeUnit
 import javax.inject.Named
 import javax.inject.Singleton
 
+private const val CONNECT_TIMEOUT_SECONDS = 10L
+private const val READ_TIMEOUT_SECONDS = 30L
+private const val CALL_TIMEOUT_SECONDS = 45L
 private const val JUSTWATCH_TIMEOUT_SECONDS = 5L
 private const val JUSTWATCH_USER_AGENT = "Mozilla/5.0 (Linux; Android 14) WatchBuddy"
 
@@ -30,6 +33,12 @@ object NetworkModule {
     fun provideOkHttpClient(
         @Named("traktClientId") traktClientId: String,
     ): OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .readTimeout(READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .callTimeout(CALL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        // Trakt scrobble endpoints (/scrobble/start|pause|stop) are not idempotent;
+        // a silent retry would double-charge a watch event on Trakt's side.
+        .retryOnConnectionFailure(false)
         .addInterceptor { chain ->
             val builder = chain.request().newBuilder()
                 .addHeader("Content-Type", "application/json")

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/TokenProxyServiceFactory.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/TokenProxyServiceFactory.kt
@@ -15,13 +15,15 @@ import javax.inject.Singleton
  * instead of relying on the build-time TOKEN_BACKEND_URL.
  */
 @Singleton
-class TokenProxyServiceFactory @Inject constructor() {
+class TokenProxyServiceFactory @Inject constructor(
+    private val sharedClient: OkHttpClient,
+) {
 
     fun create(baseUrl: String): TokenProxyService {
         val url = if (baseUrl.endsWith("/")) baseUrl else "$baseUrl/"
         return Retrofit.Builder()
             .baseUrl(url)
-            .client(OkHttpClient())
+            .client(sharedClient)
             .addConverterFactory(WatchBuddyJson.asConverterFactory("application/json".toMediaType()))
             .build()
             .create(TokenProxyService::class.java)

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/NetworkModuleTest.kt
@@ -73,6 +73,20 @@ class NetworkModuleTest {
         }
 
         @Test
+        fun `has explicit connect read and call timeouts`() {
+            val client = NetworkModule.provideOkHttpClient(traktClientId = "test-id")
+            assertEquals(10_000, client.connectTimeoutMillis)
+            assertEquals(30_000, client.readTimeoutMillis)
+            assertEquals(45_000, client.callTimeoutMillis)
+        }
+
+        @Test
+        fun `disables retry on connection failure to prevent double-charging Trakt scrobble endpoints`() {
+            val client = NetworkModule.provideOkHttpClient(traktClientId = "test-id")
+            assertFalse(client.retryOnConnectionFailure)
+        }
+
+        @Test
         fun `does not apply certificate pinning`() {
             val client = NetworkModule.provideOkHttpClient(traktClientId = "test-id")
             assertTrue(client.certificatePinner.pins.isEmpty())

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/TokenProxyServiceFactoryTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/TokenProxyServiceFactoryTest.kt
@@ -1,13 +1,35 @@
 package com.justb81.watchbuddy.core.network
 
+import com.justb81.watchbuddy.core.trakt.ProxyTokenRequest
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 @DisplayName("TokenProxyServiceFactory")
 class TokenProxyServiceFactoryTest {
 
-    private val factory = TokenProxyServiceFactory()
+    private lateinit var server: MockWebServer
+    private lateinit var sharedClient: OkHttpClient
+    private lateinit var factory: TokenProxyServiceFactory
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        sharedClient = NetworkModule.provideOkHttpClient(traktClientId = "test-id")
+        factory = TokenProxyServiceFactory(sharedClient)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
 
     @Test
     fun `creates non-null service from valid URL`() {
@@ -32,5 +54,39 @@ class TokenProxyServiceFactoryTest {
         val service1 = factory.create("https://proxy1.example.com")
         val service2 = factory.create("https://proxy2.example.com")
         assertNotSame(service1, service2)
+    }
+
+    @Test
+    fun `uses shared client timeouts`() {
+        assertEquals(10_000, sharedClient.connectTimeoutMillis)
+        assertEquals(30_000, sharedClient.readTimeoutMillis)
+        assertEquals(45_000, sharedClient.callTimeoutMillis)
+    }
+
+    @Test
+    fun `inherits retryOnConnectionFailure false from shared client`() {
+        assertFalse(sharedClient.retryOnConnectionFailure)
+    }
+
+    @Test
+    fun `forwards interceptors from the shared client to outgoing requests`() {
+        val headerName = "X-Test-Marker"
+        val headerValue = "shared-client-active"
+        val customClient = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                chain.proceed(chain.request().newBuilder().header(headerName, headerValue).build())
+            }
+            .build()
+        val tokenResponse = """
+            {"access_token":"t","refresh_token":"r","expires_in":7776000,
+             "token_type":"Bearer","scope":"public"}
+        """.trimIndent()
+        server.enqueue(MockResponse().setResponseCode(200).setBody(tokenResponse))
+        val service = TokenProxyServiceFactory(customClient).create(server.url("/").toString())
+        runBlocking {
+            try { service.exchangeDeviceCode(ProxyTokenRequest("code")) } catch (_: Exception) {}
+        }
+        val recorded = server.takeRequest()
+        assertEquals(headerValue, recorded.getHeader(headerName))
     }
 }


### PR DESCRIPTION
## Summary

- **Explicit timeouts on the shared `OkHttpClient`**: `connectTimeout(10 s)`, `readTimeout(30 s)`, `callTimeout(45 s)` — replaces the implicit 10 s OkHttp default and aligns all Trakt/TMDB calls to consistent, intentional values.
- **`retryOnConnectionFailure(false)`**: prevents silent retries on non-idempotent Trakt scrobble endpoints (`/scrobble/start|pause|stop`) that would otherwise double-charge a watch event.
- **`TokenProxyServiceFactory` now accepts the shared `OkHttpClient`** via constructor injection instead of constructing a blank `OkHttpClient()` — the old blank client bypassed every shared interceptor (logging, Trakt headers) and had no timeouts.
- **New tests**: explicit timeout assertions, `retryOnConnectionFailure=false`, and an end-to-end interceptor-forwarding test via `MockWebServer` that proves the injected client's interceptors reach outgoing requests.

Closes #564

## Test plan

- [ ] `NetworkModuleTest.has explicit connect read and call timeouts` — asserts `connectTimeoutMillis=10000`, `readTimeoutMillis=30000`, `callTimeoutMillis=45000`
- [ ] `NetworkModuleTest.disables retry on connection failure to prevent double-charging Trakt scrobble endpoints` — asserts `retryOnConnectionFailure=false`
- [ ] `TokenProxyServiceFactoryTest.uses shared client timeouts` — asserts timeout values match the shared client
- [ ] `TokenProxyServiceFactoryTest.inherits retryOnConnectionFailure false from shared client` — asserts retry is disabled
- [ ] `TokenProxyServiceFactoryTest.forwards interceptors from the shared client to outgoing requests` — makes a live call to `MockWebServer` and verifies custom interceptor header is present

> **Note:** Gradle/Android checks were skipped locally (no Android SDK in this environment). CI (`build-android.yml`) is the real gate.

https://claude.ai/code/session_01YXD7NcySxmAQqpwAFCskWL

---
_Generated by [Claude Code](https://claude.ai/code/session_01YXD7NcySxmAQqpwAFCskWL)_