### PR TITLE
fix(phone): handle ForegroundServiceStartNotAllowedException in CompanionService

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
@@ -12,6 +12,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import com.justb81.watchbuddy.R
@@ -96,11 +97,28 @@ class CompanionService : Service() {
         super.onCreate()
         DiagnosticLog.event(TAG, "onCreate")
         ensureNotificationChannel()
-        startForeground(
-            NOTIFICATION_ID,
-            buildNotification(),
-            ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
-        )
+        try {
+            startForeground(
+                NOTIFICATION_ID,
+                buildNotification(),
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE,
+            )
+        } catch (e: Exception) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+                e::class.simpleName == "ForegroundServiceStartNotAllowedException"
+            ) {
+                DiagnosticLog.warn(
+                    TAG,
+                    "ForegroundServiceStartNotAllowedException during onCreate (background recreation on Android 16+) — stopping service"
+                )
+                serviceScope.launch {
+                    settingsRepository.setCompanionEnabled(false)
+                }
+                stopSelf()
+            } else {
+                throw e
+            }
+        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -115,11 +133,10 @@ class CompanionService : Service() {
             stopSelf(startId)
             return START_NOT_STICKY
         }
-        // Idempotent: onStartCommand can fire multiple times (ViewModel re-starts,
-        // system re-delivery of START_STICKY).
+        // Idempotent: onStartCommand can fire multiple times (ViewModel re-starts).
         if (stateManager.isServiceRunning.value) {
             DiagnosticLog.debug(TAG, "onStartCommand skipped; service already running")
-            return START_STICKY
+            return START_NOT_STICKY
         }
         try {
             companionHttpServer.start()
@@ -145,7 +162,7 @@ class CompanionService : Service() {
             stopSelf(startId)
             return START_NOT_STICKY
         }
-        return START_STICKY
+        return START_NOT_STICKY
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## Summary

Fixes issue #630: `CompanionService` crashes with `ForegroundServiceStartNotAllowedException` on Android 16 when the OS recreates the service from the background.

## Changes

### 1. Exception Handling in `onCreate()`
Added a try-catch block to handle `ForegroundServiceStartNotAllowedException` when `startForeground()` is called during background service recreation. The handler:
- Logs a diagnostic warning with context
- Disables the companion toggle in settings (`companionEnabled = false`)
- Calls `stopSelf()` to gracefully stop the service

### 2. Lifecycle Fix: `START_NOT_STICKY` instead of `START_STICKY`
Changed `onStartCommand()` to return `START_NOT_STICKY` instead of `START_STICKY`. This prevents the OS from recreating the service from the background, which is the root cause. The companion service requires explicit user intent (the "I am watching TV" toggle) and cannot legally restart from the background under Android 12+ rules.

## Platform Compatibility

- **Android SDK not exercised locally**: This session ran in a sandboxed environment without the Android SDK. The Gradle scope was skipped but the changes are straightforward:
  - Import added: `android.os.Build`
  - Exception class checked by name (`e::class.simpleName`) for compatibility with reflection-based exception handling
  - Version guard: `Build.VERSION.SDK_INT >= Build.VERSION_CODES.S` (Android 12+)
- CI will run full Gradle / detekt / Android Lint checks on the green `Test & Build` workflow

## Test Plan

From issue #630:
- [ ] Repro on Android 16 (Nothing Phone or emulator with SDK 36) by enabling "I am watching TV", force-stopping the process, then waiting for the system `START_STICKY` recreation.
- [ ] Verify the catch path logs a `CompanionService` breadcrumb and the app stays alive.
- [ ] Verify `companionEnabled` is reset in DataStore so the UI reflects the off state on next launch.
- [ ] Re-test the swipe-from-recents flow (already handled by `onTaskRemoved`) to make sure it still cleans up correctly.

Closes #630

---
_Generated by [Claude Code](https://claude.ai/code/session_01RfxASDnxjZZc1ExmmNeDB2)_