### PR TITLE
docs: architecture review — fix documentation discrepancies and create simplification issues

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -49,7 +49,7 @@ private const val MAX_PAGE_SIZE = 200
 
 /**
  * Local HTTP server running on the phone (port 8765).
- * The TV app discovers this via NSD (mDNS) and calls its endpoints.
+ * The TV discovers this via BLE advertisement and calls its endpoints over plain HTTP.
  *
  * Endpoints:
  *   GET  /capability           → DeviceCapability (device score, RAM, LLM backend)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
@@ -14,6 +14,8 @@ import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import com.justb81.watchbuddy.service.CompanionStateManager
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -26,15 +28,21 @@ class DeviceCapabilityProvider @Inject constructor(
     private val settingsRepository: SettingsRepository,
     private val stateManager: CompanionStateManager
 ) {
-    private var cachedProfile: TraktUserProfile? = null
+    private val profileMutex = Mutex()
+    @Volatile private var cachedProfile: TraktUserProfile? = null
 
     private suspend fun getCachedProfile(): TraktUserProfile? {
+        // Fast path: @Volatile read avoids mutex acquisition when cache is warm.
         cachedProfile?.let { return it }
-        val token = tokenRepository.getAccessToken() ?: return null
-        return try {
-            traktApiService.getProfile("Bearer $token").also { cachedProfile = it }
-        } catch (_: Exception) {
-            null
+        return profileMutex.withLock {
+            // Re-check inside the lock: a concurrent call may have already populated it.
+            cachedProfile?.let { return@withLock it }
+            val token = tokenRepository.getAccessToken() ?: return@withLock null
+            try {
+                traktApiService.getProfile("Bearer $token").also { cachedProfile = it }
+            } catch (_: Exception) {
+                null
+            }
         }
     }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
@@ -29,6 +29,7 @@ class DeviceCapabilityProvider @Inject constructor(
     private val stateManager: CompanionStateManager
 ) {
     private val profileMutex = Mutex()
+
     @Volatile private var cachedProfile: TraktUserProfile? = null
 
     private suspend fun getCachedProfile(): TraktUserProfile? {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/WatchProvidersRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/WatchProvidersRepository.kt
@@ -6,6 +6,7 @@ import com.justb81.watchbuddy.core.model.WatchProviderEntry
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import com.justb81.watchbuddy.core.tmdb.TmdbImageHelper
 import com.justb81.watchbuddy.tv.discovery.InstalledAppsProbe
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -33,7 +34,7 @@ class WatchProvidersRepository @Inject constructor(
         val fetchedAtMs: Long,
     )
 
-    private val cache = mutableMapOf<String, CacheEntry>()
+    private val cache = ConcurrentHashMap<String, CacheEntry>()
 
     /**
      * Returns ordered, filtered [ResolvedProvider] list for [tmdbId] in [countryCode].

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -141,9 +141,8 @@ class PhoneDiscoveryManager(
     private val pollSchedules = ConcurrentHashMap<String, PollSchedule>()
 
     /**
-     * Lightweight device info reconstructed from the BLE payload (or the
-     * TXT record of a legacy NSD resolve). Available immediately, before
-     * any `/capability` round-trip.
+     * Lightweight device info reconstructed from the BLE payload.
+     * Available immediately, before any `/capability` round-trip.
      */
     data class PhoneTxtRecord(
         val version: String,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,15 +44,17 @@ The 9-byte payload is the authoritative wire contract — see
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/capability` | Device info + LLM score + TMDB API key + `avatarSource` (#342) |
+| GET | `/capability` | Device info + LLM score + TMDB API key + `avatarSource` + `lastResolvedSessionKey` + `lastResolvedTraktId` (#342, #474) |
 | GET | `/avatar` | Custom avatar JPEG (200 bytes, ETag-revalidated; 404 when `avatarSource != CUSTOM`) |
-| GET | `/shows` | User's Trakt watched shows (cached) |
+| GET | `/shows` | User's Trakt watched shows (cached), paginated via `offset` + `limit` query params |
 | POST | `/recap/{traktShowId}` | Generate HTML recap for a show |
-| GET | `/auth/token` | Current access token (server-side, not used by TV) |
+| GET | `/auth/token` | Current Trakt access token (used by TV to obtain a token for authenticated calls) |
 | POST | `/scrobble/start` | Forward scrobble start to this user's Trakt account |
 | POST | `/scrobble/pause` | Forward scrobble pause to this user's Trakt account |
 | POST | `/scrobble/stop` | Forward scrobble stop to this user's Trakt account |
 | POST | `/scrobble/extract` | LLM fallback — accepts a `MediaMetadataSnapshot` + library hints, returns normalized `(showTitle, season?, episode?, confidence)`. TV calls this only when the deterministic multi-field + fuzzy-match cascade misses (< 0.70 cache confidence). 90 s client / 75 s server budget absorbs cold LiteRT-LM inference; per-raw-title in-flight dedup on the TV side prevents the 30 s `MediaSession` poll cycle from stacking duplicate inferences. |
+| POST | `/scrobble/prompt` | Delivers an `AmbiguousScrobbleEvent` (top-3 candidates) to the phone; the phone presents a notification and/or in-app card so the user can pick the correct show. Returns HTTP 204 No Content. (#474) |
+| POST | `/shows/add-to-library` | Adds a `PhoneAddToLibraryRequest` episode to the user's Trakt history. Called after the TV overlay confirmation for an unknown show. Invalidates the local show cache on success. |
 
 **TV app API boundaries:**
 - **TMDB API** — show/movie details, images, search (direct call from TV using key from `/capability`)
@@ -192,8 +194,8 @@ the advert. The TV's `PhoneBleScanner` listens for the same UUID in
 `SCAN_MODE_BALANCED` whenever discovery is enabled; each match feeds the existing
 `/capability` fetch + heartbeat pipeline, deduped by `baseUrl`. BLE range can exceed the
 LAN's reach — a phone that's out of Wi-Fi range but still within BLE range will fail
-`/capability` and be evicted after `MAX_CONSECUTIVE_FAILURES = 3` heartbeat misses
-(~3 min). Graceful degradation is the default: on Bluetooth-off, permission-denied, or
+`/capability` and be evicted after `MAX_CONSECUTIVE_FAILURES = 5` heartbeat misses
+with exponential backoff (~5 min total). Graceful degradation is the default: on Bluetooth-off, permission-denied, or
 BLE-unsupported hardware the advertiser/scanner no-ops and the pair simply cannot
 connect until BLE is available again. Permissions: `BLUETOOTH_ADVERTISE` (phone, runtime
 prompt from HomeScreen when the "I am watching TV" toggle flips on) and `BLUETOOTH_SCAN`
@@ -224,7 +226,7 @@ manifest declaration on Android 14+. The `connectedDevice` type is authorised by
 The TV's `PhoneDiscoveryManager` runs a heartbeat coroutine every 60 seconds that re-fetches
 `GET /capability` for each discovered phone. This serves two purposes:
 
-1. **Presence verification** — if a phone fails 3 consecutive heartbeats, it is removed from
+1. **Presence verification** — if a phone fails 5 consecutive heartbeats (with exponential backoff), it is removed from
    the discovered list and excluded from scrobbling.
 2. **Capability refresh** — updated capability data (RAM, LLM backend) is reflected immediately.
 
@@ -314,17 +316,17 @@ The available-provider list for each show is fetched from TMDB `/tv/{id}/watch/p
 | TMDB provider_id | Service | Package |
 |-----------------|---------|---------|
 | 8 | Netflix | `com.netflix.ninja` |
-| 119 | Prime Video | `com.amazon.amazonvideo.livingroom` |
+| 9, 119 | Prime Video | `com.amazon.amazonvideo.livingroom` |
 | 337 | Disney+ | `com.disney.disneyplus` |
 | 350 | Apple TV+ | `com.apple.atve.androidtv.appletv` |
 | 531 | Paramount+ | `com.cbs.app` |
 | 1899 | Max / HBO | `com.hbo.hbonow` |
-| 2187 | WaipuTV | `tv.waipu.app` |
-| 2184 | Joyn | `de.prosiebensat1digital.android.joyn` |
+| 2187 | WaipuTV | `de.exaring.waipu` |
+| 2184 | Joyn / 7TV | `de.prosiebensat1digital.seventv` |
 | 192 | YouTube | `com.google.android.youtube.tv` |
-| 35 | Rakuten TV | `com.rakuten.tv` |
-| 195 | ARD Mediathek | `de.swr.avp.ard.phone` |
-| 231 | ZDF Mediathek | `de.zdf.android.app` |
+| 35 | Rakuten TV | `tv.wuaki.apptv` |
+| 195 | ARD Mediathek | `de.swr.avp.ard.tv` |
+| 231 | ZDF Mediathek | `com.zdf.android.mediathek` |
 
 ### JustWatch-powered per-episode deep links
 

--- a/docs/tmdb-integration.md
+++ b/docs/tmdb-integration.md
@@ -166,28 +166,29 @@ When no LLM backend is available (AICore unavailable, insufficient RAM for LiteR
 
 ### 2. Deep Link Resolution (TV App)
 
-When the user views a show's detail screen on the TV, the app constructs deep links to streaming services using the TMDB ID.
+When the user opens a show's detail screen on the TV, `ShowDetailViewModel.loadDeepLinks()` resolves
+per-episode streaming URLs via JustWatch's unofficial GraphQL API. Static deep-link templates were
+removed; every link is resolved at runtime and cached in a Room database on the TV.
 
 ```mermaid
 flowchart TD
-    A["User opens show detail"] --> B["ShowDetailViewModel.resolveDeepLink()"]
-    B --> C["Extract tmdbId from\nentry.show.ids.tmdb"]
-    C --> D{"tmdb == null?"}
-    D -->|Yes| E["No deep link (return null)"]
-    D -->|No| F["Substitute placeholders in template:\n{tmdb_id} → tmdbId\n{slug} → Trakt slug\n{id} → tmdbId (fallback)"]
-    F --> G["Return resolved URL\ne.g. netflix.com/title/1234"]
+    A["User opens show detail\nproviders loaded"] --> B["ShowDetailViewModel.loadDeepLinks()"]
+    B --> C["For each ResolvedProvider:\nviewModelScope.async"]
+    C --> D["JustWatchDeepLinkRepository\n.resolveDeepLink(tmdbShowId, season,\nepisode, providerId, countryCode)"]
+    D --> E{"Episode-level\nRoom cache hit?"}
+    E -->|Yes| F["DeepLinkState.Available(url)"]
+    E -->|No| G["Live JustWatch GraphQL call\n(SEARCH → SEASONS → EPISODES)"]
+    G --> H{"Offer found?"}
+    H -->|Yes| I["Cache permanently → Available(url)"]
+    H -->|No| J["Cache 30-day negative → Unavailable"]
 ```
 
-**Deep link templates using `{tmdb_id}`:**
+`ProviderCatalog` maps TMDB `provider_id` integers to Android package names so deep links can be
+attributed to the correct app. JustWatch `technicalName` strings (e.g. `nfx`, `prv`, `dnp`) are
+translated to TMDB `provider_id` integers by `JustWatchPackageMap`.
 
-| Service | Template |
-|---------|----------|
-| Netflix | `https://www.netflix.com/title/{tmdb_id}` |
-| Disney+ | `https://www.disneyplus.com/series/{slug}/{tmdb_id}` |
-| Prime Video | `https://www.primevideo.com/search?phrase={slug}` (title-based search) |
-| ARD Mediathek | `https://www.ardmediathek.de/video/{id}` (TMDB ID as fallback) |
-
-Note: This journey does **not** call the TMDB API directly. It only uses the TMDB ID already present in the Trakt data model.
+Note: This journey calls the JustWatch GraphQL API, not the TMDB API. TMDB data (the TMDB show ID
+and the episode numbers from `ShowProgressCalculator`) is used as input to the JustWatch query.
 
 ### 3. Device Capability Reporting
 
@@ -243,7 +244,7 @@ sequenceDiagram
 - `app-tv/…/data/WatchProvidersRepository.kt` — fetch, 24 h in-memory cache, ordering
 - `app-tv/…/data/LastUsedProviderRepository.kt` — TV-local DataStore, `Map<tmdbId, providerId>`
 - `app-tv/…/discovery/InstalledAppsProbe.kt` — `PackageManager` cache, invalidated on install/remove
-- `core/…/deeplink/ProviderCatalog.kt` — TMDB `provider_id` → package + deep-link template
+- `core/…/deeplink/ProviderCatalog.kt` — TMDB `provider_id` → package name (for `InstalledAppsProbe` + `<queries>` manifest)
 - `app-tv/AndroidManifest.xml` — `<queries>` block for Android 11+ package visibility
 
 ### 5. TV ShowDetail — Next-Episode Still Image and Title (#366)
@@ -373,7 +374,7 @@ Separately, `LocaleHelper.getLlmResponseLanguage()` reads the device's system lo
 | Module | File | TMDB Role |
 |--------|------|-----------|
 | **core** | `tmdb/TmdbApiService.kt` | Retrofit interface (`getShow`, `getEpisode`, `searchTv`), response DTOs, `TmdbImageHelper` |
-| **core** | `model/Models.kt` | `TmdbShow`, `TmdbEpisode`, `TmdbTvSearchResponse` data classes; `TraktIds.tmdb` mapping; `KNOWN_STREAMING_SERVICES` with `{tmdb_id}` templates |
+| **core** | `model/Models.kt` | `TmdbShow`, `TmdbEpisode`, `TmdbTvSearchResponse` data classes; `TraktIds.tmdb` mapping; `WatchProviderEntry`/`WatchProviderResponse` for TMDB watch-provider results |
 | **core** | `network/NetworkModule.kt` | OkHttpClient with cert pinning, TMDB Retrofit instance, Hilt DI |
 | **app-phone** | `server/CompanionHttpServer.kt` | Recap endpoint: calls `getShow()` + `getEpisode()`, passes data to `RecapGenerator` |
 | **app-phone** | `llm/RecapGenerator.kt` | Builds LLM prompt from TMDB data, replaces still image placeholders |
@@ -383,11 +384,11 @@ Separately, `LocaleHelper.getLlmResponseLanguage()` reads the device's system lo
 | **app-phone** | `settings/SettingsRepository.kt` | Stores and retrieves user's TMDB API key |
 | **app-phone** | `ui/home/HomeViewModel.kt` | Loads TMDB posters for each show in the library (parallel `getShow()` calls after sync) |
 | **app-phone** | `ui/showdetail/ShowDetailViewModel.kt` | Loads TMDB poster + overview for a single show's detail screen |
-| **app-tv** | `ui/showdetail/ShowDetailViewModel.kt` | Loads providers via `WatchProvidersRepository`, records last-used on tap, resolves deep links via `ProviderCatalog` |
+| **app-tv** | `ui/showdetail/ShowDetailViewModel.kt` | Loads providers via `WatchProvidersRepository`, records last-used on tap, resolves per-episode deep links via `JustWatchDeepLinkRepository` |
 | **app-tv** | `data/WatchProvidersRepository.kt` | Calls `getWatchProviders()`, caches 24 h, composes installed/last-used ordered list |
 | **app-tv** | `data/LastUsedProviderRepository.kt` | TV-local DataStore — tracks most-recently used `provider_id` per show |
 | **app-tv** | `discovery/InstalledAppsProbe.kt` | `PackageManager` cache — reports which streaming apps are installed |
-| **core** | `deeplink/ProviderCatalog.kt` | Maps TMDB `provider_id` → package name + deep-link template |
+| **core** | `deeplink/ProviderCatalog.kt` | Maps TMDB `provider_id` → Android package name (static registry; no deep-link templates) |
 | **app-tv** | `scrobbler/MediaSessionScrobbler.kt` | Uses `searchTv()` as fallback when fuzzy-matching media titles against the local show cache |
 
 ---


### PR DESCRIPTION
## Summary

Architecture review by an experienced Kotlin/networked-systems perspective. This PR contains the **documentation corrections** and two **thread-safety bug fixes** identified during the review.

### Documentation fixes

**`docs/architecture.md`**
- Add missing HTTP API endpoints `POST /scrobble/prompt` (#474 ambiguous scrobble delivery) and `POST /shows/add-to-library` (unknown-show overlay confirm) — both were implemented but absent from the table
- Fix `MAX_CONSECUTIVE_FAILURES` value: was `3` in the docs, is `5` in `DiscoveryConstants.kt`
- Fix 5 provider package names in the Deep Links table that diverged from `ProviderCatalog.kt`: WaipuTV (`de.exaring.waipu`), Joyn/7TV (`de.prosiebensat1digital.seventv`), ARD Mediathek (`de.swr.avp.ard.tv`), ZDF Mediathek (`com.zdf.android.mediathek`), Rakuten TV (`tv.wuaki.apptv`); add missing Prime Video provider_id 9 mapping
- Clarify `/capability` response fields (`lastResolvedSessionKey`, `lastResolvedTraktId`) and `/shows` pagination params
- Fix `/auth/token` endpoint description (was "not used by TV", is actually the TV's Trakt token source)

**`docs/tmdb-integration.md`**
- Replace entirely outdated Section 2 "Deep Link Resolution" that described a removed static-template substitution flow (`{tmdb_id}` placeholders) with the actual JustWatch GraphQL cascade implemented in `JustWatchDeepLinkRepository`
- Remove references to the deleted `KNOWN_STREAMING_SERVICES` constant from the module table
- Fix `ProviderCatalog` description: deep-link templates are gone; it now maps provider_id → package name only
- Fix `ShowDetailViewModel` row: uses `JustWatchDeepLinkRepository`, not `ProviderCatalog`

**`CompanionHttpServer.kt`**
- Class docstring said "TV discovers via NSD (mDNS)" — corrected to BLE (discovery is BLE-only)

**`PhoneDiscoveryManager.kt`**
- Remove "legacy NSD resolve" mention from `PhoneTxtRecord` comment

### Bug fixes (closes #612, closes #613)

**`WatchProvidersRepository`** — `mutableMapOf()` replaced with `ConcurrentHashMap`: the 24-h TMDB provider cache was a plain `HashMap` accessed concurrently from multiple `viewModelScope` coroutines, risking `ConcurrentModificationException` on rapid D-pad navigation through the show list.

**`DeviceCapabilityProvider`** — `@Volatile` + `Mutex` double-checked locking added to `getCachedProfile()`: burst `GET /capability` requests from TV heartbeats could trigger parallel Trakt `getProfile()` API calls, wasting rate-limit quota. `invalidateCache()` stays non-suspend (it's called from `disconnectTrakt()` which is not a coroutine).

### Remaining architecture findings → open issues

| Issue | Title | Type |
|-------|-------|------|
| #610 | Remove `NsdServiceInfo` from `DiscoveredPhone` — replace with plain `serviceName: String` | refactor |
| #611 | Remove duplicate `ScrobbleAction` enum from `TvScrobbleDispatcher` | refactor |

## Test plan

- [ ] Verify architecture.md renders correctly (Mermaid diagrams, tables)
- [ ] Verify Deep Links table package names match `ProviderCatalog.kt` entries
- [ ] CI: Android build must pass — only comments/docs changed for the first commit; `.kt` logic changes are minimal (type swap + mutex)

> **Note:** Gradle checks were skipped locally (no Android SDK in this environment). CI (`build-android.yml`) is the real gate for the Kotlin changes.

https://claude.ai/code/session_016Sz7gkHSz5Ff9ZgaNpQGX5