### PR TITLE
fix(core): add RateLimitInterceptor for 429 Retry-After handling

### DIFF
--- a/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/NetworkModule.kt
@@ -39,6 +39,7 @@ object NetworkModule {
         // Trakt scrobble endpoints (/scrobble/start|pause|stop) are not idempotent;
         // a silent retry would double-charge a watch event on Trakt's side.
         .retryOnConnectionFailure(false)
+        .addInterceptor(RateLimitInterceptor())
         .addInterceptor { chain ->
             val builder = chain.request().newBuilder()
                 .addHeader("Content-Type", "application/json")

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/RateLimitInterceptor.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/RateLimitInterceptor.kt
@@ -8,6 +8,7 @@ private const val TAG = "RateLimit"
 private const val HTTP_TOO_MANY_REQUESTS = 429
 private const val MAX_RETRY_DELAY_SECONDS = 60L
 private const val DEFAULT_RETRY_DELAY_SECONDS = 5L
+private const val MILLIS_PER_SECOND = 1_000L
 
 /**
  * OkHttp interceptor that handles 429 Too Many Requests responses.
@@ -38,7 +39,7 @@ internal class RateLimitInterceptor(
         if (!isSafeMethod(method)) return response
 
         response.close()
-        sleepFn(delaySeconds * 1_000)
+        sleepFn(delaySeconds * MILLIS_PER_SECOND)
 
         return chain.proceed(request)
     }

--- a/core/src/main/java/com/justb81/watchbuddy/core/network/RateLimitInterceptor.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/network/RateLimitInterceptor.kt
@@ -1,0 +1,53 @@
+package com.justb81.watchbuddy.core.network
+
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import okhttp3.Interceptor
+import okhttp3.Response
+
+private const val TAG = "RateLimit"
+private const val HTTP_TOO_MANY_REQUESTS = 429
+private const val MAX_RETRY_DELAY_SECONDS = 60L
+private const val DEFAULT_RETRY_DELAY_SECONDS = 5L
+
+/**
+ * OkHttp interceptor that handles 429 Too Many Requests responses.
+ *
+ * On a 429, it reads the `Retry-After` header (seconds, capped at 60 s) and
+ * retries the request once. Non-idempotent methods (POST, PUT, PATCH, DELETE)
+ * are not retried — the 429 is propagated so callers can decide how to proceed.
+ * All 429 hits are surfaced in [DiagnosticLog].
+ */
+internal class RateLimitInterceptor(
+    private val sleepFn: (Long) -> Unit = { ms -> Thread.sleep(ms) }
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val response = chain.proceed(request)
+
+        if (response.code != HTTP_TOO_MANY_REQUESTS) return response
+
+        val method = request.method
+        val url = request.url.toString()
+        val retryAfterSeconds = parseRetryAfter(response.header("Retry-After"))
+        val delaySeconds = retryAfterSeconds.coerceAtMost(MAX_RETRY_DELAY_SECONDS)
+
+        DiagnosticLog.warn(TAG, "429 on $method $url — retry-after: ${delaySeconds}s")
+
+        // Do not retry non-idempotent methods; caller must handle the 429.
+        if (!isSafeMethod(method)) return response
+
+        response.close()
+        sleepFn(delaySeconds * 1_000)
+
+        return chain.proceed(request)
+    }
+
+    private fun parseRetryAfter(header: String?): Long {
+        if (header == null) return DEFAULT_RETRY_DELAY_SECONDS
+        return header.trim().toLongOrNull()?.takeIf { it > 0 } ?: DEFAULT_RETRY_DELAY_SECONDS
+    }
+
+    private fun isSafeMethod(method: String) = method.equals("GET", ignoreCase = true) ||
+        method.equals("HEAD", ignoreCase = true)
+}

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/RateLimitInterceptorTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/RateLimitInterceptorTest.kt
@@ -1,0 +1,245 @@
+package com.justb81.watchbuddy.core.network
+
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("RateLimitInterceptor")
+class RateLimitInterceptorTest {
+
+    private lateinit var server: MockWebServer
+    private val sleepDelays = mutableListOf<Long>()
+    private val interceptor = RateLimitInterceptor(sleepFn = { ms -> sleepDelays.add(ms) })
+    private val client = OkHttpClient.Builder().addInterceptor(interceptor).build()
+
+    @BeforeEach
+    fun setUp() {
+        server = MockWebServer()
+        server.start()
+        DiagnosticLog.clear()
+        sleepDelays.clear()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        server.shutdown()
+    }
+
+    @Nested
+    @DisplayName("non-429 responses")
+    inner class NonRateLimited {
+
+        @Test
+        fun `passes through 200 without retry`() {
+            server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+            val response = client.newCall(Request.Builder().url(server.url("/")).build()).execute()
+            assertEquals(200, response.code)
+            assertEquals(1, server.requestCount)
+            assertTrue(sleepDelays.isEmpty())
+        }
+
+        @Test
+        fun `passes through 404 without retry`() {
+            server.enqueue(MockResponse().setResponseCode(404))
+            val response = client.newCall(Request.Builder().url(server.url("/")).build()).execute()
+            assertEquals(404, response.code)
+            assertEquals(1, server.requestCount)
+        }
+
+        @Test
+        fun `passes through 500 without retry`() {
+            server.enqueue(MockResponse().setResponseCode(500))
+            val response = client.newCall(Request.Builder().url(server.url("/")).build()).execute()
+            assertEquals(500, response.code)
+            assertEquals(1, server.requestCount)
+        }
+    }
+
+    @Nested
+    @DisplayName("GET 429 retry behaviour")
+    inner class GetRetry {
+
+        @Test
+        fun `retries GET once and returns second response`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "2"))
+            server.enqueue(MockResponse().setResponseCode(200).setBody("ok"))
+            val response = client.newCall(Request.Builder().url(server.url("/")).build()).execute()
+            assertEquals(200, response.code)
+            assertEquals(2, server.requestCount)
+        }
+
+        @Test
+        fun `sleeps for Retry-After seconds on GET 429`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "10"))
+            server.enqueue(MockResponse().setResponseCode(200))
+            client.newCall(Request.Builder().url(server.url("/")).build()).execute()
+            assertEquals(listOf(10_000L), sleepDelays)
+        }
+
+        @Test
+        fun `caps delay at 60 seconds`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "120"))
+            server.enqueue(MockResponse().setResponseCode(200))
+            client.newCall(Request.Builder().url(server.url("/")).build()).execute()
+            assertEquals(listOf(60_000L), sleepDelays)
+        }
+
+        @Test
+        fun `uses default 5s delay when Retry-After header is absent`() {
+            server.enqueue(MockResponse().setResponseCode(429))
+            server.enqueue(MockResponse().setResponseCode(200))
+            client.newCall(Request.Builder().url(server.url("/")).build()).execute()
+            assertEquals(listOf(5_000L), sleepDelays)
+        }
+
+        @Test
+        fun `uses default 5s delay when Retry-After is non-numeric`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "Wed, 21 Oct 2025 07:28:00 GMT"))
+            server.enqueue(MockResponse().setResponseCode(200))
+            client.newCall(Request.Builder().url(server.url("/")).build()).execute()
+            assertEquals(listOf(5_000L), sleepDelays)
+        }
+
+        @Test
+        fun `uses default 5s delay when Retry-After is zero`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "0"))
+            server.enqueue(MockResponse().setResponseCode(200))
+            client.newCall(Request.Builder().url(server.url("/")).build()).execute()
+            assertEquals(listOf(5_000L), sleepDelays)
+        }
+
+        @Test
+        fun `uses default 5s delay when Retry-After is negative`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "-5"))
+            server.enqueue(MockResponse().setResponseCode(200))
+            client.newCall(Request.Builder().url(server.url("/")).build()).execute()
+            assertEquals(listOf(5_000L), sleepDelays)
+        }
+
+        @Test
+        fun `does not retry a second time when retried request also returns 429`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "1"))
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "1"))
+            val response = client.newCall(Request.Builder().url(server.url("/")).build()).execute()
+            assertEquals(429, response.code)
+            assertEquals(2, server.requestCount)
+            // Only one sleep — we only retry once
+            assertEquals(1, sleepDelays.size)
+        }
+    }
+
+    @Nested
+    @DisplayName("non-idempotent methods are not retried")
+    inner class NonIdempotentMethods {
+
+        @Test
+        fun `POST 429 is not retried`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "5"))
+            val response = client.newCall(
+                Request.Builder()
+                    .url(server.url("/"))
+                    .post(okhttp3.RequestBody.create(null, ByteArray(0)))
+                    .build()
+            ).execute()
+            assertEquals(429, response.code)
+            assertEquals(1, server.requestCount)
+            assertTrue(sleepDelays.isEmpty())
+        }
+
+        @Test
+        fun `PUT 429 is not retried`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "5"))
+            val response = client.newCall(
+                Request.Builder()
+                    .url(server.url("/"))
+                    .put(okhttp3.RequestBody.create(null, ByteArray(0)))
+                    .build()
+            ).execute()
+            assertEquals(429, response.code)
+            assertEquals(1, server.requestCount)
+            assertTrue(sleepDelays.isEmpty())
+        }
+
+        @Test
+        fun `DELETE 429 is not retried`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "5"))
+            val response = client.newCall(
+                Request.Builder()
+                    .url(server.url("/"))
+                    .delete()
+                    .build()
+            ).execute()
+            assertEquals(429, response.code)
+            assertEquals(1, server.requestCount)
+            assertTrue(sleepDelays.isEmpty())
+        }
+    }
+
+    @Nested
+    @DisplayName("DiagnosticLog surfacing")
+    inner class DiagnosticLogTests {
+
+        @Test
+        fun `logs WARN entry on GET 429`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "3"))
+            server.enqueue(MockResponse().setResponseCode(200))
+            client.newCall(Request.Builder().url(server.url("/path")).build()).execute()
+            val entries = DiagnosticLog.snapshot()
+            val warn429 = entries.filter {
+                it.level == DiagnosticLog.Level.WARN && it.message.contains("429")
+            }
+            assertTrue(warn429.isNotEmpty(), "Expected a WARN entry for 429 in DiagnosticLog")
+        }
+
+        @Test
+        fun `logs WARN entry on POST 429 even though not retried`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "3"))
+            client.newCall(
+                Request.Builder()
+                    .url(server.url("/scrobble/start"))
+                    .post(okhttp3.RequestBody.create(null, ByteArray(0)))
+                    .build()
+            ).execute()
+            val entries = DiagnosticLog.snapshot()
+            val warn429 = entries.filter {
+                it.level == DiagnosticLog.Level.WARN && it.message.contains("429")
+            }
+            assertTrue(warn429.isNotEmpty(), "Expected a WARN entry for POST 429 in DiagnosticLog")
+        }
+
+        @Test
+        fun `log entry includes retry-after delay seconds`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "42"))
+            server.enqueue(MockResponse().setResponseCode(200))
+            client.newCall(Request.Builder().url(server.url("/")).build()).execute()
+            val warn = DiagnosticLog.snapshot().first {
+                it.level == DiagnosticLog.Level.WARN && it.message.contains("429")
+            }
+            assertTrue(warn.message.contains("42s"), "Log should include delay: ${warn.message}")
+        }
+    }
+
+    @Nested
+    @DisplayName("HEAD method")
+    inner class HeadMethod {
+
+        @Test
+        fun `HEAD 429 is retried like GET`() {
+            server.enqueue(MockResponse().setResponseCode(429).addHeader("Retry-After", "1"))
+            server.enqueue(MockResponse().setResponseCode(200))
+            val response = client.newCall(
+                Request.Builder().url(server.url("/")).head().build()
+            ).execute()
+            assertEquals(200, response.code)
+            assertEquals(2, server.requestCount)
+        }
+    }
+}

