### PR TITLE
fix(tv): resolve YouTube/Joyn deep links, country code, and provider chip (#620)

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.phone.server
 import android.app.ActivityManager
 import android.content.Context
 import android.os.Build
+import java.util.Locale
 import com.justb81.watchbuddy.core.model.AvatarSource
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.trakt.TraktApiService
@@ -75,6 +76,7 @@ class DeviceCapabilityProvider @Inject constructor(
             avatarSource = settings.avatarSource,
             lastResolvedSessionKey = stateManager.lastResolvedSessionKey.value,
             lastResolvedTraktId = stateManager.lastResolvedTraktId.value,
+            countryCode = Locale.getDefault().country.takeIf { it.length == 2 },
         )
     }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
@@ -3,7 +3,6 @@ package com.justb81.watchbuddy.phone.server
 import android.app.ActivityManager
 import android.content.Context
 import android.os.Build
-import java.util.Locale
 import com.justb81.watchbuddy.core.model.AvatarSource
 import com.justb81.watchbuddy.core.model.DeviceCapability
 import com.justb81.watchbuddy.core.trakt.TraktApiService
@@ -17,6 +16,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
@@ -8,6 +8,9 @@ import com.justb81.watchbuddy.core.justwatch.JustWatchPackageMap
 import com.justb81.watchbuddy.core.justwatch.JustWatchTitle
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.json.buildJsonObject
@@ -25,6 +28,35 @@ private val COUNTRY_CODE_REGEX = Regex("[A-Z]{2}")
 private const val DEFAULT_MISS_WINDOW_MS = 24L * 60 * 60 * 1_000
 private const val MAX_ERROR_SUMMARY_LENGTH = 200
 private const val MAX_HTTP_ERROR_BODY_LENGTH = 500
+private const val MAX_OUTCOME_EVENTS = 50
+
+/**
+ * A single deep-link resolution outcome recorded in [JustWatchDeepLinkRepository.outcomeEvents].
+ *
+ * [providerId] is -1 when the outcome is not specific to a single provider (e.g., HTTP errors
+ * and search misses affect all providers for a given show). [detail] carries extra context
+ * such as the unmapped technical name or HTTP status.
+ */
+data class JustWatchOutcomeEvent(
+    val timestampMs: Long,
+    val tmdbShowId: Int,
+    val providerId: Int,
+    val countryCode: String,
+    val outcome: Outcome,
+    val detail: String = "",
+) {
+    enum class Outcome {
+        EPISODE_CACHE_HIT,
+        EPISODE_API_HIT,
+        SHOW_CACHE_HIT,
+        SHOW_API_HIT,
+        SEARCH_MISS,
+        TECHNICAL_NAME_UNMAPPED,
+        HTTP_ERROR,
+        GRAPHQL_ERROR,
+        EPISODE_NOT_IN_RESULTS,
+    }
+}
 
 /**
  * Resolves JustWatch per-episode deep links with a persistent Room cache.
@@ -78,6 +110,25 @@ class JustWatchDeepLinkRepository @Inject constructor(
     private val missTimestamps = ArrayDeque<Long>()
     private val missLock = Any()
 
+    private val _outcomeEvents = MutableStateFlow<List<JustWatchOutcomeEvent>>(emptyList())
+
+    /** Bounded ring-buffer (max [MAX_OUTCOME_EVENTS]) of recent deep-link resolution outcomes. */
+    val outcomeEvents: StateFlow<List<JustWatchOutcomeEvent>> = _outcomeEvents.asStateFlow()
+
+    private val outcomeLock = Any()
+
+    private fun recordOutcome(
+        tmdbShowId: Int,
+        providerId: Int,
+        countryCode: String,
+        outcome: JustWatchOutcomeEvent.Outcome,
+        detail: String = "",
+    ) = synchronized(outcomeLock) {
+        val event = JustWatchOutcomeEvent(System.currentTimeMillis(), tmdbShowId, providerId, countryCode, outcome, detail)
+        val current = _outcomeEvents.value
+        _outcomeEvents.value = if (current.size >= MAX_OUTCOME_EVENTS) current.drop(1) + event else current + event
+    }
+
     private fun recordMiss() = synchronized(missLock) {
         missTimestamps.addLast(System.currentTimeMillis())
     }
@@ -116,20 +167,29 @@ class JustWatchDeepLinkRepository @Inject constructor(
 
         // 1. Episode-level cache
         val epCached = dao.get(tmdbShowId, season, episode, providerId, country)
-        if (epCached != null && epCached.isValidCache()) return epCached.standardWebUrl
+        if (epCached != null && epCached.isValidCache()) {
+            recordOutcome(tmdbShowId, providerId, country, JustWatchOutcomeEvent.Outcome.EPISODE_CACHE_HIT)
+            return epCached.standardWebUrl
+        }
 
         // 2. Episode-level live fetch (deduped per episode)
         val episodeKey = FetchKey(tmdbShowId, season, episode, country)
         getMutex(episodeKey).withLock {
             // Re-check cache after acquiring lock — another coroutine may have populated it
             val refreshed = dao.get(tmdbShowId, season, episode, providerId, country)
-            if (refreshed != null && refreshed.isValidCache()) return refreshed.standardWebUrl
+            if (refreshed != null && refreshed.isValidCache()) {
+                recordOutcome(tmdbShowId, providerId, country, JustWatchOutcomeEvent.Outcome.EPISODE_CACHE_HIT)
+                return refreshed.standardWebUrl
+            }
             fetchAndCacheEpisodeOffers(tmdbShowId, season, episode, country, showTitle)
         }
 
         // Re-read after episode fetch
         val epResult = dao.get(tmdbShowId, season, episode, providerId, country)
-        if (epResult != null && epResult.isValidCache()) return epResult.standardWebUrl
+        if (epResult != null && epResult.isValidCache()) {
+            recordOutcome(tmdbShowId, providerId, country, JustWatchOutcomeEvent.Outcome.EPISODE_API_HIT)
+            return epResult.standardWebUrl
+        }
 
         return resolveShowLevel(tmdbShowId, providerId, country, showTitle)
     }
