### PR TITLE
feat(phone): user-configurable country override in Advanced Settings

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/di/AppModule.kt
@@ -3,6 +3,9 @@ package com.justb81.watchbuddy.phone.di
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.WorkManager
 import com.justb81.watchbuddy.BuildConfig
@@ -21,6 +24,8 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Named
 import javax.inject.Singleton
 
+private val Context.settingsDataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+
 /**
  * App-specific Hilt bindings.
  *
@@ -31,6 +36,17 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
+
+    /**
+     * Provides the app's singleton [DataStore] for settings persistence.
+     * Declared here so that [com.justb81.watchbuddy.phone.settings.SettingsRepository]
+     * receives the store as an injected dependency and can be tested with a
+     * substitute store in unit tests.
+     */
+    @Provides
+    @Singleton
+    fun provideSettingsDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        context.settingsDataStore
 
     /** Trakt Client ID from BuildConfig (set via app-phone/build.gradle.kts). */
     @Provides

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProvider.kt
@@ -76,7 +76,8 @@ class DeviceCapabilityProvider @Inject constructor(
             avatarSource = settings.avatarSource,
             lastResolvedSessionKey = stateManager.lastResolvedSessionKey.value,
             lastResolvedTraktId = stateManager.lastResolvedTraktId.value,
-            countryCode = Locale.getDefault().country.takeIf { it.length == 2 },
+            countryCode = settings.countryOverride.takeIf { it.length == 2 }
+                ?: Locale.getDefault().country.takeIf { it.length == 2 },
         )
     }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/AppSettings.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/AppSettings.kt
@@ -32,5 +32,11 @@ data class AppSettings(
      * can surface them. Off-by-default would hide the feature; on-by-default
      * mirrors how the rest of the Diagnostics data is always captured.
      */
-    val llmActivityLoggingEnabled: Boolean = true
+    val llmActivityLoggingEnabled: Boolean = true,
+    /**
+     * Two-letter ISO 3166-1 alpha-2 country code chosen by the user in Settings → Advanced.
+     * Blank string means "Auto" — fall back to [java.util.Locale.getDefault] country.
+     * Projected into `/capability` by [com.justb81.watchbuddy.phone.server.DeviceCapabilityProvider].
+     */
+    val countryOverride: String = ""
 )

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/settings/SettingsRepository.kt
@@ -7,7 +7,6 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import com.justb81.watchbuddy.core.model.AvatarSource
 import com.justb81.watchbuddy.phone.auth.TokenRepository
@@ -29,11 +28,10 @@ import javax.inject.Inject
 import javax.inject.Named
 import javax.inject.Singleton
 
