### PR TITLE
fix(tv): atomic Mutex creation in JustWatchDeepLinkRepository via ConcurrentHashMap

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
@@ -7,15 +7,16 @@ import com.justb81.watchbuddy.core.justwatch.JustWatchOffer
 import com.justb81.watchbuddy.core.justwatch.JustWatchPackageMap
 import com.justb81.watchbuddy.core.justwatch.JustWatchTitle
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import java.util.ArrayDeque
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import retrofit2.Response
-import java.util.ArrayDeque
-import javax.inject.Inject
-import javax.inject.Singleton
 
 private val ALLOWED_MONETIZATION = setOf("FLATRATE", "ADS", "FREE")
 private const val SEARCH_RESULT_LIMIT = 5
@@ -69,8 +70,7 @@ class JustWatchDeepLinkRepository @Inject constructor(
         val countryCode: String,
     )
 
-    private val fetchMutexMap = mutableMapOf<FetchKey, Mutex>()
-    private val mapLock = Mutex()
+    private val fetchMutexMap = ConcurrentHashMap<FetchKey, Mutex>()
 
     // ── In-memory diagnostics ─────────────────────────────────────────────────
 
@@ -168,9 +168,7 @@ class JustWatchDeepLinkRepository @Inject constructor(
     private fun JustWatchDeepLink.isValidCache(): Boolean =
         standardWebUrl != null || !isNegativeExpired(this)
 
-    private suspend fun getMutex(key: FetchKey): Mutex = mapLock.withLock {
-        fetchMutexMap.getOrPut(key) { Mutex() }
-    }
+    private fun getMutex(key: FetchKey): Mutex = fetchMutexMap.computeIfAbsent(key) { Mutex() }
 
     private fun isNegativeExpired(entry: JustWatchDeepLink): Boolean =
         entry.standardWebUrl == null &&

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
@@ -7,16 +7,16 @@ import com.justb81.watchbuddy.core.justwatch.JustWatchOffer
 import com.justb81.watchbuddy.core.justwatch.JustWatchPackageMap
 import com.justb81.watchbuddy.core.justwatch.JustWatchTitle
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
-import java.util.ArrayDeque
-import java.util.concurrent.ConcurrentHashMap
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import retrofit2.Response
+import java.util.ArrayDeque
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
 
 private val ALLOWED_MONETIZATION = setOf("FLATRATE", "ADS", "FREE")
 private const val SEARCH_RESULT_LIMIT = 5

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
@@ -524,28 +524,28 @@ class JustWatchDeepLinkRepositoryTest {
         }
     }
 