--- a/core/src/test/java/com/justb81/watchbuddy/core/network/RateLimitInterceptorTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/network/RateLimitInterceptorTest.kt
@@ -6,7 +6,8 @@ import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested


### PR DESCRIPTION
## Summary

- Adds `RateLimitInterceptor`, an OkHttp interceptor installed on the shared client, that catches 429 Too Many Requests responses, reads the `Retry-After` header (seconds; capped at 60 s), sleeps, and retries the request once.
- Non-idempotent methods (POST, PUT, DELETE) are **not** retried — the 429 is propagated to the caller. This preserves the existing guard against double-charging Trakt scrobble endpoints (`/scrobble/start|pause|stop`).
- All 429 hits are surfaced in `DiagnosticLog` as a `WARN` entry (tag `RateLimit`) regardless of whether a retry is attempted.
- Default delay when `Retry-After` is absent, non-numeric, or ≤ 0 is **5 s**.

## Test plan

- [x] `RateLimitInterceptorTest` covers non-429 pass-through, GET retry with Retry-After header, delay capping at 60 s, default 5 s delay (absent / non-numeric / zero / negative header), single-retry limit (second 429 not retried again), POST/PUT/DELETE not retried, HEAD retried like GET, and DiagnosticLog WARN entry for both retried and non-retried 429s.
- [x] `NetworkModuleTest` existing tests unchanged (interceptor is wired via `addInterceptor` before the Trakt-header interceptor).
- [x] Precommit: Android SDK not available — CI (`build-android.yml`) is the real gate for Kotlin/Android changes.

Closes #572

https://claude.ai/code/session_01Hsnbr1xJybZTNzigpzjZsZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hsnbr1xJybZTNzigpzjZsZ)_