### PR TITLE
test(core): add edge-case locale tests for LocaleHelper.getTmdbLanguage

### DIFF
--- a/core/src/test/java/com/justb81/watchbuddy/core/locale/LocaleHelperTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/locale/LocaleHelperTest.kt
@@ -46,9 +46,9 @@ class LocaleHelperTest {
             Arguments.of(Locale.ENGLISH, "en"),
             Arguments.of(Locale.GERMAN, "de"),
             Arguments.of(locale("fr"), "fr"),
-            Arguments.of(locale("eo"), "eo"),   // Esperanto — no country variant exists
-            Arguments.of(locale("la"), "la"),   // Latin — no country variant exists
-            Arguments.of(locale("en"), "en")    // regionless English
+            Arguments.of(locale("eo"), "eo"), // Esperanto — no country variant exists
+            Arguments.of(locale("la"), "la"), // Latin — no country variant exists
+            Arguments.of(locale("en"), "en") // regionless English
         )
     }
 

--- a/core/src/test/java/com/justb81/watchbuddy/core/locale/LocaleHelperTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/locale/LocaleHelperTest.kt
@@ -42,9 +42,13 @@ class LocaleHelperTest {
             Arguments.of(Locale.FRANCE, "fr-FR"),
             Arguments.of(locale("es", "ES"), "es-ES"),
             Arguments.of(locale("ja", "JP"), "ja-JP"),
+            // language-only locales must not produce a trailing hyphen
             Arguments.of(Locale.ENGLISH, "en"),
             Arguments.of(Locale.GERMAN, "de"),
-            Arguments.of(locale("fr"), "fr")
+            Arguments.of(locale("fr"), "fr"),
+            Arguments.of(locale("eo"), "eo"),   // Esperanto — no country variant exists
+            Arguments.of(locale("la"), "la"),   // Latin — no country variant exists
+            Arguments.of(locale("en"), "en")    // regionless English
         )
     }
 
@@ -95,6 +99,21 @@ class LocaleHelperTest {
         fun `language-only locale returns language without hyphen`() {
             val result = LocaleHelper.getTmdbLanguage(Locale.ENGLISH)
             assertFalse(result.contains("-"))
+        }
+
+        @Test
+        fun `Esperanto locale returns eo without trailing hyphen`() {
+            assertEquals("eo", LocaleHelper.getTmdbLanguage(locale("eo")))
+        }
+
+        @Test
+        fun `Latin locale returns la without trailing hyphen`() {
+            assertEquals("la", LocaleHelper.getTmdbLanguage(locale("la")))
+        }
+
+        @Test
+        fun `regionless English returns en without trailing hyphen`() {
+            assertEquals("en", LocaleHelper.getTmdbLanguage(locale("en")))
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds parameterized test entries for Esperanto (`eo`), Latin (`la`), and regionless English (`en`) in `tmdbLanguageProvider` to cover the edge cases called out in #576.
- Adds three explicit named tests (`Esperanto locale returns eo without trailing hyphen`, `Latin locale returns la without trailing hyphen`, `regionless English returns en without trailing hyphen`) for clarity and easier failure diagnosis.
- The `LocaleHelper.getTmdbLanguage` implementation already guards against the trailing-hyphen bug via `country.takeIf { it.isNotEmpty() }`; this PR anchors that behaviour with regression tests so any future refactor can't silently reintroduce it.

> **Note:** The Gradle scope was skipped locally (no Android SDK in this environment). CI (`build-android.yml`) is the gate for the new JUnit tests.

## Test plan

- [ ] CI `Test & Build` passes with the three new explicit tests and the three new parameterized cases all green.
- [ ] `LocaleHelper.getTmdbLanguage(locale("eo"))` → `"eo"` (no trailing hyphen)
- [ ] `LocaleHelper.getTmdbLanguage(locale("la"))` → `"la"` (no trailing hyphen)
- [ ] `LocaleHelper.getTmdbLanguage(locale("en"))` → `"en"` (no trailing hyphen)

Closes #576

https://claude.ai/code/session_01UvR2aBTD74c38cL5WPNFdw

---
_Generated by [Claude Code](https://claude.ai/code/session_01UvR2aBTD74c38cL5WPNFdw)_