+    private class FakeDao : JustWatchDeepLinkDao {
+        private val store = ConcurrentHashMap<String, JustWatchDeepLink>()
+
+        private fun key(showId: Int, season: Int, episode: Int, providerId: Int, countryCode: String) =
+            "$showId:$season:$episode:$providerId:$countryCode"
+
+        override suspend fun get(showId: Int, season: Int, episode: Int, providerId: Int, countryCode: String): JustWatchDeepLink? =
+            store[key(showId, season, episode, providerId, countryCode)]
+
+        override suspend fun upsert(entry: JustWatchDeepLink) {
+            store[key(entry.tmdbShowId, entry.season, entry.episode, entry.providerId, entry.countryCode)] = entry
+        }
+
+        override suspend fun deleteAll() = store.clear()
+        override suspend fun countPositive(): Int = store.values.count { it.standardWebUrl != null }
+        override suspend fun countNegative(): Int = store.values.count { it.standardWebUrl == null }
+        override suspend fun lastFetchedAt(): Long? = store.values.maxOfOrNull { it.fetchedAt }
+    }
+
     @Nested
     @DisplayName("fetch deduplication")
     inner class FetchDeduplicationTests {
-
-        private class FakeDao : JustWatchDeepLinkDao {
-            private val store = ConcurrentHashMap<String, JustWatchDeepLink>()
-
-            private fun key(showId: Int, season: Int, episode: Int, providerId: Int, countryCode: String) =
-                "$showId:$season:$episode:$providerId:$countryCode"
-
-            override suspend fun get(showId: Int, season: Int, episode: Int, providerId: Int, countryCode: String): JustWatchDeepLink? =
-                store[key(showId, season, episode, providerId, countryCode)]
-
-            override suspend fun upsert(entry: JustWatchDeepLink) {
-                store[key(entry.tmdbShowId, entry.season, entry.episode, entry.providerId, entry.countryCode)] = entry
-            }
-
-            override suspend fun deleteAll() = store.clear()
-            override suspend fun countPositive(): Int = store.values.count { it.standardWebUrl != null }
-            override suspend fun countNegative(): Int = store.values.count { it.standardWebUrl == null }
-            override suspend fun lastFetchedAt(): Long? = store.values.maxOfOrNull { it.fetchedAt }
-        }
 
         @Test
         fun `100 concurrent requests for same episode deduplicate to a single API roundtrip`() =

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
@@ -18,8 +18,14 @@ import io.mockk.coVerify
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
@@ -516,5 +522,64 @@ class JustWatchDeepLinkRepositoryTest {
         fun `lastFetchError returns null initially`() {
             assertNull(repository.lastFetchError())
         }
+    }
+
+    @Nested
+    @DisplayName("fetch deduplication")
+    inner class FetchDeduplicationTests {
+
+        private class FakeDao : JustWatchDeepLinkDao {
+            private val store = ConcurrentHashMap<String, JustWatchDeepLink>()
+
+            private fun key(showId: Int, season: Int, episode: Int, providerId: Int, countryCode: String) =
+                "$showId:$season:$episode:$providerId:$countryCode"
+
+            override suspend fun get(showId: Int, season: Int, episode: Int, providerId: Int, countryCode: String): JustWatchDeepLink? =
+                store[key(showId, season, episode, providerId, countryCode)]
+
+            override suspend fun upsert(entry: JustWatchDeepLink) {
+                store[key(entry.tmdbShowId, entry.season, entry.episode, entry.providerId, entry.countryCode)] = entry
+            }
+
+            override suspend fun deleteAll() = store.clear()
+            override suspend fun countPositive(): Int = store.values.count { it.standardWebUrl != null }
+            override suspend fun countNegative(): Int = store.values.count { it.standardWebUrl == null }
+            override suspend fun lastFetchedAt(): Long? = store.values.maxOfOrNull { it.fetchedAt }
+        }
+
+        @Test
+        fun `100 concurrent requests for same episode deduplicate to a single API roundtrip`() =
+            runTest(UnconfinedTestDispatcher()) {
+                val searchCallCount = AtomicInteger(0)
+                val fakeDao = FakeDao()
+                val episodeOffer = makeOffer(url = "https://www.netflix.com/watch/42")
+
+                coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } coAnswers {
+                    // yield so all waiting coroutines can race to the mutex before the
+                    // fetch result is written to the cache
+                    yield()
+                    searchCallCount.incrementAndGet()
+                    makeSearchResponse(offers = listOf(episodeOffer))
+                }
+                coEvery { api.query(match { it.query == JustWatchApiService.SEASONS_QUERY }) } returns
+                    makeSeasonsResponse(listOf("season-1-id"))
+                coEvery { api.query(match { it.query == JustWatchApiService.EPISODES_QUERY }) } returns
+                    makeEpisodesResponse(
+                        listOf(JustWatchEpisode(episodeNumber = 2, seasonNumber = 1, offers = listOf(episodeOffer)))
+                    )
+
+                val repo = JustWatchDeepLinkRepository(fakeDao, api)
+
+                val results = (1..100).map {
+                    async { repo.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad") }
+                }.awaitAll()
+
+                assertTrue(results.all { it == "https://www.netflix.com/watch/42" })
+                assertEquals(
+                    1,
+                    searchCallCount.get(),
+                    "Expected exactly 1 SEARCH_QUERY call for 100 concurrent requests, got ${searchCallCount.get()}",
+                )
+            }
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
@@ -18,8 +18,6 @@ import io.mockk.coVerify
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -40,6 +38,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import retrofit2.Response
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @DisplayName("JustWatchDeepLinkRepository")


### PR DESCRIPTION
## Summary

- Replaces `mutableMapOf<FetchKey, Mutex>` + a separate `mapLock: Mutex` with `ConcurrentHashMap<FetchKey, Mutex>` in `JustWatchDeepLinkRepository`.
- The old `getMutex` held `mapLock`, retrieved/created the per-key `Mutex`, then **returned it to the caller to use outside `mapLock`**. If eviction were ever added to the map, two coroutines could obtain different `Mutex` instances for the same `FetchKey`, defeating the dedup guarantee.
- `ConcurrentHashMap.computeIfAbsent` is atomic at the map level: it guarantees exactly one `Mutex` instance per key without requiring a secondary guard lock.
- `getMutex` is now a plain (non-suspending) function.

## Test plan

- [ ] New `FetchDeduplicationTests` nested class in `JustWatchDeepLinkRepositoryTest`
  - `FakeJustWatchDeepLinkDao` — in-memory `ConcurrentHashMap`-backed DAO implementation for stateful dedup testing
  - Stress test: 100 concurrent coroutines (`UnconfinedTestDispatcher` + `yield()` in the API mock to force real interleaving) all requesting the same `(showId, season, episode, providerId, countryCode)` — asserts the JustWatch `SEARCH_QUERY` API is called **exactly once** and all coroutines resolve the correct URL
- [ ] All existing `JustWatchDeepLinkRepositoryTest` tests continue to pass

Fixes #579

> ⚠️ Gradle checks skipped locally (no Android SDK). CI (`build-android.yml`) is the real gate for Kotlin/Android changes.

https://claude.ai/code/session_01CoPn9XD58VayfpdqaD5yV7

---
_Generated by [Claude Code](https://claude.ai/code/session_01CoPn9XD58VayfpdqaD5yV7)_