-private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
-
 @Singleton
 class SettingsRepository @Inject constructor(
     @param:ApplicationContext private val context: Context,
+    private val dataStore: DataStore<Preferences>,
     private val tokenRepository: TokenRepository,
     private val llmEventLog: LlmEventLog,
     @param:Named("defaultTmdbApiKey") private val defaultTmdbApiKey: String
@@ -50,6 +48,7 @@ class SettingsRepository @Inject constructor(
         val AVATAR_SOURCE = stringPreferencesKey("avatar_source")
         val CUSTOM_AVATAR_VERSION = longPreferencesKey("custom_avatar_version")
         val LLM_ACTIVITY_LOGGING_ENABLED = booleanPreferencesKey("llm_activity_logging_enabled")
+        val COUNTRY_OVERRIDE = stringPreferencesKey("country_override")
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -59,7 +58,7 @@ class SettingsRepository @Inject constructor(
 
     init {
         scope.launch {
-            context.dataStore.data
+            dataStore.data
                 .catch { e ->
                     DiagnosticLog.error(TAG, "modelReady flow errored at subscription", e)
                 }
@@ -70,7 +69,7 @@ class SettingsRepository @Inject constructor(
         }
     }
 
-    val settings: Flow<AppSettings> = context.dataStore.data.map { prefs ->
+    val settings: Flow<AppSettings> = dataStore.data.map { prefs ->
         AppSettings(
             authMode = prefs[Keys.AUTH_MODE]
                 ?.let { runCatching { AuthMode.valueOf(it) }.getOrNull() }
@@ -86,12 +85,13 @@ class SettingsRepository @Inject constructor(
                 ?.let { runCatching { AvatarSource.valueOf(it) }.getOrNull() }
                 ?: AvatarSource.TRAKT,
             customAvatarVersion = prefs[Keys.CUSTOM_AVATAR_VERSION] ?: 0L,
-            llmActivityLoggingEnabled = prefs[Keys.LLM_ACTIVITY_LOGGING_ENABLED] ?: true
+            llmActivityLoggingEnabled = prefs[Keys.LLM_ACTIVITY_LOGGING_ENABLED] ?: true,
+            countryOverride = prefs[Keys.COUNTRY_OVERRIDE] ?: ""
         )
     }
 
     suspend fun saveSettings(settings: AppSettings) {
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             prefs[Keys.AUTH_MODE] = settings.authMode.name
             prefs[Keys.BACKEND_URL] = settings.backendUrl
             prefs[Keys.DIRECT_CLIENT_ID] = settings.directClientId
@@ -102,6 +102,7 @@ class SettingsRepository @Inject constructor(
             prefs[Keys.AVATAR_SOURCE] = settings.avatarSource.name
             prefs[Keys.CUSTOM_AVATAR_VERSION] = settings.customAvatarVersion
             prefs[Keys.LLM_ACTIVITY_LOGGING_ENABLED] = settings.llmActivityLoggingEnabled
+            prefs[Keys.COUNTRY_OVERRIDE] = settings.countryOverride
         }
     }
 
@@ -110,7 +111,7 @@ class SettingsRepository @Inject constructor(
         displayNameOverride: String,
         avatarSource: AvatarSource
     ) {
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             prefs[Keys.DISPLAY_NAME_OVERRIDE] = displayNameOverride
             prefs[Keys.AVATAR_SOURCE] = avatarSource.name
         }
@@ -124,7 +125,7 @@ class SettingsRepository @Inject constructor(
      */
     suspend fun bumpCustomAvatarVersion(): Long {
         var next = 0L
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             next = (prefs[Keys.CUSTOM_AVATAR_VERSION] ?: 0L) + 1L
             prefs[Keys.CUSTOM_AVATAR_VERSION] = next
         }
@@ -150,7 +151,7 @@ class SettingsRepository @Inject constructor(
      * Returns the effective TMDB API key: the user's custom key when set, otherwise the
      * default key baked in at build time.  Returns an empty string when neither is available.
      */
-    fun getTmdbApiKey(): Flow<String> = context.dataStore.data.map { prefs ->
+    fun getTmdbApiKey(): Flow<String> = dataStore.data.map { prefs ->
         val userKey = prefs[Keys.TMDB_API_KEY] ?: ""
         userKey.ifBlank { defaultTmdbApiKey }
     }
@@ -160,7 +161,7 @@ class SettingsRepository @Inject constructor(
 
     fun setModelReady(ready: Boolean) {
         scope.launch {
-            context.dataStore.edit { prefs ->
+            dataStore.edit { prefs ->
                 prefs[Keys.MODEL_READY] = ready
             }
         }
@@ -168,7 +169,7 @@ class SettingsRepository @Inject constructor(
 
     /** Updates only the companion-enabled flag without touching other settings. */
     suspend fun setCompanionEnabled(enabled: Boolean) {
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             prefs[Keys.COMPANION_ENABLED] = enabled
         }
     }
@@ -179,10 +180,17 @@ class SettingsRepository @Inject constructor(
      * immediately — turning the switch off should mean no in-memory trace.
      */
     suspend fun setLlmActivityLoggingEnabled(enabled: Boolean) {
-        context.dataStore.edit { prefs ->
+        dataStore.edit { prefs ->
             prefs[Keys.LLM_ACTIVITY_LOGGING_ENABLED] = enabled
         }
         if (!enabled) llmEventLog.clear()
+    }
+
+    /** Persists the two-letter ISO 3166-1 country code override, or clears it when blank. */
+    suspend fun setCountryOverride(countryCode: String) {
+        dataStore.edit { prefs ->
+            prefs[Keys.COUNTRY_OVERRIDE] = countryCode.uppercase().take(2)
+        }
     }
 
     /** Absolute path where downloaded model files are stored. */

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -624,8 +624,11 @@ private val COUNTRY_OPTIONS = listOf(
 private fun CountryOverrideDropdown(selected: String, onSelect: (String) -> Unit) {
     var expanded by remember { mutableStateOf(false) }
     val autoLabel = stringResource(R.string.settings_country_auto)
-    val displayLabel = if (selected.isBlank()) autoLabel
-    else COUNTRY_OPTIONS.firstOrNull { it.code == selected }?.label ?: selected
+    val displayLabel = if (selected.isBlank()) {
+        autoLabel
+    } else {
+        COUNTRY_OPTIONS.firstOrNull { it.code == selected }?.label ?: selected
+    }
 
     ExposedDropdownMenuBox(
         expanded = expanded,

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -564,6 +565,31 @@ private fun AdvancedAuthSettings(uiState: SettingsUiState, viewModel: SettingsVi
         )
 
         Spacer(Modifier.height(12.dp))
+        HorizontalDivider(
+            color     = MaterialTheme.colorScheme.outline.copy(alpha = 0.3f),
+            thickness = 0.5.dp
+        )
+        Spacer(Modifier.height(12.dp))
+
+        // ── Country / Region group ────────────────────────────────────────────
+        Text(
+            text  = stringResource(R.string.settings_country_section),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Spacer(Modifier.height(4.dp))
+        CountryOverrideDropdown(
+            selected  = uiState.countryOverride,
+            onSelect  = viewModel::setCountryOverride
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text  = stringResource(R.string.settings_country_helper),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+        )
+
+        Spacer(Modifier.height(12.dp))
         Button(
             onClick  = { viewModel.saveAdvancedSettings() },
             modifier = Modifier.fillMaxWidth()
@@ -571,6 +597,67 @@ private fun AdvancedAuthSettings(uiState: SettingsUiState, viewModel: SettingsVi
             Text(stringResource(R.string.settings_save))
         }
         Spacer(Modifier.height(12.dp))
+    }
+}
+
+// ── Country / Region dropdown ──────────────────────────────────────────────────
+
+private data class CountryOption(val code: String, val label: String)
+
+private val COUNTRY_OPTIONS = listOf(
+    CountryOption("", ""),  // placeholder; label resolved from string resource at call site
+    CountryOption("AT", "AT — Austria"),
+    CountryOption("AU", "AU — Australia"),
+    CountryOption("CA", "CA — Canada"),
+    CountryOption("CH", "CH — Switzerland"),
+    CountryOption("DE", "DE — Germany"),
+    CountryOption("ES", "ES — Spain"),
+    CountryOption("FR", "FR — France"),
+    CountryOption("GB", "GB — United Kingdom"),
+    CountryOption("IT", "IT — Italy"),
+    CountryOption("NL", "NL — Netherlands"),
+    CountryOption("US", "US — United States"),
+)
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun CountryOverrideDropdown(selected: String, onSelect: (String) -> Unit) {
+    var expanded by remember { mutableStateOf(false) }
+    val autoLabel = stringResource(R.string.settings_country_auto)
+    val displayLabel = if (selected.isBlank()) autoLabel
+    else COUNTRY_OPTIONS.firstOrNull { it.code == selected }?.label ?: selected
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it }
+    ) {
+        OutlinedTextField(
+            value             = displayLabel,
+            onValueChange     = {},
+            readOnly          = true,
+            label             = { Text(stringResource(R.string.settings_country_label)) },
+            trailingIcon      = {
+                Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+            },
+            modifier          = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+        )
+        ExposedDropdownMenu(
+            expanded         = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            COUNTRY_OPTIONS.forEach { option ->
+                val itemLabel = if (option.code.isBlank()) autoLabel else option.label
+                DropdownMenuItem(
+                    text    = { Text(itemLabel) },
+                    onClick = {
+                        onSelect(option.code)
+                        expanded = false
+                    }
+                )
+            }
+        }
     }
 }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsViewModel.kt
@@ -76,7 +76,12 @@ data class SettingsUiState(
      * True when advanced settings must always be visible (i.e. at least one bundled option
      * is not configured in this build so the user must configure it manually).
      */
-    val forceShowAdvanced: Boolean = false
+    val forceShowAdvanced: Boolean = false,
+    /**
+     * Two-letter ISO 3166-1 country code override. Empty string = "Auto (device locale)".
+     * Shown in Settings → Advanced as a dropdown.
+     */
+    val countryOverride: String = ""
 )
 
 @HiltViewModel
@@ -192,7 +197,8 @@ class SettingsViewModel @Inject constructor(
                     avatarSource = saved.avatarSource,
                     hasCustomAvatar = avatarImageStore.exists(),
                     customAvatarVersion = saved.customAvatarVersion,
-                    llmActivityLoggingEnabled = saved.llmActivityLoggingEnabled
+                    llmActivityLoggingEnabled = saved.llmActivityLoggingEnabled,
+                    countryOverride = saved.countryOverride
                 )
                 Log.d(TAG, "loadPersistedSettings: authMode=$resolvedAuthMode tmdbConnected=${saved.tmdbApiKey.isNotBlank()}")
             } catch (e: Exception) {
@@ -287,6 +293,10 @@ class SettingsViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(directClientSecret = secret)
     }
 
+    fun setCountryOverride(countryCode: String) {
+        _uiState.value = _uiState.value.copy(countryOverride = countryCode)
+    }
+
     fun setModelDownloadUrl(url: String) {
         _uiState.value = _uiState.value.copy(
             modelDownloadUrl = url,
@@ -348,7 +358,8 @@ class SettingsViewModel @Inject constructor(
                         backendUrl = state.customBackendUrl,
                         directClientId = state.directClientId,
                         modelDownloadUrl = state.modelDownloadUrl,
-                        tmdbApiKey = tmdbKeyToSave
+                        tmdbApiKey = tmdbKeyToSave,
+                        countryOverride = state.countryOverride
                     )
                 )
                 settingsRepository.saveClientSecret(state.directClientSecret)

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -243,6 +243,12 @@
     <string name="diagnostics_llm_detail_empty_response">(keine Antwort)</string>
     <string name="diagnostics_llm_detail_not_found">Dieser LLM-Aufruf ist nicht mehr verfügbar — neuere Aufrufe haben ihn aus dem Puffer verdrängt.</string>
 
+    <!-- Country / Region override -->
+    <string name="settings_country_section">Land / Region</string>
+    <string name="settings_country_label">Land / Region</string>
+    <string name="settings_country_auto">Automatisch (Gerätesprache)</string>
+    <string name="settings_country_helper">Wird auf dem TV zur Suche nach Streaming-Anbietern verwendet. Nur ändern, wenn das Geräte-Gebietsschema nicht deinem Abonnementland entspricht.</string>
+
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (Build %2$d)</string>
 </resources>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -247,6 +247,12 @@
     <string name="diagnostics_llm_detail_empty_response">(sin respuesta)</string>
     <string name="diagnostics_llm_detail_not_found">Esta llamada al LLM ya no está disponible — llamadas más recientes la desplazaron del búfer.</string>
 
+    <!-- Country / Region override -->
+    <string name="settings_country_section">País / Región</string>
+    <string name="settings_country_label">País / Región</string>
+    <string name="settings_country_auto">Automático (usar configuración regional)</string>
+    <string name="settings_country_helper">Se usa para buscar proveedores de streaming en la TV. Déjalo en Automático salvo que la configuración regional de tu teléfono difiera de tu país de suscripción.</string>
+
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>
 </resources>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -247,6 +247,12 @@
     <string name="diagnostics_llm_detail_empty_response">(pas de réponse)</string>
     <string name="diagnostics_llm_detail_not_found">Cet appel LLM n\'est plus disponible — des appels plus récents l\'ont évincé du tampon.</string>
 
+    <!-- Country / Region override -->
+    <string name="settings_country_section">Pays / Région</string>
+    <string name="settings_country_label">Pays / Région</string>
+    <string name="settings_country_auto">Automatique (locale de l\'appareil)</string>
+    <string name="settings_country_helper">Utilisé pour rechercher les fournisseurs de streaming sur la TV. Laissez sur Automatique sauf si la langue de votre téléphone diffère de votre pays d\'abonnement.</string>
+
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>
 </resources>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -243,6 +243,12 @@
     <string name="diagnostics_llm_detail_empty_response">(no response)</string>
     <string name="diagnostics_llm_detail_not_found">This LLM call is no longer available — newer calls pushed it out of the buffer.</string>
 
+    <!-- Country / Region override -->
+    <string name="settings_country_section">Country / Region</string>
+    <string name="settings_country_label">Country / Region</string>
+    <string name="settings_country_auto">Auto (use device locale)</string>
+    <string name="settings_country_helper">Used to look up streaming providers on the TV. Leave on Auto unless your phone locale differs from where you subscribe.</string>
+
     <!-- Version footer -->
     <string name="settings_version_footer">WatchBuddy v%1$s (build %2$d)</string>
 </resources>

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProviderTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/DeviceCapabilityProviderTest.kt
@@ -132,4 +132,34 @@ class DeviceCapabilityProviderTest {
         // API should be called twice (once before and once after invalidation)
         coVerify(exactly = 2) { traktApi.getProfile(any()) }
     }
+
+    @Test
+    fun `overrideTakesPrecedenceOverLocale — countryOverride is used when set`() = runTest {
+        every { tokenRepository.getAccessToken() } returns null
+        every { settingsRepository.settings } returns flowOf(AppSettings(countryOverride = "DE"))
+
+        val cap = provider.getCapability()
+        assertEquals("DE", cap.countryCode)
+    }
+
+    @Test
+    fun `overrideTakesPrecedenceOverLocale — locale is used when override is blank`() = runTest {
+        every { tokenRepository.getAccessToken() } returns null
+        every { settingsRepository.settings } returns flowOf(AppSettings(countryOverride = ""))
+
+        val cap = provider.getCapability()
+        // On JVM the default locale country may vary; just verify it is not the override
+        // and is either null or a 2-letter code (locale-dependent).
+        assertTrue(cap.countryCode == null || cap.countryCode!!.length == 2)
+    }
+
+    @Test
+    fun `overrideTakesPrecedenceOverLocale — override wins over locale`() = runTest {
+        every { tokenRepository.getAccessToken() } returns null
+        // Locale.getDefault().country on JVM is typically "US" or similar, but we want "AT"
+        every { settingsRepository.settings } returns flowOf(AppSettings(countryOverride = "AT"))
+
+        val cap = provider.getCapability()
+        assertEquals("AT", cap.countryCode)
+    }
 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/settings/SettingsRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/settings/SettingsRepositoryTest.kt
@@ -1,0 +1,82 @@
+package com.justb81.watchbuddy.phone.settings
+
+import android.content.Context
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.llm.LlmEventLog
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@DisplayName("SettingsRepository")
+class SettingsRepositoryTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    private lateinit var repository: SettingsRepository
+
+    @BeforeEach
+    fun setUp() {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = testScope,
+            produceFile = { File(tempDir, "test_settings.preferences_pb") }
+        )
+        repository = SettingsRepository(
+            context = mockk<Context>(relaxed = true),
+            dataStore = dataStore,
+            tokenRepository = mockk<TokenRepository>(relaxed = true),
+            llmEventLog = mockk<LlmEventLog>(relaxed = true),
+            defaultTmdbApiKey = ""
+        )
+    }
+
+    @Test
+    fun `countryOverridePersists — default is empty`() = runTest {
+        val settings = repository.settings.first()
+        assertEquals("", settings.countryOverride)
+    }
+
+    @Test
+    fun `countryOverridePersists — set override is reflected in settings flow`() = runTest {
+        repository.setCountryOverride("DE")
+        val settings = repository.settings.first()
+        assertEquals("DE", settings.countryOverride)
+    }
+
+    @Test
+    fun `countryOverridePersists — override is uppercased`() = runTest {
+        repository.setCountryOverride("de")
+        val settings = repository.settings.first()
+        assertEquals("DE", settings.countryOverride)
+    }
+
+    @Test
+    fun `countryOverridePersists — override can be cleared by setting empty string`() = runTest {
+        repository.setCountryOverride("US")
+        repository.setCountryOverride("")
+        val settings = repository.settings.first()
+        assertEquals("", settings.countryOverride)
+    }
+
+    @Test
+    fun `countryOverridePersists — saveSettings round-trips countryOverride`() = runTest {
+        val original = repository.settings.first()
+        repository.saveSettings(original.copy(countryOverride = "FR"))
+        val updated = repository.settings.first()
+        assertEquals("FR", updated.countryOverride)
+    }
+}


### PR DESCRIPTION
## Summary

Implements the country / region override requested in #626. Users can now pin a specific ISO 3166-1 alpha-2 country code in **Settings → Advanced** instead of relying on `Locale.getDefault().country`, which fixes watch-provider lookups for:
- Travellers who want to keep seeing their home-region providers
- Users whose phone locale differs from their streaming subscription region
- Multi-account users with providers spread across regions

## Changes

- **`AppSettings`** — adds `countryOverride: String` (`""` = Auto)
- **`SettingsRepository`** — injects `DataStore<Preferences>` (replaces `context.dataStore` extension dependency, makes repo unit-testable); adds `COUNTRY_OVERRIDE` key, `setCountryOverride()`, and persists/loads the field in `saveSettings()` / `settings` flow
- **`AppModule`** — provides `DataStore<Preferences>` as a Hilt singleton via the `preferencesDataStore` delegate (single source of truth, no double-instantiation risk)
- **`DeviceCapabilityProvider`** — `countryCode` prefers `countryOverride` when set, falls back to `Locale.getDefault().country`
- **`SettingsViewModel` / `SettingsUiState`** — exposes `countryOverride`; loads from persisted settings; saves via `saveAdvancedSettings()`
- **`SettingsScreen`** — `ExposedDropdownMenuBox` in Advanced Settings with: AT, AU, CA, CH, DE, ES, FR, GB, IT, NL, US + **Auto** (device locale) as default
- **String resources** — `settings_country_section`, `settings_country_label`, `settings_country_auto`, `settings_country_helper` in EN / DE / FR / ES

## Tests

- `SettingsRepositoryTest` — 5 cases: default empty, set override, uppercase normalisation, clear to empty, `saveSettings` round-trip
- `DeviceCapabilityProviderTest` — 3 new cases: override used when set, blank falls back to locale, override beats locale

## Notes for reviewers

- Gradle checks were skipped locally (no Android SDK in sandbox) — CI is the real gate.
- The `SettingsRepository` constructor now takes `DataStore<Preferences>` directly. This is a non-breaking internal change; Hilt wires it automatically via the new `provideSettingsDataStore` binding in `AppModule`.

Closes #626

https://claude.ai/code/session_0157WPrB8qh8rh7zVhDL9vfn

---
_Generated by [Claude Code](https://claude.ai/code/session_0157WPrB8qh8rh7zVhDL9vfn)_