### PR TITLE
fix(phone): eliminate read-modify-write races in ShowRepository and HomeViewModel

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
@@ -20,6 +20,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -89,20 +90,21 @@ class ShowRepository @Inject constructor(
         episode: Int,
         watched: Boolean
     ) {
-        val current = _shows.value
-        val index = current.indexOfFirst { it.entry.show.ids.trakt == traktShowId }
-        if (index < 0) return
-        val existing = current[index]
-        val updatedSeasons = if (watched) {
-            addEpisode(existing.entry.seasons, season, episode)
-        } else {
-            removeEpisode(existing.entry.seasons, season, episode)
+        _shows.update { current ->
+            val index = current.indexOfFirst { it.entry.show.ids.trakt == traktShowId }
+            if (index < 0) return@update current
+            val existing = current[index]
+            val updatedSeasons = if (watched) {
+                addEpisode(existing.entry.seasons, season, episode)
+            } else {
+                removeEpisode(existing.entry.seasons, season, episode)
+            }
+            if (updatedSeasons === existing.entry.seasons) return@update current
+            val updatedEntry = existing.copy(entry = existing.entry.copy(seasons = updatedSeasons))
+            current.toMutableList()
+                .also { it[index] = updatedEntry }
+                .sortedWith(showComparator)
         }
-        if (updatedSeasons === existing.entry.seasons) return
-        val updatedEntry = existing.copy(entry = existing.entry.copy(seasons = updatedSeasons))
-        _shows.value = current.toMutableList()
-            .also { it[index] = updatedEntry }
-            .sortedWith(showComparator)
     }
 
     private fun addEpisode(

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.getAndUpdate
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.Duration
@@ -182,12 +183,10 @@ class HomeViewModel @Inject constructor(
     private fun observeWifiState() {
         viewModelScope.launch {
             wifiStateProvider.isOnWifi.collect { onWifi ->
-                val wasWatching = _uiState.value.isWatchingTv
-                _uiState.update { it.copy(isOnWifi = onWifi) }
-                // Auto-stop a running companion when Wi-Fi drops: without it the
-                // NSD advertisement binds to nothing and the foreground
-                // notification lingers on a non-functional state.
-                if (!onWifi && wasWatching) {
+                // getAndUpdate atomically captures the previous state and writes the new one,
+                // eliminating the read-modify-write race with concurrent toggleWatchingTv calls.
+                val prevState = _uiState.getAndUpdate { it.copy(isOnWifi = onWifi) }
+                if (!onWifi && prevState.isWatchingTv) {
                     toggleWatchingTv(false)
                 }
             }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
@@ -296,8 +296,10 @@ class ShowRepositoryTest {
                         show = TraktShow("Show A", 2024, TraktIds(trakt = 1, tmdb = 100)),
                         seasons = listOf(
                             TraktWatchedSeason(
-                                1,
-                                listOf(TraktWatchedEpisode(5, "2026-04-29T10:00:00Z"))
+                                number = 1,
+                                episodes = listOf(
+                                    TraktWatchedEpisode(number = 5, last_watched_at = "2026-04-29T10:00:00Z")
+                                )
                             )
                         )
                     )

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.phone.server
 
+import app.cash.turbine.test
 import com.justb81.watchbuddy.core.model.TmdbShow
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
@@ -11,11 +12,14 @@ import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import io.mockk.*
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("ShowRepository")
@@ -231,6 +235,134 @@ class ShowRepositoryTest {
         // Order must be unchanged: show 1 still on top because its highest S×E (S02E01)
         // timestamp (Apr 20) is still newer than show 2's S01E01 timestamp (Apr 19).
         assertEquals(listOf(1, 2), repository.shows.value.map { it.entry.show.ids.trakt })
+    }
+
+    @Nested
+    @DisplayName("concurrent fetch and toggle — atomic update (#532)")
+    inner class ConcurrentFetchToggleTest {
+
+        @Test
+        fun `updateLocalWatched emits correct state via StateFlow (Turbine)`() = runTest {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "token"
+            coEvery { traktApi.getWatchedShows(any()) } returns listOf(
+                TraktWatchedEntry(TraktShow("Show A", 2024, TraktIds(trakt = 1, tmdb = 100)))
+            )
+
+            repository.shows.test {
+                // No initial emission yet for an empty StateFlow with empty value.
+                // Seed via getShows so the flow emits.
+                repository.getShows()
+                val afterFetch = awaitItem()
+                assertTrue(afterFetch.isNotEmpty())
+
+                // Apply local toggle — must emit a new value atomically.
+                repository.updateLocalWatched(traktShowId = 1, season = 2, episode = 7, watched = true)
+                val afterToggle = awaitItem()
+                assertTrue(
+                    afterToggle.any { e ->
+                        e.entry.seasons.any { s -> s.number == 2 && s.episodes.any { ep -> ep.number == 7 } }
+                    },
+                    "S02E07 must appear in the StateFlow after toggle"
+                )
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `toggle applied while fetch is in-flight does not lose Trakt data from fetch result`() = runTest {
+            // This exercises the specific race fixed by update{}: without the CAS-based
+            // update, updateLocalWatched could write a stale-based state AFTER getShows
+            // wrote fresh Trakt data, clobbering that fresh data. With update{}, the lambda
+            // retries on CAS failure so it always applies the toggle on top of the most
+            // current value at write time.
+            val apiCallStarted = CompletableDeferred<Unit>()
+            val apiCallAllowed = CompletableDeferred<Unit>()
+
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "token"
+            // Seed initial state: Show A with no watched episodes.
+            coEvery { traktApi.getWatchedShows(any()) } returns listOf(
+                TraktWatchedEntry(TraktShow("Show A", 2024, TraktIds(trakt = 1, tmdb = 100)))
+            )
+            repository.getShows()
+
+            // Second fetch: returns S01E05 from Trakt, but suspends until signalled.
+            repository.invalidateCache()
+            coEvery { traktApi.getWatchedShows(any()) } coAnswers {
+                apiCallStarted.complete(Unit)
+                apiCallAllowed.await()
+                listOf(
+                    TraktWatchedEntry(
+                        show = TraktShow("Show A", 2024, TraktIds(trakt = 1, tmdb = 100)),
+                        seasons = listOf(
+                            TraktWatchedSeason(
+                                1,
+                                listOf(TraktWatchedEpisode(5, "2026-04-29T10:00:00Z"))
+                            )
+                        )
+                    )
+                )
+            }
+
+            repository.shows.test {
+                awaitItem() // consume seeded emission
+
+                // Start the second fetch — it suspends at the API call.
+                val fetchJob = launch { repository.getShows() }
+                apiCallStarted.await()
+
+                // Toggle S02E03 while the fetch is suspended.
+                // With update{}, this CAS-writes [old + S02E03].
+                // When the fetch later writes [S01E05] directly, the CAS in a concurrent
+                // update{} would detect the change and retry — but since our toggle
+                // already completed, the toggle emission fires now and the fetch will
+                // overwrite it with authoritative Trakt data next.
+                repository.updateLocalWatched(traktShowId = 1, season = 2, episode = 3, watched = true)
+
+                val afterToggle = awaitItem()
+                assertTrue(
+                    afterToggle.any { e ->
+                        e.entry.seasons.any { s -> s.number == 2 && s.episodes.any { ep -> ep.number == 3 } }
+                    },
+                    "Toggle must be visible in the flow before the fetch completes"
+                )
+
+                // Let the fetch complete — it writes authoritative Trakt data ([S01E05]).
+                apiCallAllowed.complete(Unit)
+                fetchJob.join()
+
+                val afterFetch = awaitItem()
+                assertTrue(
+                    afterFetch.any { e ->
+                        e.entry.seasons.any { s -> s.number == 1 && s.episodes.any { ep -> ep.number == 5 } }
+                    },
+                    "S01E05 from Trakt must be present after the fetch completes"
+                )
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `rapid concurrent toggles leave _shows in a consistent state`() = runTest {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "token"
+            coEvery { traktApi.getWatchedShows(any()) } returns listOf(
+                TraktWatchedEntry(TraktShow("Show A", 2024, TraktIds(trakt = 1, tmdb = 100)))
+            )
+            repository.getShows()
+
+            // Fire many toggles sequentially within the same test coroutine to verify
+            // that the update{} lambda never panics and the state stays non-empty.
+            for (ep in 1..10) {
+                repository.updateLocalWatched(traktShowId = 1, season = 1, episode = ep, watched = true)
+            }
+
+            val state = repository.shows.value
+            assertEquals(1, state.size, "Exactly one show must remain")
+            val seasons = state.first().entry.seasons
+            val s1episodes = seasons.find { it.number == 1 }?.episodes ?: emptyList()
+            assertEquals(10, s1episodes.size, "All 10 episodes must be toggled on")
+        }
     }
 
     @Test

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
@@ -247,13 +247,13 @@ class ShowRepositoryTest {
             coEvery { traktApi.getWatchedShows(any()) } returns listOf(
                 TraktWatchedEntry(TraktShow("Show A", 2024, TraktIds(trakt = 1, tmdb = 100)))
             )
+            // Seed state BEFORE subscribing so the initial StateFlow emission is non-empty.
+            // StateFlow always replays its current value to new collectors; subscribing before
+            // the fetch would deliver the empty-list snapshot as the first item.
+            repository.getShows()
 
             repository.shows.test {
-                // No initial emission yet for an empty StateFlow with empty value.
-                // Seed via getShows so the flow emits.
-                repository.getShows()
-                val afterFetch = awaitItem()
-                assertTrue(afterFetch.isNotEmpty())
+                awaitItem() // consume the seeded [Show A] emission
 
                 // Apply local toggle — must emit a new value atomically.
                 repository.updateLocalWatched(traktShowId = 1, season = 2, episode = 7, watched = true)

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModelTest.kt
@@ -691,5 +691,46 @@ class HomeViewModelTest {
 
             assertTrue(vm.uiState.value.canStartCompanion)
         }
+
+        @Test
+        fun `observeWifiState reads isWatchingTv atomically - no spurious toggleWatchingTv when already off`() = runTest {
+            // Guard against the pre-fix race: the old code read wasWatching from
+            // _uiState.value.isWatchingTv and then updated isOnWifi in a separate
+            // _uiState.update{} call. A concurrent toggleWatchingTv(false) between those
+            // two steps could set isWatchingTv=false, yet the stale wasWatching=true would
+            // still trigger an extra toggleWatchingTv(false). With getAndUpdate{}, the
+            // read and write of isOnWifi happen in one atomic step, so wasWatching always
+            // reflects the state at exactly the moment isOnWifi is updated.
+            every { settingsRepository.settings } returns flowOf(AppSettings(companionEnabled = false))
+            wifiFlow.value = true
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            assertFalse(vm.uiState.value.isWatchingTv)
+
+            // Drop Wi-Fi when companion is NOT running — must not trigger setCompanionEnabled.
+            wifiFlow.value = false
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { settingsRepository.setCompanionEnabled(any()) }
+            assertFalse(vm.uiState.value.isOnWifi)
+        }
+
+        @Test
+        fun `observeWifiState triggers auto-stop exactly once even if Wi-Fi toggles rapidly`() = runTest {
+            every { settingsRepository.settings } returns flowOf(AppSettings(companionEnabled = true))
+            wifiFlow.value = true
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+            assertTrue(vm.uiState.value.isWatchingTv)
+
+            // Wi-Fi drops — should trigger exactly one auto-stop.
+            wifiFlow.value = false
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { settingsRepository.setCompanionEnabled(false) }
+            assertFalse(vm.uiState.value.isOnWifi)
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the two data-consistency races described in #532.

- **`ShowRepository.updateLocalWatched`** used a plain `_shows.value = mutate(_shows.value)` (read → compute → write). If `getShows()` completed a Trakt fetch and wrote `_shows.value` between the read and the write, the optimistic local toggle was applied to stale state and clobbered the fresh Trakt data. Fixed by replacing with `_shows.update { current → … }` which uses a CAS loop; the lambda is re-executed against the latest value on contention so the toggle always lands on top of the most-current state.

- **`HomeViewModel.observeWifiState`** read `wasWatching` from `_uiState.value.isWatchingTv` and then updated `isOnWifi` in a separate `_uiState.update { }` call. A concurrent `toggleWatchingTv` between those two steps could leave `wasWatching` stale and trigger a spurious auto-stop. Fixed by replacing with `_uiState.getAndUpdate { }` which atomically captures the previous state and applies the new one in one CAS step.

## Test plan

- [ ] `ShowRepositoryTest` — new `@Nested` group `concurrent fetch and toggle — atomic update (#532)`:
  - Turbine test: verifies `updateLocalWatched` emits the correct value via `shows` StateFlow
  - Controlled-ordering coroutine test: suspends the fetch at the Trakt API call, applies the toggle, then lets the fetch complete — confirms each emission is correct
  - Rapid-toggle stress test: 10 sequential toggles leave exactly 10 episodes in the state (no lost updates)
- [ ] `HomeViewModelTest` — two new tests in `WifiGate`:
  - Verifies `setCompanionEnabled` is never called when companion is already off and Wi-Fi drops
  - Verifies `setCompanionEnabled(false)` is called exactly once (not multiple times) on a single Wi-Fi drop

> **Note:** Gradle/Kotlin checks were skipped locally (no Android SDK in this sandbox). CI (`build-android.yml`) is the real gate — please treat a red `Test & Build` check as a blocker.

Closes #532

https://claude.ai/code/session_01GQTDKTUU98FLcLmsPeMURi

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQTDKTUU98FLcLmsPeMURi)_