@@ -152,17 +212,27 @@ class JustWatchDeepLinkRepository @Inject constructor(
     ): String? {
         // 3. Show-level cache
         val showCached = dao.get(tmdbShowId, 0, 0, providerId, countryCode)
-        if (showCached != null && showCached.isValidCache()) return showCached.standardWebUrl
+        if (showCached != null && showCached.isValidCache()) {
+            recordOutcome(tmdbShowId, providerId, countryCode, JustWatchOutcomeEvent.Outcome.SHOW_CACHE_HIT)
+            return showCached.standardWebUrl
+        }
 
         // 4. Show-level live fetch (deduped)
         val showKey = FetchKey(tmdbShowId, 0, 0, countryCode)
         getMutex(showKey).withLock {
             val refreshed = dao.get(tmdbShowId, 0, 0, providerId, countryCode)
-            if (refreshed != null && refreshed.isValidCache()) return refreshed.standardWebUrl
+            if (refreshed != null && refreshed.isValidCache()) {
+                recordOutcome(tmdbShowId, providerId, countryCode, JustWatchOutcomeEvent.Outcome.SHOW_CACHE_HIT)
+                return refreshed.standardWebUrl
+            }
             fetchAndCacheShowOffers(tmdbShowId, countryCode, showTitle)
         }
 
-        return dao.get(tmdbShowId, 0, 0, providerId, countryCode)?.standardWebUrl
+        val showResult = dao.get(tmdbShowId, 0, 0, providerId, countryCode)
+        if (showResult?.standardWebUrl != null) {
+            recordOutcome(tmdbShowId, providerId, countryCode, JustWatchOutcomeEvent.Outcome.SHOW_API_HIT)
+        }
+        return showResult?.standardWebUrl
     }
 
     private fun JustWatchDeepLink.isValidCache(): Boolean =
@@ -200,17 +270,20 @@ class JustWatchDeepLinkRepository @Inject constructor(
                     val msg = "HTTP ${result.code} searching '$showTitle' (tmdb=$tmdbShowId): ${result.bodySummary}"
                     DiagnosticLog.error(TAG, msg)
                     recordError(msg)
+                    recordOutcome(tmdbShowId, -1, countryCode, JustWatchOutcomeEvent.Outcome.HTTP_ERROR, "HTTP ${result.code}")
                     return
                 }
                 is SearchResult.GraphQlError -> {
                     val msg = "GraphQL error searching '$showTitle' (tmdb=$tmdbShowId): ${result.summary}"
                     DiagnosticLog.error(TAG, msg)
                     recordError(msg)
+                    recordOutcome(tmdbShowId, -1, countryCode, JustWatchOutcomeEvent.Outcome.GRAPHQL_ERROR, result.summary)
                     return
                 }
                 is SearchResult.SearchMiss -> {
                     DiagnosticLog.warn(TAG, "No JustWatch node matched tmdbId=$tmdbShowId title='$showTitle'")
                     recordMiss()
+                    recordOutcome(tmdbShowId, -1, countryCode, JustWatchOutcomeEvent.Outcome.SEARCH_MISS)
                     return
                 }
                 is SearchResult.Found ->
@@ -288,6 +361,7 @@ class JustWatchDeepLinkRepository @Inject constructor(
             cacheOffers(jwEp.offers, tmdbShowId, season, episode, countryCode)
         } else {
             DiagnosticLog.warn(TAG, "Episode S${season}E$episode not found in JustWatch for tmdbId=$tmdbShowId")
+            recordOutcome(tmdbShowId, -1, countryCode, JustWatchOutcomeEvent.Outcome.EPISODE_NOT_IN_RESULTS, "S${season}E$episode")
         }
     }
 
@@ -418,9 +492,14 @@ class JustWatchDeepLinkRepository @Inject constructor(
             .filter { it.monetizationType in ALLOWED_MONETIZATION }
             .forEach { offer ->
                 val technicalName = offer.`package`?.technicalName ?: return@forEach
-                val providerId = JustWatchPackageMap.resolveProviderId(technicalName) ?: return@forEach
+                val resolvedId = JustWatchPackageMap.resolveProviderId(technicalName)
+                if (resolvedId == null) {
+                    DiagnosticLog.warn(TAG, "technicalNameUnmapped: '$technicalName' (tmdbShowId=$tmdbShowId)")
+                    recordOutcome(tmdbShowId, -1, countryCode, JustWatchOutcomeEvent.Outcome.TECHNICAL_NAME_UNMAPPED, technicalName)
+                    return@forEach
+                }
                 val url = offer.standardWebURL ?: return@forEach
-                providerUrls.putIfAbsent(providerId, url)
+                providerUrls.putIfAbsent(resolvedId, url)
             }
         for ((providerId, url) in providerUrls) {
             dao.upsert(JustWatchDeepLink(tmdbShowId, season, episode, providerId, countryCode, url, now))

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepository.kt
@@ -124,7 +124,9 @@ class JustWatchDeepLinkRepository @Inject constructor(
         outcome: JustWatchOutcomeEvent.Outcome,
         detail: String = "",
     ) = synchronized(outcomeLock) {
-        val event = JustWatchOutcomeEvent(System.currentTimeMillis(), tmdbShowId, providerId, countryCode, outcome, detail)
+        val event = JustWatchOutcomeEvent(
+            System.currentTimeMillis(), tmdbShowId, providerId, countryCode, outcome, detail,
+        )
         val current = _outcomeEvents.value
         _outcomeEvents.value = if (current.size >= MAX_OUTCOME_EVENTS) current.drop(1) + event else current + event
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.tv.material3.*
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.tv.data.JustWatchOutcomeEvent
 import com.justb81.watchbuddy.core.model.PlaybackTick
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.core.scrobbler.PlaybackIntentStats
@@ -236,6 +237,7 @@ fun TvDiagnosticsScreen(
                     lastFetchMs = uiState.lastDeepLinkFetchMs,
                     lastError = uiState.lastJustWatchError,
                     searchMisses24h = uiState.justWatchSearchMisses24h,
+                    recentOutcomes = uiState.recentJustWatchOutcomes,
                     onClearCache = { viewModel.clearJustWatchCache() },
                 )
             }
@@ -589,6 +591,7 @@ private fun StreamingDeepLinksSection(
     lastFetchMs: Long,
     lastError: String?,
     searchMisses24h: Int,
+    recentOutcomes: List<JustWatchOutcomeEvent>,
     onClearCache: () -> Unit,
 ) {
     Text(
@@ -641,6 +644,57 @@ private fun StreamingDeepLinksSection(
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f),
                     )
+                }
+            }
+            if (recentOutcomes.isNotEmpty()) {
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.tv_diagnostics_row_jw_recent_outcomes),
+                    fontSize = 12.sp,
+                    color = Color.White.copy(alpha = 0.5f),
+                    modifier = Modifier.padding(top = 4.dp),
+                )
+                recentOutcomes.asReversed().forEach { event ->
+                    val outcomeStatus = when (event.outcome) {
+                        JustWatchOutcomeEvent.Outcome.EPISODE_CACHE_HIT,
+                        JustWatchOutcomeEvent.Outcome.EPISODE_API_HIT,
+                        JustWatchOutcomeEvent.Outcome.SHOW_CACHE_HIT,
+                        JustWatchOutcomeEvent.Outcome.SHOW_API_HIT -> Status.OK
+                        JustWatchOutcomeEvent.Outcome.SEARCH_MISS,
+                        JustWatchOutcomeEvent.Outcome.TECHNICAL_NAME_UNMAPPED,
+                        JustWatchOutcomeEvent.Outcome.EPISODE_NOT_IN_RESULTS -> Status.WARN
+                        JustWatchOutcomeEvent.Outcome.HTTP_ERROR,
+                        JustWatchOutcomeEvent.Outcome.GRAPHQL_ERROR -> Status.FAIL
+                    }
+                    val label = event.outcome.name.lowercase().replace('_', ' ')
+                    val value = buildString {
+                        append("tmdb=${event.tmdbShowId}")
+                        if (event.providerId >= 0) append(" p=${event.providerId}")
+                        if (event.detail.isNotBlank()) append(" (${event.detail})")
+                        append(" · ${formatAge(event.timestampMs)}")
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 3.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                    ) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.weight(1f),
+                        ) {
+                            Box(Modifier.size(8.dp).background(statusColor(outcomeStatus), RoundedCornerShape(2.dp)))
+                            Spacer(Modifier.width(8.dp))
+                            Text(label, fontSize = 12.sp, color = Color.White)
+                        }
+                        Text(
+                            value,
+                            fontSize = 11.sp,
+                            color = Color.White.copy(alpha = 0.6f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
                 }
             }
             Spacer(Modifier.height(8.dp))

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -30,10 +30,10 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.tv.material3.*
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
-import com.justb81.watchbuddy.tv.data.JustWatchOutcomeEvent
 import com.justb81.watchbuddy.core.model.PlaybackTick
 import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.core.scrobbler.PlaybackIntentStats
