### PR TITLE
fix(core): make CrashReporter.install() idempotent and add chaining tests

### DIFF
--- a/core/src/main/java/com/justb81/watchbuddy/core/logging/CrashReporter.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/logging/CrashReporter.kt
@@ -28,6 +28,16 @@ object CrashReporter {
 
     private val installed = AtomicBoolean(false)
 
+    /**
+     * Installs the uncaught-exception handler.
+     *
+     * Must be called exactly once from [android.app.Application.onCreate], before any
+     * other component (Crashlytics, test frameworks, etc.) installs its own handler.
+     * Subsequent calls are no-ops — the [AtomicBoolean] compare-and-set guard makes
+     * this function idempotent and thread-safe, so the handler chain is never broken
+     * or duplicated even if the call site is reachable more than once (e.g. Hilt
+     * re-injection in tests).
+     */
     fun install(context: Context) {
         if (!installed.compareAndSet(false, true)) return
         val appContext = context.applicationContext
@@ -37,6 +47,10 @@ object CrashReporter {
             previous?.uncaughtException(thread, throwable)
         }
         DiagnosticLog.event(TAG, "CrashReporter installed")
+    }
+
+    internal fun resetForTest() {
+        installed.set(false)
     }
 
     fun reportsDir(context: Context): File =

--- a/core/src/test/java/com/justb81/watchbuddy/core/logging/CrashReporterTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/logging/CrashReporterTest.kt
@@ -1,0 +1,122 @@
+package com.justb81.watchbuddy.core.logging
+
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+@DisplayName("CrashReporter — idempotent install and handler chaining (#575)")
+class CrashReporterTest {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var fakeContext: Context
+
+    @BeforeEach
+    fun setUp() {
+        CrashReporter.resetForTest()
+        Thread.setDefaultUncaughtExceptionHandler(null)
+
+        val ctx = mockk<Context>(relaxed = true)
+        every { ctx.applicationContext } returns ctx
+        every { ctx.filesDir } returns tempDir
+        every { ctx.packageName } returns "com.test"
+        fakeContext = ctx
+    }
+
+    @AfterEach
+    fun tearDown() {
+        CrashReporter.resetForTest()
+        Thread.setDefaultUncaughtExceptionHandler(null)
+    }
+
+    @Test
+    fun `install registers an uncaught exception handler`() {
+        assertNull(Thread.getDefaultUncaughtExceptionHandler())
+
+        CrashReporter.install(fakeContext)
+
+        assertNotNull(Thread.getDefaultUncaughtExceptionHandler())
+    }
+
+    @Test
+    fun `install is idempotent — second call does not replace the registered handler`() {
+        CrashReporter.install(fakeContext)
+        val firstHandler = Thread.getDefaultUncaughtExceptionHandler()
+
+        CrashReporter.install(fakeContext)
+        val secondHandler = Thread.getDefaultUncaughtExceptionHandler()
+
+        assertSame(firstHandler, secondHandler)
+    }
+
+    @Test
+    fun `handler chains to previously installed handler`() {
+        val previousCalled = AtomicBoolean(false)
+        Thread.setDefaultUncaughtExceptionHandler { _, _ -> previousCalled.set(true) }
+
+        CrashReporter.install(fakeContext)
+
+        val handler = Thread.getDefaultUncaughtExceptionHandler()!!
+        handler.uncaughtException(Thread.currentThread(), RuntimeException("test crash"))
+
+        assertTrue(previousCalled.get())
+    }
+
+    @Test
+    fun `double install does not duplicate handler chain — previous called exactly once`() {
+        val callCount = AtomicInteger(0)
+        Thread.setDefaultUncaughtExceptionHandler { _, _ -> callCount.incrementAndGet() }
+
+        CrashReporter.install(fakeContext)
+        CrashReporter.install(fakeContext)
+
+        val handler = Thread.getDefaultUncaughtExceptionHandler()!!
+        handler.uncaughtException(Thread.currentThread(), RuntimeException("test crash"))
+
+        assertEquals(1, callCount.get())
+    }
+
+    @Test
+    fun `handler completes gracefully when no previous handler is installed`() {
+        CrashReporter.install(fakeContext)
+
+        val handler = Thread.getDefaultUncaughtExceptionHandler()!!
+        var threw = false
+        try {
+            handler.uncaughtException(Thread.currentThread(), RuntimeException("test crash"))
+        } catch (_: Throwable) {
+            threw = true
+        }
+
+        assertTrue(!threw, "Handler should not throw when no previous handler is set")
+    }
+
+    @Test
+    fun `second install after reset re-registers a new handler`() {
+        CrashReporter.install(fakeContext)
+        val firstHandler = Thread.getDefaultUncaughtExceptionHandler()
+
+        CrashReporter.resetForTest()
+        Thread.setDefaultUncaughtExceptionHandler(null)
+
+        CrashReporter.install(fakeContext)
+        val secondHandler = Thread.getDefaultUncaughtExceptionHandler()
+
+        assertNotNull(firstHandler)
+        assertNotNull(secondHandler)
+    }
+}


### PR DESCRIPTION
## Summary

- `CrashReporter.install()` already had the `AtomicBoolean.compareAndSet` guard preventing double-registration; this PR adds KDoc making the contract explicit (must be the first call in `Application.onCreate`) and documents the thread-safety guarantee.
- Adds `internal fun resetForTest()` to allow unit-test isolation without exposing the `installed` flag publicly.
- Adds `CrashReporterTest` with 6 focused tests covering: handler registration, idempotency, previous-handler chaining, no-double-dispatch under double-install, graceful completion with no prior handler, and re-registration after reset.

**Note:** Android SDK is not available in this sandbox environment — the Gradle scope (`:core:test`, `detektAll`, `lintDebug`) was skipped locally. CI (`build-android.yml`) is the real gate for Kotlin/Android changes.

Closes #575

## Test plan

- [ ] `./gradlew :core:test` passes — all 6 `CrashReporterTest` cases green
- [ ] `./gradlew detektAll` — no new findings
- [ ] `./gradlew :app-phone:lintDebug :app-tv:lintDebug` — clean

https://claude.ai/code/session_011MnWddzckdQQxYq8K4TD7Z

---
_Generated by [Claude Code](https://claude.ai/code/session_011MnWddzckdQQxYq8K4TD7Z)_