### PR TITLE
fix: fix JustWatch 422 GRAPHQL_VALIDATION_FAILED on seasons/episodes queries

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
@@ -243,8 +243,6 @@ class JustWatchDeepLinkRepository @Inject constructor(
                 query = JustWatchApiService.SEASONS_QUERY,
                 variables = buildJsonObject {
                     put("nodeId", jwNode.id)
-                    put("country", countryCode)
-                    put("language", language)
                 },
             )
         )
@@ -285,7 +283,7 @@ class JustWatchDeepLinkRepository @Inject constructor(
             return
         }
 
-        val jwEp = jwEpisodes.find { it.seasonNumber == season && it.episodeNumber == episode }
+        val jwEp = jwEpisodes.find { it.content?.seasonNumber == season && it.content?.episodeNumber == episode }
         if (jwEp != null) {
             cacheOffers(jwEp.offers, tmdbShowId, season, episode, countryCode)
         } else {

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.justb81.watchbuddy.core.justwatch.JustWatchApiService
 import com.justb81.watchbuddy.core.justwatch.JustWatchContent
 import com.justb81.watchbuddy.core.justwatch.JustWatchData
 import com.justb81.watchbuddy.core.justwatch.JustWatchEpisode
+import com.justb81.watchbuddy.core.justwatch.JustWatchEpisodeContent
 import com.justb81.watchbuddy.core.justwatch.JustWatchExternalIds
 import com.justb81.watchbuddy.core.justwatch.JustWatchGraphQlResponse
 import com.justb81.watchbuddy.core.justwatch.JustWatchNode
@@ -205,8 +206,7 @@ class JustWatchDeepLinkRepositoryTest {
                 makeEpisodesResponse(
                     listOf(
                         JustWatchEpisode(
-                            episodeNumber = 2,
-                            seasonNumber = 1,
+                            content = JustWatchEpisodeContent(episodeNumber = 2, seasonNumber = 1),
                             offers = listOf(episodeOffer),
                         )
                     )
@@ -565,7 +565,7 @@ class JustWatchDeepLinkRepositoryTest {
                     makeSeasonsResponse(listOf("season-1-id"))
                 coEvery { api.query(match { it.query == JustWatchApiService.EPISODES_QUERY }) } returns
                     makeEpisodesResponse(
-                        listOf(JustWatchEpisode(episodeNumber = 2, seasonNumber = 1, offers = listOf(episodeOffer)))
+                        listOf(JustWatchEpisode(content = JustWatchEpisodeContent(episodeNumber = 2, seasonNumber = 1), offers = listOf(episodeOffer)))
                     )
 
                 val repo = JustWatchDeepLinkRepository(fakeDao, api)

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
@@ -565,7 +565,12 @@ class JustWatchDeepLinkRepositoryTest {
                     makeSeasonsResponse(listOf("season-1-id"))
                 coEvery { api.query(match { it.query == JustWatchApiService.EPISODES_QUERY }) } returns
                     makeEpisodesResponse(
-                        listOf(JustWatchEpisode(content = JustWatchEpisodeContent(episodeNumber = 2, seasonNumber = 1), offers = listOf(episodeOffer)))
+                        listOf(
+                            JustWatchEpisode(
+                                content = JustWatchEpisodeContent(episodeNumber = 2, seasonNumber = 1),
+                                offers = listOf(episodeOffer),
+                            )
+                        )
                     )
 
                 val repo = JustWatchDeepLinkRepository(fakeDao, api)

--- a/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchApiService.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchApiService.kt
@@ -55,7 +55,7 @@ interface JustWatchApiService {
         """.trimIndent()
 
         val SEASONS_QUERY = """
-            query GetShowSeasons(${'$'}nodeId: ID!, ${'$'}country: Country!, ${'$'}language: Language!) {
+            query GetShowSeasons(${'$'}nodeId: ID!) {
               node(id: ${'$'}nodeId) {
                 ... on Show {
                   seasons { id }
@@ -69,8 +69,10 @@ interface JustWatchApiService {
               node(id: ${'$'}nodeId) {
                 ... on Season {
                   episodes {
-                    episodeNumber
-                    seasonNumber
+                    content(country: ${'$'}country, language: ${'$'}language) {
+                      episodeNumber
+                      seasonNumber
+                    }
                     offers(country: ${'$'}country, platform: WEB) {
                       standardWebURL
                       monetizationType
@@ -137,9 +139,14 @@ data class JustWatchSeasonRef(
 
 @Serializable
 data class JustWatchEpisode(
+    val content: JustWatchEpisodeContent? = null,
+    val offers: List<JustWatchOffer> = emptyList(),
+)
+
+@Serializable
+data class JustWatchEpisodeContent(
     val episodeNumber: Int,
     val seasonNumber: Int,
-    val offers: List<JustWatchOffer> = emptyList(),
 )
 
 @Serializable


### PR DESCRIPTION
## Summary

- **`SEASONS_QUERY`**: Removed `$country` and `$language` from the `GetShowSeasons` operation signature — `seasons { id }` takes no arguments, so both variables were declared but never used (GraphQL spec §5.8.5 violation → HTTP 422 `GRAPHQL_VALIDATION_FAILED`)
- **`EPISODES_QUERY`**: `episodeNumber` and `seasonNumber` moved from the top-level `Episode` fields into `content(country, language) { ... }` to match the current JustWatch schema; `$language` is now correctly used there
- Updated `JustWatchEpisode` data class: replaced top-level `episodeNumber`/`seasonNumber` fields with `content: JustWatchEpisodeContent?`
- Updated `fetchEpisodeOffersForNode` episode lookup to use `it.content?.seasonNumber` / `it.content?.episodeNumber`
- Removed `country`/`language` from the `SEASONS_QUERY` call-site variables
- Updated tests to construct `JustWatchEpisode` with the new `content` sub-object

## Verification

Tested directly with `curl` against `https://apis.justwatch.com/graphql`:

| Query | Before | After |
|---|---|---|
| `GetShowSeasons` (broken) | `422 GRAPHQL_VALIDATION_FAILED` — `$country` never used | `200 {"data":{"node":{"seasons":[...]}}}` |
| `GetSeasonEpisodes` (broken) | `422` — `$language` never used, `episodeNumber`/`seasonNumber` invalid fields | `200` with episode data incl. `content.episodeNumber` / `content.seasonNumber` |

## Test plan

- [x] CI build passes (`build-android.yml`)
- [x] No new detekt / lint findings
- [ ] On device: open a show in TV ShowDetail → streaming providers load without 422 errors in diagnostics log

Note: Gradle scope skipped locally (no Android SDK in sandbox); CI is the real gate.

https://claude.ai/code/session_01JuDTkVnRymwbJByXiZp3AH

---
_Generated by [Claude Code](https://claude.ai/code/session_01JuDTkVnRymwbJByXiZp3AH)_