### PR TITLE
refactor(tv): replace local ScrobbleAction with core model enum

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcher.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.AmbiguousScrobbleEvent
 import com.justb81.watchbuddy.core.model.PhoneAddToLibraryRequest
+import com.justb81.watchbuddy.core.model.ScrobbleAction
 import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.scrobbler.ScrobbleDispatcher
@@ -65,8 +66,6 @@ class TvScrobbleDispatcher(
         /** At-most-once delivery window for ambiguous prompts. Keys older than this are evicted. */
         internal const val AMBIGUOUS_KEY_TTL_MS = 30 * 60 * 1_000L
     }
-
-    internal enum class ScrobbleAction { START, PAUSE, STOP }
 
     internal data class QueuedScrobble(
         val action: ScrobbleAction,

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
@@ -5,6 +5,7 @@ import com.justb81.watchbuddy.core.model.AmbiguousCandidate
 import com.justb81.watchbuddy.core.model.AmbiguousScrobbleEvent
 import com.justb81.watchbuddy.core.model.LlmBackend
 import com.justb81.watchbuddy.core.model.PlaybackTick
+import com.justb81.watchbuddy.core.model.ScrobbleAction
 import com.justb81.watchbuddy.tv.TestFixtures
 import com.justb81.watchbuddy.tv.discovery.DiscoveryConstants
 import com.justb81.watchbuddy.tv.discovery.PhoneApiClientFactory
@@ -424,6 +425,36 @@ class TvScrobbleDispatcherTest {
             advanceUntilIdle()
 
             coVerify(exactly = 1) { phoneApiService.scrobbleStart(any()) }
+        }
+    }
+
+    // ── QueuedScrobble type contract ──────────────────────────────────────────
+
+    @Nested
+    @DisplayName("QueuedScrobble uses core ScrobbleAction (#611)")
+    inner class QueuedScrobbleTypeTest {
+
+        @Test
+        fun `QueuedScrobble action field holds core ScrobbleAction values`() {
+            val queued = TvScrobbleDispatcher.QueuedScrobble(
+                action = ScrobbleAction.START,
+                show = TestFixtures.traktShow(),
+                episode = TestFixtures.traktEpisode(),
+                progress = 10f,
+                capturedAtMs = fakeNow,
+            )
+            assertEquals(ScrobbleAction.START, queued.action)
+            assertInstanceOf(ScrobbleAction::class.java, queued.action)
+        }
+
+        @Test
+        fun `all three core ScrobbleAction values can be stored in QueuedScrobble`() {
+            val show = TestFixtures.traktShow()
+            val episode = TestFixtures.traktEpisode()
+            val actions = ScrobbleAction.entries.map { action ->
+                TvScrobbleDispatcher.QueuedScrobble(action, show, episode, 50f, fakeNow).action
+            }
+            assertEquals(listOf(ScrobbleAction.START, ScrobbleAction.PAUSE, ScrobbleAction.STOP), actions)
         }
     }
 


### PR DESCRIPTION
## Summary

- Removes the private `internal enum class ScrobbleAction { START, PAUSE, STOP }` from `TvScrobbleDispatcher` (was line 69)
- Imports `com.justb81.watchbuddy.core.model.ScrobbleAction` instead — already on the classpath via `:core`
- `QueuedScrobble.action` now uses the canonical serialisable core enum; no translation needed since names are identical
- No behaviour change — pure deduplication of a ~6-line internal copy

## Test plan

- [ ] New `QueuedScrobbleTypeTest` nested class added to `TvScrobbleDispatcherTest` with two tests:
  - Verifies a `QueuedScrobble` can be constructed with `ScrobbleAction.START` and the field holds the core enum value
  - Verifies all three core enum entries (`START`, `PAUSE`, `STOP`) can be stored in `QueuedScrobble`
- [ ] All existing `TvScrobbleDispatcherTest` tests continue to pass (no logic changed, action routing/queuing behaviour unchanged)
- [ ] CI `Test & Build` workflow is the real gate for Kotlin compilation (no Android SDK in this environment)

> **Note:** Android SDK not available in this web session — Gradle checks were skipped locally per `scripts/precommit.sh` policy. CI is the gate for Kotlin/detekt/lint.

Closes #611

https://claude.ai/code/session_01Y2vVKhdtypq9a9QhndPEWj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2vVKhdtypq9a9QhndPEWj)_