+import com.justb81.watchbuddy.tv.data.JustWatchOutcomeEvent
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import com.justb81.watchbuddy.tv.scrobbler.WatchNextMetadataSource
 
@@ -647,55 +647,7 @@ private fun StreamingDeepLinksSection(
                 }
             }
             if (recentOutcomes.isNotEmpty()) {
-                Spacer(Modifier.height(8.dp))
-                Text(
-                    text = stringResource(R.string.tv_diagnostics_row_jw_recent_outcomes),
-                    fontSize = 12.sp,
-                    color = Color.White.copy(alpha = 0.5f),
-                    modifier = Modifier.padding(top = 4.dp),
-                )
-                recentOutcomes.asReversed().forEach { event ->
-                    val outcomeStatus = when (event.outcome) {
-                        JustWatchOutcomeEvent.Outcome.EPISODE_CACHE_HIT,
-                        JustWatchOutcomeEvent.Outcome.EPISODE_API_HIT,
-                        JustWatchOutcomeEvent.Outcome.SHOW_CACHE_HIT,
-                        JustWatchOutcomeEvent.Outcome.SHOW_API_HIT -> Status.OK
-                        JustWatchOutcomeEvent.Outcome.SEARCH_MISS,
-                        JustWatchOutcomeEvent.Outcome.TECHNICAL_NAME_UNMAPPED,
-                        JustWatchOutcomeEvent.Outcome.EPISODE_NOT_IN_RESULTS -> Status.WARN
-                        JustWatchOutcomeEvent.Outcome.HTTP_ERROR,
-                        JustWatchOutcomeEvent.Outcome.GRAPHQL_ERROR -> Status.FAIL
-                    }
-                    val label = event.outcome.name.lowercase().replace('_', ' ')
-                    val value = buildString {
-                        append("tmdb=${event.tmdbShowId}")
-                        if (event.providerId >= 0) append(" p=${event.providerId}")
-                        if (event.detail.isNotBlank()) append(" (${event.detail})")
-                        append(" · ${formatAge(event.timestampMs)}")
-                    }
-                    Row(
-                        modifier = Modifier.fillMaxWidth().padding(vertical = 3.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                    ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.weight(1f),
-                        ) {
-                            Box(Modifier.size(8.dp).background(statusColor(outcomeStatus), RoundedCornerShape(2.dp)))
-                            Spacer(Modifier.width(8.dp))
-                            Text(label, fontSize = 12.sp, color = Color.White)
-                        }
-                        Text(
-                            value,
-                            fontSize = 11.sp,
-                            color = Color.White.copy(alpha = 0.6f),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.weight(1f),
-                        )
-                    }
-                }
+                RecentOutcomesBlock(recentOutcomes)
             }
             Spacer(Modifier.height(8.dp))
             Text(
@@ -703,6 +655,59 @@ private fun StreamingDeepLinksSection(
                 fontSize = 13.sp,
                 fontWeight = FontWeight.Bold,
                 color = ActionHintColor,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecentOutcomesBlock(recentOutcomes: List<JustWatchOutcomeEvent>) {
+    Spacer(Modifier.height(8.dp))
+    Text(
+        text = stringResource(R.string.tv_diagnostics_row_jw_recent_outcomes),
+        fontSize = 12.sp,
+        color = Color.White.copy(alpha = 0.5f),
+        modifier = Modifier.padding(top = 4.dp),
+    )
+    recentOutcomes.asReversed().forEach { event ->
+        val outcomeStatus = when (event.outcome) {
+            JustWatchOutcomeEvent.Outcome.EPISODE_CACHE_HIT,
+            JustWatchOutcomeEvent.Outcome.EPISODE_API_HIT,
+            JustWatchOutcomeEvent.Outcome.SHOW_CACHE_HIT,
+            JustWatchOutcomeEvent.Outcome.SHOW_API_HIT -> Status.OK
+            JustWatchOutcomeEvent.Outcome.SEARCH_MISS,
+            JustWatchOutcomeEvent.Outcome.TECHNICAL_NAME_UNMAPPED,
+            JustWatchOutcomeEvent.Outcome.EPISODE_NOT_IN_RESULTS -> Status.WARN
+            JustWatchOutcomeEvent.Outcome.HTTP_ERROR,
+            JustWatchOutcomeEvent.Outcome.GRAPHQL_ERROR -> Status.FAIL
+        }
+        val label = event.outcome.name.lowercase().replace('_', ' ')
+        val value = buildString {
+            append("tmdb=${event.tmdbShowId}")
+            if (event.providerId >= 0) append(" p=${event.providerId}")
+            if (event.detail.isNotBlank()) append(" (${event.detail})")
+            append(" · ${formatAge(event.timestampMs)}")
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(vertical = 3.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.weight(1f),
+            ) {
+                Box(Modifier.size(8.dp).background(statusColor(outcomeStatus), RoundedCornerShape(2.dp)))
+                Spacer(Modifier.width(8.dp))
+                Text(label, fontSize = 12.sp, color = Color.White)
+            }
+            Text(
+                value,
+                fontSize = 11.sp,
+                color = Color.White.copy(alpha = 0.6f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
             )
         }
     }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModel.kt
@@ -10,6 +10,7 @@ import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.core.scrobbler.PlaybackIntentProvider
 import com.justb81.watchbuddy.core.scrobbler.PlaybackIntentStats
 import com.justb81.watchbuddy.tv.data.JustWatchDeepLinkRepository
+import com.justb81.watchbuddy.tv.data.JustWatchOutcomeEvent
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import com.justb81.watchbuddy.tv.scrobbler.NotificationMetadataSource
 import com.justb81.watchbuddy.tv.scrobbler.WatchNextMetadataSource
@@ -61,6 +62,11 @@ data class TvDiagnosticsUiState(
     val ambiguousPromptStats: MediaSessionScrobbler.AmbiguousPromptStats? = null,
     /** Counters for Watch-Now intent lifecycle (hits / fallthroughs / manual-mark overrides). Null before first refresh. */
     val intentStats: PlaybackIntentStats? = null,
+    /**
+     * The last 5 JustWatch resolution outcomes for display in the Streaming Links diagnostics section.
+     * Most recent event is last. Empty until the user navigates to a show-detail screen.
+     */
+    val recentJustWatchOutcomes: List<JustWatchOutcomeEvent> = emptyList(),
 )
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -144,6 +150,12 @@ class TvDiagnosticsViewModel @Inject constructor(
             DiagnosticLog.updates.onStart { emit(Unit) }.collect {
                 val latest = DiagnosticLog.snapshot().asReversed().take(MAX_RECENT_EVENTS)
                 _uiState.update { it.copy(recentEvents = latest) }
+            }
+        }
+
+        viewModelScope.launch {
+            justWatchRepo.outcomeEvents.collect { events ->
+                _uiState.update { it.copy(recentJustWatchOutcomes = events.takeLast(MAX_DISPLAYED_OUTCOMES)) }
             }
         }
     }
@@ -240,5 +252,6 @@ class TvDiagnosticsViewModel @Inject constructor(
 
     companion object {
         private const val MAX_RECENT_EVENTS = 100
+        private const val MAX_DISPLAYED_OUTCOMES = 5
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -409,9 +409,9 @@ private fun ProviderChip(
         else -> Color.Transparent
     }
     val borderWidth = if (provider.isLastUsed) 2.dp else 0.dp
-    val isEnabled = deepLinkState is DeepLinkState.Available
-        || deepLinkState == null
-        || (deepLinkState is DeepLinkState.Unavailable && provider.isInstalled)
+    val isEnabled = deepLinkState is DeepLinkState.Available ||
+        deepLinkState == null ||
+        (deepLinkState is DeepLinkState.Unavailable && provider.isInstalled)
     val focusedContainerColor = if (isEnabled) {
         MaterialTheme.colorScheme.surfaceVariant
     } else {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -409,7 +409,9 @@ private fun ProviderChip(
         else -> Color.Transparent
     }
     val borderWidth = if (provider.isLastUsed) 2.dp else 0.dp
-    val isEnabled = deepLinkState is DeepLinkState.Available || deepLinkState == null
+    val isEnabled = deepLinkState is DeepLinkState.Available
+        || deepLinkState == null
+        || (deepLinkState is DeepLinkState.Unavailable && provider.isInstalled)
     val focusedContainerColor = if (isEnabled) {
         MaterialTheme.colorScheme.surfaceVariant
     } else {
@@ -435,8 +437,11 @@ private fun ProviderChip(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
             ) {
                 ProviderLogo(provider)
-                val labelText = when (deepLinkState) {
-                    is DeepLinkState.Unavailable -> stringResource(R.string.tv_provider_no_deep_link)
+                val labelText = when {
+                    deepLinkState is DeepLinkState.Unavailable && provider.isInstalled ->
+                        stringResource(R.string.tv_provider_open_app)
+                    deepLinkState is DeepLinkState.Unavailable ->
+                        stringResource(R.string.tv_provider_no_deep_link)
                     else -> provider.name
                 }
                 Text(

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModel.kt
@@ -162,6 +162,19 @@ class ShowDetailViewModel @Inject constructor(
     }
 
     /**
+     * Resolves the country code for watch-provider and JustWatch lookups.
+     *
+     * Cascade:
+     *   1. Country code reported by the best-connected phone's locale (via [DeviceCapability.countryCode]).
+     *   2. TV's own default locale country (may be empty on TVs with English-only firmware).
+     *   3. Hard-coded "US" fallback.
+     */
+    private fun resolveCountryCode(): String =
+        phoneDiscovery.getBestPhone()?.capability?.countryCode
+            ?: Locale.getDefault().country.takeIf { it.length == 2 }
+            ?: "US"
+
+    /**
      * Fetches TMDB watch providers for [enriched], applies installed-app filter and
      * last-used ordering, then updates [providers]. Safe to call multiple times (retry).
      */
@@ -178,7 +191,7 @@ class ShowDetailViewModel @Inject constructor(
                 return@launch
             }
             try {
-                val countryCode = Locale.getDefault().country.takeIf { it.length == 2 } ?: "US"
+                val countryCode = resolveCountryCode()
                 val showNonInstalled = streamingPrefs.getShowNonInstalledProviders()
                 val (resolved, pageUrl) = watchProviders.getResolvedProviders(
                     tmdbId, countryCode, apiKey, showNonInstalled
@@ -208,7 +221,7 @@ class ShowDetailViewModel @Inject constructor(
             ShowProgressCalculator.nextUnwatchedEpisodeNumbers(enriched.entry, enriched.tmdb) ?: return
         val providerState = _providers.value
         val providerList = (providerState as? ProviderListUiState.Success)?.providers ?: return
-        val countryCode = Locale.getDefault().country.takeIf { it.length == 2 } ?: "US"
+        val countryCode = resolveCountryCode()
         val showTitle = enriched.entry.show.title
 
         // Set all providers to Loading

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -63,10 +63,11 @@
     <string name="tv_provider_last_used_label">Zuletzt genutzt</string>
     <!-- JustWatch deep links (#476) -->
     <string name="tv_provider_no_deep_link">Kein Deep Link</string>
+    <string name="tv_provider_open_app">App öffnen</string>
     <string name="tv_watch_now_unavailable">Deep Link nicht verfügbar</string>
     <string name="tv_watch_now_no_provider">Kein Anbieter verfügbar</string>
     <string name="tv_justwatch_attribution">Streaming-Daten von JustWatch</string>
-    <!-- Diagnostics — streaming deep links (#476) -->
+    <!-- Diagnostics — streaming deep links (#476 / #620) -->
     <string name="tv_diagnostics_section_streaming_links">Streaming-Deep-Links</string>
     <string name="tv_diagnostics_row_cached_urls">Gespeicherte URLs</string>
     <string name="tv_diagnostics_row_negative_entries">Negative Einträge</string>
@@ -74,6 +75,7 @@
     <string name="tv_diagnostics_action_clear_streaming_cache">Streaming-Link-Cache löschen</string>
     <string name="tv_diagnostics_row_jw_search_misses">Suchtreffer fehler (24 Std.)</string>
     <string name="tv_diagnostics_row_jw_last_error">Letzter JustWatch-Fehler</string>
+    <string name="tv_diagnostics_row_jw_recent_outcomes">Letzte Ergebnisse</string>
 
     <!-- TV Settings hub (#344 / #367) -->
     <string name="tv_settings_title">Einstellungen</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -66,10 +66,11 @@
     <string name="tv_provider_last_used_label">Última vez usado</string>
     <!-- JustWatch deep links (#476) -->
     <string name="tv_provider_no_deep_link">Sin enlace directo</string>
+    <string name="tv_provider_open_app">Abrir app</string>
     <string name="tv_watch_now_unavailable">Enlace directo no disponible</string>
     <string name="tv_watch_now_no_provider">Ningún proveedor disponible</string>
     <string name="tv_justwatch_attribution">Datos de streaming por JustWatch</string>
-    <!-- Diagnostics — streaming deep links (#476) -->
+    <!-- Diagnostics — streaming deep links (#476 / #620) -->
     <string name="tv_diagnostics_section_streaming_links">Enlaces directos de streaming</string>
     <string name="tv_diagnostics_row_cached_urls">URLs en caché</string>
     <string name="tv_diagnostics_row_negative_entries">Entradas negativas</string>
@@ -77,6 +78,7 @@
     <string name="tv_diagnostics_action_clear_streaming_cache">Vaciar caché de enlaces de streaming</string>
     <string name="tv_diagnostics_row_jw_search_misses">Búsquedas fallidas (24 h)</string>
     <string name="tv_diagnostics_row_jw_last_error">Último error de JustWatch</string>
+    <string name="tv_diagnostics_row_jw_recent_outcomes">Últimos resultados</string>
 
     <!-- TV Settings hub (#344 / #367) -->
     <string name="tv_settings_title">Ajustes</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -66,10 +66,11 @@
     <string name="tv_provider_last_used_label">Dernière utilisation</string>
     <!-- JustWatch deep links (#476) -->
     <string name="tv_provider_no_deep_link">Pas de lien direct</string>
+    <string name="tv_provider_open_app">Ouvrir l\'app</string>
     <string name="tv_watch_now_unavailable">Lien direct indisponible</string>
     <string name="tv_watch_now_no_provider">Aucun fournisseur disponible</string>
     <string name="tv_justwatch_attribution">Données streaming par JustWatch</string>
-    <!-- Diagnostics — streaming deep links (#476) -->
+    <!-- Diagnostics — streaming deep links (#476 / #620) -->
     <string name="tv_diagnostics_section_streaming_links">Liens directs streaming</string>
     <string name="tv_diagnostics_row_cached_urls">URLs en cache</string>
     <string name="tv_diagnostics_row_negative_entries">Entrées négatives</string>
@@ -77,6 +78,7 @@
     <string name="tv_diagnostics_action_clear_streaming_cache">Vider le cache des liens streaming</string>
     <string name="tv_diagnostics_row_jw_search_misses">Recherches manquées (24 h)</string>
     <string name="tv_diagnostics_row_jw_last_error">Dernière erreur JustWatch</string>
+    <string name="tv_diagnostics_row_jw_recent_outcomes">Derniers résultats</string>
 
     <!-- TV Settings hub (#344 / #367) -->
     <string name="tv_settings_title">Paramètres</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -63,10 +63,12 @@
     <string name="tv_provider_last_used_label">Last used</string>
     <!-- JustWatch deep links (#476) -->
     <string name="tv_provider_no_deep_link">No deep link</string>
+    <!-- Shown on a provider chip when JustWatch has no deep link but the app is installed (#620) -->
+    <string name="tv_provider_open_app">Open app</string>
     <string name="tv_watch_now_unavailable">Deep link unavailable</string>
     <string name="tv_watch_now_no_provider">No provider available</string>
     <string name="tv_justwatch_attribution">Streaming data by JustWatch</string>
-    <!-- Diagnostics — streaming deep links (#476) -->
+    <!-- Diagnostics — streaming deep links (#476 / #620) -->
     <string name="tv_diagnostics_section_streaming_links">Streaming deep links</string>
     <string name="tv_diagnostics_row_cached_urls">Cached URLs</string>
     <string name="tv_diagnostics_row_negative_entries">Negative entries</string>
@@ -74,6 +76,7 @@
     <string name="tv_diagnostics_action_clear_streaming_cache">Clear streaming-link cache</string>
     <string name="tv_diagnostics_row_jw_search_misses">Search misses (24 h)</string>
     <string name="tv_diagnostics_row_jw_last_error">Last JustWatch error</string>
+    <string name="tv_diagnostics_row_jw_recent_outcomes">Last outcomes</string>
 
     <!-- TV Settings hub (#344 / #367) -->
     <string name="tv_settings_title">Settings</string>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.tv.data
 
+import com.justb81.watchbuddy.tv.data.JustWatchOutcomeEvent
 import com.justb81.watchbuddy.core.justwatch.JustWatchApiService
 import com.justb81.watchbuddy.core.justwatch.JustWatchContent
 import com.justb81.watchbuddy.core.justwatch.JustWatchData
@@ -521,6 +522,80 @@ class JustWatchDeepLinkRepositoryTest {
         @Test
         fun `lastFetchError returns null initially`() {
             assertNull(repository.lastFetchError())
+        }
+    }
+
+    @Nested
+    @DisplayName("outcome events ring buffer")
+    inner class OutcomeEventTests {
+
+        @Test
+        fun `records EPISODE_CACHE_HIT outcome on cache hit`() = runTest {
+            coEvery { dao.get(100, 1, 2, 8, "US") } returns makeLink(url = "https://www.netflix.com/watch/99")
+
+            repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
+
+            val outcomes = repository.outcomeEvents.value
+            assertTrue(outcomes.any { it.outcome == JustWatchOutcomeEvent.Outcome.EPISODE_CACHE_HIT })
+        }
+
+        @Test
+        fun `records SEARCH_MISS outcome when JustWatch returns no matching TMDB id`() = runTest {
+            coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
+            coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } returns
+                makeSearchResponse(tmdbId = "999")
+
+            repository.resolveDeepLink(100, 1, 2, 8, "US", "Unknown Show")
+
+            val outcomes = repository.outcomeEvents.value
+            assertTrue(outcomes.any { it.outcome == JustWatchOutcomeEvent.Outcome.SEARCH_MISS })
+        }
+
+        @Test
+        fun `logsTechnicalNameUnmapped records TECHNICAL_NAME_UNMAPPED outcome for unknown aliases`() = runTest {
+            val unknownOffer = makeOffer(technicalName = "xyz_unknown")
+            coEvery { dao.get(100, 1, 2, 8, "US") } returns null andThen null
+            coEvery { dao.get(100, 0, 0, 8, "US") } returns null andThen null
+
+            coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } returns
+                makeSearchResponse(offers = listOf(unknownOffer))
+            coEvery { api.query(match { it.query == JustWatchApiService.SEASONS_QUERY }) } returns
+                makeSeasonsResponse()
+            coEvery { api.query(match { it.query == JustWatchApiService.EPISODES_QUERY }) } returns
+                makeEpisodesResponse(emptyList())
+
+            repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
+
+            val outcomes = repository.outcomeEvents.value
+            val unmapped = outcomes.filter { it.outcome == JustWatchOutcomeEvent.Outcome.TECHNICAL_NAME_UNMAPPED }
+            assertTrue(unmapped.isNotEmpty(), "Expected at least one TECHNICAL_NAME_UNMAPPED outcome")
+            assertEquals("xyz_unknown", unmapped.first().detail)
+        }
+
+        @Test
+        fun `records HTTP_ERROR outcome on HTTP 422 from search`() = runTest {
+            coEvery { dao.get(any(), any(), any(), any(), any()) } returns null
+            coEvery { api.query(match { it.query == JustWatchApiService.SEARCH_QUERY }) } answers {
+                makeHttpErrorResponse(422)
+            }
+
+            repository.resolveDeepLink(100, 1, 2, 8, "US", "Breaking Bad")
+
+            val outcomes = repository.outcomeEvents.value
+            assertTrue(outcomes.any { it.outcome == JustWatchOutcomeEvent.Outcome.HTTP_ERROR })
+        }
+
+        @Test
+        fun `ring buffer caps at MAX_OUTCOME_EVENTS and does not grow indefinitely`() = runTest {
+            coEvery { dao.get(any(), any(), any(), any(), any()) } answers {
+                makeLink(url = "https://example.com/${System.nanoTime()}")
+            }
+
+            repeat(60) { i ->
+                repository.resolveDeepLink(i, 1, 1, 8, "US", "Show $i")
+            }
+
+            assertTrue(repository.outcomeEvents.value.size <= 50)
         }
     }
 

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
@@ -1,6 +1,5 @@
 package com.justb81.watchbuddy.tv.data
 
-import com.justb81.watchbuddy.tv.data.JustWatchOutcomeEvent
 import com.justb81.watchbuddy.core.justwatch.JustWatchApiService
 import com.justb81.watchbuddy.core.justwatch.JustWatchContent
 import com.justb81.watchbuddy.core.justwatch.JustWatchData

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsViewModelTest.kt
@@ -6,6 +6,7 @@ import com.justb81.watchbuddy.core.scrobbler.MediaSessionScrobbler
 import com.justb81.watchbuddy.core.scrobbler.NoOpPlaybackIntentProvider
 import com.justb81.watchbuddy.tv.MainDispatcherRule
 import com.justb81.watchbuddy.tv.data.JustWatchDeepLinkRepository
+import com.justb81.watchbuddy.tv.data.JustWatchOutcomeEvent
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
 import com.justb81.watchbuddy.tv.scrobbler.NotificationMetadataSource
 import com.justb81.watchbuddy.tv.scrobbler.WatchNextMetadataSource
@@ -60,6 +61,7 @@ class TvDiagnosticsViewModelTest {
         coEvery { justWatchRepo.clearAll() } returns Unit
         every { justWatchRepo.lastFetchError() } returns null
         every { justWatchRepo.searchMissCount() } returns 0
+        every { justWatchRepo.outcomeEvents } returns MutableStateFlow(emptyList<JustWatchOutcomeEvent>())
         every { watchNextSource.countPublishingApps() } returns WatchNextMetadataSource.CountResult.Success(0)
     }
 

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModelTest.kt
@@ -54,7 +54,7 @@ class ShowDetailViewModelTest {
     private val justWatchRepo: JustWatchDeepLinkRepository = mockk()
     private lateinit var viewModel: ShowDetailViewModel
 
-    private fun makeCapability(apiKey: String?) = DeviceCapability(
+    private fun makeCapability(apiKey: String?, countryCode: String? = null) = DeviceCapability(
         deviceId = "dev1",
         userName = "user",
         deviceName = "Pixel",
@@ -62,10 +62,11 @@ class ShowDetailViewModelTest {
         modelQuality = 0,
         freeRamMb = 0,
         tmdbApiKey = apiKey,
+        countryCode = countryCode,
     )
 
-    private fun makePhone(apiKey: String?) = mockk<PhoneDiscoveryManager.DiscoveredPhone> {
-        every { capability } returns makeCapability(apiKey)
+    private fun makePhone(apiKey: String?, countryCode: String? = null) = mockk<PhoneDiscoveryManager.DiscoveredPhone> {
+        every { capability } returns makeCapability(apiKey, countryCode)
     }
 
     private fun makeEntry(
@@ -185,6 +186,26 @@ class ShowDetailViewModelTest {
 
             val state = assertInstanceOf(ProviderListUiState.Empty::class.java, viewModel.providers.value)
             assertNull(state.tmdbPageUrl)
+        }
+
+        @Test
+        fun `usesPhoneCountryCodeWhenAvailable`() = runTest {
+            val providers = listOf(makeProvider())
+            every { phoneDiscovery.getBestPhone() } returns makePhone("api-key", countryCode = "DE")
+            coEvery { watchProviders.getResolvedProviders(100, "DE", "api-key", false) } returns (providers to null)
+
+            viewModel.loadProviders(makeEntry())
+
+            assertInstanceOf(ProviderListUiState.Success::class.java, viewModel.providers.value)
+        }
+
+        @Test
+        fun `fallsBackToLocaleWhenNoPhone`() = runTest {
+            every { phoneDiscovery.getBestPhone() } returns null
+
+            viewModel.loadProviders(makeEntry())
+
+            assertEquals(ProviderListUiState.Error, viewModel.providers.value)
         }
     }
 

--- a/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMap.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMap.kt
@@ -20,6 +20,10 @@ object JustWatchPackageMap {
         "wpu" to 2187, // WaipuTV
         "ard" to 195, // ARD Mediathek
         "zdf" to 231, // ZDF Mediathek
+        // YouTube: JustWatch has shuffled aliases over time; map all known variants to TMDB 192
+        "yti" to 192, // YouTube (primary alias)
+        "yot" to 192, // YouTube (alternate alias)
+        "ytv" to 192, // YouTube (TV variant alias)
     )
 
     fun resolveProviderId(technicalName: String): Int? =

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -158,6 +158,14 @@ data class DeviceCapability(
      * [TvShowCache] so the same metadata shape short-circuits Phase 1 next time.
      */
     val lastResolvedTraktId: Int? = null,
+    /**
+     * ISO 3166-1 alpha-2 country code reported by the phone's default Locale, or null
+     * when the phone's locale has no country component. The TV uses this for watch-provider
+     * and JustWatch lookups so that region-specific services (e.g. Joyn in DE/AT) appear
+     * correctly even when the TV's own UI locale returns an empty country string.
+     * Nullable for backward compatibility with older phone builds that don't include this field.
+     */
+    val countryCode: String? = null,
 )
 
 enum class LlmBackend { AICORE, LITERT, NONE }

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/AppProfiles.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/AppProfiles.kt
@@ -95,6 +95,22 @@ object AppProfiles {
             packageName = "org.xbmc.kodi",
             preferredSourceTags = listOf("mediaSession.title"),
         ),
+        // Joyn (German free streaming, ProSiebenSat.1) — episode marker uses "Staffel Y, Folge X"
+        AppProfile(
+            packageName = "de.prosiebensat1digital.seventv",
+            preferredSourceTags = listOf("watchNext.contentId", "watchNext.episodeNumber", "mediaSession.subtitle"),
+            markerRegexes = listOf(
+                // "Staffel 2, Folge 3" or "Staffel 2 Folge 3"
+                Regex("""Staffel\s*(\d+)[,\s]+Folge\s*(\d+)""", RegexOption.IGNORE_CASE),
+            ),
+            llmHint = "App is Joyn (German free streaming, ProSiebenSat.1). Episode markers may use 'Folge'/'Staffel' German keywords.",
+        ),
+        // YouTube TV — titles are descriptive; skip Phase 1 to avoid noisy cache matches
+        AppProfile(
+            packageName = "com.google.android.youtube.tv",
+            skipPhase1 = true,
+            llmHint = "App is YouTube. The 'series' may be a creator's playlist; the title is usually descriptive ('Episode 47: How to ...'). If no SxxExx pattern is detected, return null rather than guessing.",
+        ),
     ).associateBy { it.packageName }
 
     fun forPackage(pkg: String): AppProfile? = ALL[pkg]

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/AppProfiles.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/AppProfiles.kt
@@ -109,7 +109,9 @@ object AppProfiles {
         AppProfile(
             packageName = "com.google.android.youtube.tv",
             skipPhase1 = true,
-            llmHint = "App is YouTube. The 'series' may be a creator's playlist; the title is usually descriptive ('Episode 47: How to ...'). If no SxxExx pattern is detected, return null rather than guessing.",
+            llmHint = "App is YouTube. The 'series' may be a creator's playlist; the title is usually" +
+                " descriptive ('Episode 47: How to ...'). If no SxxExx pattern is detected, return null" +
+                " rather than guessing.",
         ),
     ).associateBy { it.packageName }
 

--- a/core/src/test/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMapTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMapTest.kt
@@ -23,9 +23,19 @@ class JustWatchPackageMapTest {
         "wpu, 2187",
         "ard, 195",
         "zdf, 231",
+        "yti, 192",
+        "yot, 192",
+        "ytv, 192",
     )
     fun `resolves known technical names to TMDB provider ids`(technicalName: String, expectedId: Int) {
         assertEquals(expectedId, JustWatchPackageMap.resolveProviderId(technicalName))
+    }
+
+    @Test
+    fun `youtubeAliasesResolveToProvider192`() {
+        assertEquals(192, JustWatchPackageMap.resolveProviderId("yti"))
+        assertEquals(192, JustWatchPackageMap.resolveProviderId("yot"))
+        assertEquals(192, JustWatchPackageMap.resolveProviderId("ytv"))
     }
 
     @Test

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/AppProfilesTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/AppProfilesTest.kt
@@ -95,10 +95,13 @@ class AppProfilesTest {
         }
 
         @Test
-        fun `no profile has skipPhase1 = true in default registry`() {
-            AppProfiles.ALL.values.forEach { p ->
-                assertFalse(p.skipPhase1, "Unexpected skipPhase1=true for ${p.packageName}")
-            }
+        fun `only YouTube TV profile has skipPhase1 = true`() {
+            val skipPhase1Profiles = AppProfiles.ALL.values.filter { it.skipPhase1 }.map { it.packageName }
+            assertEquals(
+                listOf("com.google.android.youtube.tv"),
+                skipPhase1Profiles,
+                "Only the YouTube TV profile should have skipPhase1=true",
+            )
         }
     }
 
@@ -337,6 +340,84 @@ class AppProfilesTest {
             assertEquals("The Office", result!!.matchedShow?.title)
             assertEquals(2, result.matchedEpisode?.season)
             assertEquals(1, result.matchedEpisode?.number)
+        }
+    }
+
+    // ── Joyn fixture ─────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Joyn (de.prosiebensat1digital.seventv)")
+    inner class JoynFixture {
+
+        @Test
+        fun `forPackage returns profile for joyn`() {
+            val profile = AppProfiles.forPackage("de.prosiebensat1digital.seventv")
+            assertNotNull(profile)
+            assertEquals("de.prosiebensat1digital.seventv", profile!!.packageName)
+        }
+
+        @Test
+        fun `Staffel Y Folge X marker regex extracts season and episode`() {
+            val profile = AppProfiles.forPackage("de.prosiebensat1digital.seventv")!!
+            val regex = profile.markerRegexes.first()
+
+            val match1 = regex.find("Staffel 2, Folge 3")
+            assertNotNull(match1)
+            assertEquals("2", match1!!.groupValues[1])
+            assertEquals("3", match1.groupValues[2])
+
+            val match2 = regex.find("Staffel 1 Folge 12")
+            assertNotNull(match2)
+            assertEquals("1", match2!!.groupValues[1])
+            assertEquals("12", match2.groupValues[2])
+        }
+
+        @Test
+        fun `Staffel Folge marker regex is case-insensitive`() {
+            val profile = AppProfiles.forPackage("de.prosiebensat1digital.seventv")!!
+            val regex = profile.markerRegexes.first()
+            val match = regex.find("staffel 3, folge 5")
+            assertNotNull(match)
+            assertEquals("3", match!!.groupValues[1])
+            assertEquals("5", match.groupValues[2])
+        }
+
+        @Test
+        fun `joyn profile has llmHint`() {
+            val profile = AppProfiles.forPackage("de.prosiebensat1digital.seventv")!!
+            assertNotNull(profile.llmHint)
+        }
+    }
+
+    // ── YouTube TV fixture ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("YouTube TV (com.google.android.youtube.tv)")
+    inner class YouTubeTvFixture {
+
+        @Test
+        fun `forPackage returns profile for youtube tv`() {
+            val profile = AppProfiles.forPackage("com.google.android.youtube.tv")
+            assertNotNull(profile)
+            assertEquals("com.google.android.youtube.tv", profile!!.packageName)
+        }
+
+        @Test
+        fun `youtube tv profile has skipPhase1 = true`() {
+            val profile = AppProfiles.forPackage("com.google.android.youtube.tv")!!
+            assertTrue(profile.skipPhase1)
+        }
+
+        @Test
+        fun `youtube tv profile has llmHint`() {
+            val profile = AppProfiles.forPackage("com.google.android.youtube.tv")!!
+            assertNotNull(profile.llmHint)
+        }
+
+        @Test
+        fun `youtube tv profile has no markerRegexes`() {
+            val profile = AppProfiles.forPackage("com.google.android.youtube.tv")!!
+            assertTrue(profile.markerRegexes.isEmpty())
         }
     }
 

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/AppProfilesTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/AppProfilesTest.kt
@@ -11,7 +11,6 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue


### PR DESCRIPTION
## Summary

Fixes five independent defects identified in #620 that caused streaming provider deep links and chips to silently fail for many services.

### A — YouTube aliases in `JustWatchPackageMap`
- Added `yti`, `yot`, `ytv` → TMDB provider ID 192 so JustWatch offers for YouTube are no longer silently dropped at the `?: return@forEach` in `cacheOffers`.

### B — Country code via phone `/capability`
- Added `countryCode: String?` (nullable, backwards-compatible) to `DeviceCapability`.
- `DeviceCapabilityProvider` populates it from `Locale.getDefault().country` on the phone.
- `ShowDetailViewModel.resolveCountryCode()` cascades: phone's `countryCode` → TV locale → `"US"` fallback.
- This fixes Joyn and other DE/AT-only providers that disappeared entirely on TVs with English-only firmware (where `Locale.getDefault().country` is empty).

### C — Provider chip clickable when installed but no deep link
- `isEnabled` now covers `Unavailable && provider.isInstalled`, unblocking `launchProvider()`'s existing stage-3 `getLaunchIntentForPackage` fallback.
- Chip label shows `"Open app"` (localised EN/DE/FR/ES) instead of `"No deep link"` in that case.

### D — Structured diagnostic logging in `JustWatchDeepLinkRepository`
- `DiagnosticLog.warn()` at every unmapped `technicalName` (the silent `?: return@forEach`).
- New `JustWatchOutcomeEvent` data class with `Outcome` enum (`EPISODE_CACHE_HIT`, `EPISODE_API_HIT`, `SHOW_CACHE_HIT`, `SHOW_API_HIT`, `SEARCH_MISS`, `TECHNICAL_NAME_UNMAPPED`, `HTTP_ERROR`, `GRAPHQL_ERROR`, `EPISODE_NOT_IN_RESULTS`).
- Bounded `StateFlow` ring-buffer (max 50 entries) in the repository.
- TV Diagnostics → Streaming Links section extended with "Last outcomes" (last 5, most recent first, colour-coded).

### E — AppProfiles for Joyn and YouTube TV
- **Joyn** (`de.prosiebensat1digital.seventv`): `Staffel Y, Folge X` marker regex, preferred source tags (`watchNext.contentId`, `watchNext.episodeNumber`, `mediaSession.subtitle`), German LLM hint.
- **YouTube TV** (`com.google.android.youtube.tv`): `skipPhase1 = true`, LLM hint to return null when no S×E marker is detected.

## Test plan

- [ ] `JustWatchPackageMapTest` — YouTube aliases (`yti`/`yot`/`ytv` → 192)
- [ ] `AppProfilesTest` — Joyn `Staffel/Folge` regex, YouTube TV `skipPhase1`, updated registry assertion
- [ ] `ShowDetailViewModelTest` — `usesPhoneCountryCodeWhenAvailable`, `fallsBackToLocaleWhenNoPhone`
- [ ] `JustWatchDeepLinkRepositoryTest` — `EPISODE_CACHE_HIT`, `SEARCH_MISS`, `TECHNICAL_NAME_UNMAPPED`, `HTTP_ERROR` outcomes; ring-buffer cap
- [ ] `TvDiagnosticsViewModelTest` — `outcomeEvents` mock updated
- [ ] CI `Test & Build` green

**Note:** Android SDK is not available in this sandbox; Gradle/Kotlin checks are skipped locally per `scripts/precommit.sh`. CI is the real gate for Kotlin/Android changes.

Closes #620

https://claude.ai/code/session_01JLjsvo9bcEkRVBVEi65MQf

---
_Generated by [Claude Code](https://claude.ai/code/session_01JLjsvo9bcEkRVBVEi65MQf)_