### PR TITLE
fix(backend): reduce default upstream timeout from 15 s to 8 s; add FETCH_TIMEOUT_MS override

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ export TRAKT_CLIENT_SECRET=your_trakt_client_secret_here
 docker-compose up -d
 ```
 
+Optional environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PORT` | `3000` | HTTP port the proxy listens on |
+| `DEBUG_MODE` | `false` | Set to `true` to enable request debug logging |
+| `FETCH_TIMEOUT_MS` | `8000` | Upstream Trakt API timeout in milliseconds. Increase only if Trakt responses are consistently slow in your network; keeping it low limits slow-loris-style resource exhaustion. |
+
 ## Play Store
 
 Both apps share the package name `com.justb81.watchbuddy`:

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - TRAKT_CLIENT_SECRET
       - PORT
       - DEBUG_MODE
+      - FETCH_TIMEOUT_MS
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://localhost:3000/health']
       interval: 30s

--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -1371,6 +1371,25 @@ describe('Production-mode safety — no internal details in responses', () => {
   });
 });
 
+// ── Default fetch timeout — 8 s (#560) ────────────────────────────────────
+
+describe('Default fetch timeout — 8 s (#560)', () => {
+  it('uses 8 s as the default fetchTimeoutMs', () => {
+    const app = buildApp(mockFetch(200, {})); // no fetchTimeoutMs override
+    expect(app.fetchTimeoutMs).toBe(8_000);
+  });
+
+  it('exposes a custom fetchTimeoutMs when explicitly provided', () => {
+    const app = buildApp(mockFetch(200, {}), { fetchTimeoutMs: 3_000 });
+    expect(app.fetchTimeoutMs).toBe(3_000);
+  });
+
+  it('previous default of 15 s is no longer in effect', () => {
+    const app = buildApp(mockFetch(200, {}));
+    expect(app.fetchTimeoutMs).not.toBe(15_000);
+  });
+});
+
 // ── filterTokenResponse (shared helper) ────────────────────────────────────
 
 describe('filterTokenResponse — extra Trakt fields are stripped', () => {

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -50,7 +50,9 @@ function maskSecrets(obj) {
  * @param {string} config.clientSecret - Trakt client secret
  * @param {string} [config.traktApi]   - Trakt API base URL (default: https://api.trakt.tv)
  * @param {Function} [config.fetchFn]  - fetch implementation (default: global fetch)
- * @param {number} [config.fetchTimeoutMs] - Upstream fetch timeout in ms (default: 15000)
+ * @param {number} [config.fetchTimeoutMs] - Upstream fetch timeout in ms (default: 8000).
+ *   Trakt token exchanges typically complete in < 2 s; 8 s leaves a generous margin while
+ *   limiting how long a slow-loris connection can pin a socket. Override via FETCH_TIMEOUT_MS.
  * @param {boolean} [config.debug]     - Enable request debug logging (default: false)
  * @param {number} [config.healthCacheTtlMs] - TTL for /health response cache in ms (default: 30000, 0 = disabled)
  * @returns {import('express').Express}
@@ -61,7 +63,7 @@ export function createApp(config) {
     clientSecret,
     traktApi = 'https://api.trakt.tv',
     fetchFn = fetch,
-    fetchTimeoutMs = 15_000,
+    fetchTimeoutMs = 8_000,
     version = '0.0.0',
     debug = false,
     healthCacheTtlMs = 30_000,
@@ -499,6 +501,7 @@ export function createApp(config) {
   app.clearHealthCache = () => {
     healthCache = null;
   };
+  app.fetchTimeoutMs = fetchTimeoutMs;
 
   return app;
 }

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -19,7 +19,13 @@ import { createApp } from './app.js';
 
 const { version } = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8'));
 
-const { TRAKT_CLIENT_ID, TRAKT_CLIENT_SECRET, PORT = 3000, DEBUG_MODE } = process.env;
+const {
+  TRAKT_CLIENT_ID,
+  TRAKT_CLIENT_SECRET,
+  PORT = 3000,
+  DEBUG_MODE,
+  FETCH_TIMEOUT_MS,
+} = process.env;
 
 if (!TRAKT_CLIENT_ID || !TRAKT_CLIENT_SECRET) {
   console.error(
@@ -30,11 +36,24 @@ if (!TRAKT_CLIENT_ID || !TRAKT_CLIENT_SECRET) {
 
 const debug = DEBUG_MODE === 'true';
 
+let fetchTimeoutMs;
+if (FETCH_TIMEOUT_MS !== undefined && FETCH_TIMEOUT_MS !== '') {
+  const parsed = parseInt(FETCH_TIMEOUT_MS, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    console.warn(
+      `FETCH_TIMEOUT_MS="${FETCH_TIMEOUT_MS}" is not a valid positive integer — using default`
+    );
+  } else {
+    fetchTimeoutMs = parsed;
+  }
+}
+
 const app = createApp({
   clientId: TRAKT_CLIENT_ID,
   clientSecret: TRAKT_CLIENT_SECRET,
   version,
   debug,
+  fetchTimeoutMs,
 });
 
 const server = app.listen(PORT, () => {


### PR DESCRIPTION
## Summary

- Drops the default `fetchTimeoutMs` from 15 000 ms to 8 000 ms, reducing the slow-loris resource-exhaustion window without impacting normal Trakt exchanges (which complete well under 2 s).
- Adds `FETCH_TIMEOUT_MS` env var so operators can tune the value without rebuilding the Docker image; invalid values log a warning and fall back to the 8 s default.
- Adds `FETCH_TIMEOUT_MS` to `docker-compose.yml` so it is passed through automatically when set in the host environment.
- Exposes `app.fetchTimeoutMs` on the app instance for testability (mirrors the existing `app.verifyCredentials` / `app.clearRetryTimer` / `app.clearHealthCache` pattern).
- Documents the new env var and the tradeoff in `README.md`.

## Test plan

- [x] New `Default fetch timeout — 8 s (#560)` test suite: verifies the default is `8_000`, that a custom value is wired through, and that the old `15_000` default is no longer in effect.
- [x] All 126 existing backend tests continue to pass.
- [x] ESLint + Prettier pass (`npm --prefix backend run lint && npm --prefix backend run format:check`).

> ⚠️ Gradle checks skipped locally (no Android SDK). CI (`build-android.yml`) is the real gate for Kotlin/Android changes. No Kotlin/Android files were modified in this PR.

Closes #560

https://claude.ai/code/session_01MwtXHEQXhgS6hxuVQeus9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwtXHEQXhgS6hxuVQeus9U)_