### PR TITLE
refactor(tv): replace NsdServiceInfo with plain serviceName in DiscoveredPhone

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -5,7 +5,6 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
-import android.net.nsd.NsdServiceInfo
 import android.util.Log
 import androidx.annotation.VisibleForTesting
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
@@ -151,7 +150,7 @@ class PhoneDiscoveryManager(
     )
 
     data class DiscoveredPhone(
-        val serviceInfo: NsdServiceInfo,
+        val serviceName: String,
         val txtRecord: PhoneTxtRecord?,
         val capability: DeviceCapability?,
         val score: Int,
@@ -558,10 +557,7 @@ class PhoneDiscoveryManager(
             return
         }
 
-        val synthInfo = NsdServiceInfo().apply {
-            serviceName = "watchbuddy-ble-$hostAddress-$port"
-            this.port = port
-        }
+        val serviceName = "watchbuddy-ble-$hostAddress-$port"
         val txtRecord = PhoneTxtRecord(
             version = "", // unknown until /capability is fetched
             modelQuality = modelQuality,
@@ -570,7 +566,7 @@ class PhoneDiscoveryManager(
         )
         Log.i(TAG, "BLE advertisement → resolving phone at $baseUrl (rssi=$rssi dBm)")
         heartbeatScope.launch {
-            fetchCapabilityAndAdd(synthInfo, txtRecord, baseUrl, rssi)
+            fetchCapabilityAndAdd(serviceName, txtRecord, baseUrl, rssi)
         }
     }
 
@@ -586,7 +582,7 @@ class PhoneDiscoveryManager(
      *   malformed or structurally invalid payload should not be ranked.
      */
     private fun fetchCapabilityAndAdd(
-        serviceInfo: NsdServiceInfo,
+        serviceName: String,
         txtRecord: PhoneTxtRecord,
         baseUrl: String,
         rssi: Int,
@@ -595,7 +591,7 @@ class PhoneDiscoveryManager(
             is CapabilityResult.Ok -> {
                 val score = calculateScore(txtRecord, result.capability)
                 addOrUpdatePhone(
-                    DiscoveredPhone(serviceInfo, txtRecord, result.capability, score, baseUrl, rssi = rssi)
+                    DiscoveredPhone(serviceName, txtRecord, result.capability, score, baseUrl, rssi = rssi)
                 )
             }
             is CapabilityResult.Invalid -> {
@@ -613,7 +609,7 @@ class PhoneDiscoveryManager(
                 Log.w(TAG, "Phone discovered at $baseUrl but capability fetch failed: ${result.reason}")
                 val score = calculateScore(txtRecord, null)
                 addOrUpdatePhone(
-                    DiscoveredPhone(serviceInfo, txtRecord, null, score, baseUrl, rssi = rssi)
+                    DiscoveredPhone(serviceName, txtRecord, null, score, baseUrl, rssi = rssi)
                 )
             }
         }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -299,8 +299,7 @@ private fun PhoneDiagnosticsCard(phone: PhoneDiscoveryManager.DiscoveredPhone) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
                 text = phone.capability?.userName
-                    ?: phone.serviceInfo.serviceName
-                    ?: phone.baseUrl,
+                    ?: phone.serviceName,
                 fontSize = 16.sp,
                 fontWeight = FontWeight.Medium,
                 color = Color.White,

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManagerTest.kt
@@ -1,7 +1,6 @@
 package com.justb81.watchbuddy.tv.discovery
 
 import android.content.Context
-import android.net.nsd.NsdServiceInfo
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.model.LlmBackend
 import io.mockk.every
@@ -49,18 +48,15 @@ class PhoneDiscoveryManagerTest {
         name: String = "test",
         baseUrl: String = "http://test/",
         rssi: Int? = null,
-    ): PhoneDiscoveryManager.DiscoveredPhone {
-        val serviceInfo = mockk<NsdServiceInfo>()
-        every { serviceInfo.serviceName } returns name
-        return PhoneDiscoveryManager.DiscoveredPhone(
-            serviceInfo = serviceInfo,
+    ): PhoneDiscoveryManager.DiscoveredPhone =
+        PhoneDiscoveryManager.DiscoveredPhone(
+            serviceName = name,
             txtRecord = txtRecord,
             capability = capability,
             score = score,
             baseUrl = baseUrl,
             rssi = rssi,
         )
-    }
 
     private fun makeTxtRecord(
         modelQuality: Int = 70,
@@ -136,7 +132,7 @@ class PhoneDiscoveryManagerTest {
             setPhones(txtPhone, capPhone)
 
             val best = manager.getBestPhone()
-            assertEquals("cap-phone", best?.serviceInfo?.serviceName)
+            assertEquals("cap-phone", best?.serviceName)
         }
     }
 
@@ -331,9 +327,7 @@ class PhoneDiscoveryManagerTest {
 
         private fun seedPhone(failCount: Int = 0): PhoneDiscoveryManager.DiscoveredPhone {
             val phone = PhoneDiscoveryManager.DiscoveredPhone(
-                serviceInfo = mockk<NsdServiceInfo>().also {
-                    every { it.serviceName } returns "phone"
-                },
+                serviceName = "phone",
                 txtRecord = makeTxtRecord(),
                 capability = DeviceCapability("d1", "u1", null, "P1", LlmBackend.NONE, 70, 4000, true),
                 score = 76,

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneTitleExtractionClientTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/PhoneTitleExtractionClientTest.kt
@@ -1,6 +1,5 @@
 package com.justb81.watchbuddy.tv.discovery
 
-import android.net.nsd.NsdServiceInfo
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.model.LlmBackend
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
@@ -196,10 +195,8 @@ class PhoneTitleExtractionClientTest {
         modelQuality: Int,
         score: Int = modelQuality,
     ): PhoneDiscoveryManager.DiscoveredPhone {
-        val serviceInfo = mockk<NsdServiceInfo>(relaxed = true)
-        every { serviceInfo.serviceName } returns "test-$baseUrl"
         return PhoneDiscoveryManager.DiscoveredPhone(
-            serviceInfo = serviceInfo,
+            serviceName = "test-$baseUrl",
             txtRecord = PhoneDiscoveryManager.PhoneTxtRecord(
                 version = "1",
                 modelQuality = modelQuality,

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/scrobbler/TvScrobbleDispatcherTest.kt
@@ -1,6 +1,5 @@
 package com.justb81.watchbuddy.tv.scrobbler
 
-import android.net.nsd.NsdServiceInfo
 import com.justb81.watchbuddy.core.model.AmbiguousCandidate
 import com.justb81.watchbuddy.core.model.AmbiguousScrobbleEvent
 import com.justb81.watchbuddy.core.model.LlmBackend
@@ -48,8 +47,6 @@ class TvScrobbleDispatcherTest {
         lastSuccessfulCheck: Long = fakeNow,
         name: String = "test-phone"
     ): PhoneDiscoveryManager.DiscoveredPhone {
-        val serviceInfo = mockk<NsdServiceInfo>()
-        every { serviceInfo.serviceName } returns name
         val capability = TestFixtures.deviceCapability(isAvailable = isAvailable)
         val txt = PhoneDiscoveryManager.PhoneTxtRecord(
             version = "1.0.0",
@@ -57,7 +54,7 @@ class TvScrobbleDispatcherTest {
             llmBackend = LlmBackend.LITERT
         )
         return PhoneDiscoveryManager.DiscoveredPhone(
-            serviceInfo = serviceInfo,
+            serviceName = name,
             txtRecord = txt,
             capability = capability,
             score = 75,


### PR DESCRIPTION
## Summary

- Replace `serviceInfo: NsdServiceInfo` with `serviceName: String` in `DiscoveredPhone` — removes the only `android.net.nsd` dependency from the TV discovery layer
- Remove synthetic `NsdServiceInfo` construction in `onBleAdvertisement`; pass `"watchbuddy-ble-$hostAddress-$port"` directly as `serviceName`
- Update `fetchCapabilityAndAdd` parameter and all `DiscoveredPhone(...)` call sites accordingly
- Change `phone.serviceInfo.serviceName ?: phone.baseUrl` → `phone.serviceName` in `TvDiagnosticsScreen`
- Update all test fixtures in `PhoneDiscoveryManagerTest`, `PhoneTitleExtractionClientTest`, and `TvScrobbleDispatcherTest` to construct `DiscoveredPhone` without mocking `NsdServiceInfo`

No behaviour change — `serviceName` value equals `"watchbuddy-ble-{ip}-{port}"` exactly as before.

> **Note:** Android SDK not available in this sandboxed environment — Gradle checks (unit tests, detekt, Android Lint) were skipped locally. CI (`Test & Build`) is the real gate.

## Test plan

- [ ] CI `Test & Build` passes green
- [ ] `PhoneDiscoveryManagerTest` — existing assertions updated (`best?.serviceName` instead of `best?.serviceInfo?.serviceName`)
- [ ] `PhoneTitleExtractionClientTest` — `makeDiscoveredPhone` no longer mocks `NsdServiceInfo`
- [ ] `TvScrobbleDispatcherTest` — `makePhone` no longer mocks `NsdServiceInfo`

Closes #610

https://claude.ai/code/session_01378q86d6zqvYFirKrkWx6r

---
_Generated by [Claude Code](https://claude.ai/code/session_01378q86d6zqvYFirKrkWx6r)_