### PR TITLE
fix(tv): replace fragile pipe-format encoding in LastUsedProviderRepository with JSON

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/LastUsedProviderRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/LastUsedProviderRepository.kt
@@ -7,9 +7,13 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.emptyPreferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -17,11 +21,21 @@ private val Context.providerDataStore: DataStore<Preferences> by preferencesData
     name = "last_used_providers"
 )
 
+private const val TAG = "LastUsedProviderRepo"
+private const val V1_PREFIX = "v1:"
+
+@Serializable
+private data class ProviderMapV1(val providers: Map<String, Int> = emptyMap())
+
+private val codec = Json { ignoreUnknownKeys = true }
+
 /**
  * Persists which streaming provider was most recently used for each show on this TV.
  * Stored locally — not synced to phones.
  *
- * Format: a single string preference encoded as "tmdbShowId1|providerId1;tmdbShowId2|providerId2".
+ * Storage format: a single string preference prefixed with "v1:" followed by a
+ * JSON-serialized object. Legacy pipe-delimited entries ("showId|providerId;...") are
+ * migrated on first read and rewritten in the v1 format on the next write.
  * Updated whenever the user launches a provider deep link from ShowDetailScreen, or
  * when a confirmed scrobble can be attributed to a known package in ProviderCatalog.
  */
@@ -46,20 +60,47 @@ class LastUsedProviderRepository @Inject constructor(
         return decode(raw)[tmdbShowId]
     }
 
-    private fun encode(map: Map<Int, Int>): String =
-        map.entries.joinToString(";") { "${it.key}|${it.value}" }
+    internal fun encode(map: Map<Int, Int>): String {
+        val dto = ProviderMapV1(map.mapKeys { it.key.toString() })
+        return "$V1_PREFIX${codec.encodeToString(dto)}"
+    }
 
-    private fun decode(s: String): Map<Int, Int> {
+    internal fun decode(s: String): Map<Int, Int> {
         if (s.isBlank()) return emptyMap()
-        return s.split(";").mapNotNull { entry ->
+        return if (s.startsWith(V1_PREFIX)) {
+            decodeV1(s.removePrefix(V1_PREFIX))
+        } else {
+            migrateLegacy(s)
+        }
+    }
+
+    private fun decodeV1(jsonPart: String): Map<Int, Int> {
+        return try {
+            val dto = codec.decodeFromString<ProviderMapV1>(jsonPart)
+            dto.providers.entries.mapNotNull { (k, v) ->
+                k.toIntOrNull()?.let { it to v }
+            }.toMap()
+        } catch (e: Exception) {
+            DiagnosticLog.warn(TAG, "v1 provider map decode failed, discarding entries", e)
+            emptyMap()
+        }
+    }
+
+    private fun migrateLegacy(s: String): Map<Int, Int> {
+        val result = s.split(";").mapNotNull { entry ->
             val parts = entry.split("|")
             if (parts.size == 2) {
                 parts[0].toIntOrNull()?.let { k ->
                     parts[1].toIntOrNull()?.let { v -> k to v }
                 }
             } else {
+                if (entry.isNotBlank()) {
+                    DiagnosticLog.warn(TAG, "Legacy provider map entry malformed, skipping: '$entry'")
+                }
                 null
             }
         }.toMap()
+        DiagnosticLog.warn(TAG, "Migrated legacy pipe-format provider map (${result.size} entries)")
+        return result
     }
 }

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/LastUsedProviderRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/LastUsedProviderRepositoryTest.kt
@@ -1,0 +1,169 @@
+package com.justb81.watchbuddy.tv.data
+
+import android.content.Context
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("LastUsedProviderRepository — encode/decode")
+class LastUsedProviderRepositoryTest {
+
+    // encode/decode do not access DataStore; a relaxed mock Context is sufficient.
+    private val repo = LastUsedProviderRepository(mockk<Context>(relaxed = true))
+
+    @BeforeEach
+    fun clearLog() {
+        DiagnosticLog.clear()
+    }
+
+    @AfterEach
+    fun cleanLog() {
+        DiagnosticLog.clear()
+    }
+
+    @Nested
+    @DisplayName("encode")
+    inner class EncodeTests {
+
+        @Test
+        fun `empty map produces v1 prefix`() {
+            assertTrue(repo.encode(emptyMap()).startsWith("v1:"))
+        }
+
+        @Test
+        fun `non-empty map round-trips through decode`() {
+            val original = mapOf(100 to 8, 200 to 350, 999 to 1)
+            val encoded = repo.encode(original)
+            assertEquals(original, repo.decode(encoded))
+        }
+
+        @Test
+        fun `single-entry map round-trips`() {
+            val original = mapOf(42 to 7)
+            assertEquals(original, repo.decode(repo.encode(original)))
+        }
+
+        @Test
+        fun `overwrite of existing key survives round-trip`() {
+            val map = mapOf(1 to 10, 2 to 20)
+            val updated = map.toMutableMap().also { it[1] = 99 }
+            assertEquals(99, repo.decode(repo.encode(updated))[1])
+        }
+    }
+
+    @Nested
+    @DisplayName("decode — blank / empty input")
+    inner class BlankInputTests {
+
+        @Test
+        fun `blank string returns empty map`() {
+            assertTrue(repo.decode("").isEmpty())
+        }
+
+        @Test
+        fun `whitespace-only string returns empty map`() {
+            assertTrue(repo.decode("   ").isEmpty())
+        }
+    }
+
+    @Nested
+    @DisplayName("decode — v1 JSON format")
+    inner class V1DecodeTests {
+
+        @Test
+        fun `valid v1 JSON decodes correctly`() {
+            val encoded = repo.encode(mapOf(1 to 2, 3 to 4))
+            val result = repo.decode(encoded)
+            assertEquals(mapOf(1 to 2, 3 to 4), result)
+        }
+
+        @Test
+        fun `v1 JSON with unknown extra field is tolerated`() {
+            val raw = """v1:{"providers":{"100":8},"future_field":true}"""
+            val result = repo.decode(raw)
+            assertEquals(mapOf(100 to 8), result)
+        }
+
+        @Test
+        fun `corrupt v1 JSON returns empty map`() {
+            val result = repo.decode("v1:{not valid json!}")
+            assertTrue(result.isEmpty())
+        }
+
+        @Test
+        fun `corrupt v1 JSON logs a WARN entry`() {
+            repo.decode("v1:{not valid json!}")
+            val warns = DiagnosticLog.snapshot().filter { it.level == DiagnosticLog.Level.WARN }
+            assertTrue(warns.isNotEmpty(), "Expected at least one WARN log entry")
+        }
+
+        @Test
+        fun `v1 JSON with non-integer string key is silently dropped`() {
+            val raw = """v1:{"providers":{"abc":8,"100":9}}"""
+            val result = repo.decode(raw)
+            assertEquals(mapOf(100 to 9), result)
+        }
+    }
+
+    @Nested
+    @DisplayName("decode — legacy pipe-delimited format (migration)")
+    inner class LegacyMigrationTests {
+
+        @Test
+        fun `legacy format decodes all valid entries`() {
+            val result = repo.decode("100|8;200|350;999|1")
+            assertEquals(mapOf(100 to 8, 200 to 350, 999 to 1), result)
+        }
+
+        @Test
+        fun `legacy format logs a WARN migration entry`() {
+            repo.decode("100|8;200|350")
+            val warns = DiagnosticLog.snapshot().filter { it.level == DiagnosticLog.Level.WARN }
+            assertTrue(warns.any { it.message.contains("Migrated legacy") })
+        }
+
+        @Test
+        fun `malformed legacy entry without pipe is skipped and logged`() {
+            val result = repo.decode("100|8;BADENTRY;200|350")
+            assertEquals(mapOf(100 to 8, 200 to 350), result)
+            val warns = DiagnosticLog.snapshot().filter { it.level == DiagnosticLog.Level.WARN }
+            assertTrue(warns.any { it.message.contains("malformed") })
+        }
+
+        @Test
+        fun `legacy entry with non-integer value is silently dropped`() {
+            val result = repo.decode("100|abc;200|350")
+            assertEquals(mapOf(200 to 350), result)
+        }
+
+        @Test
+        fun `legacy entry with non-integer key is silently dropped`() {
+            val result = repo.decode("abc|8;200|350")
+            assertEquals(mapOf(200 to 350), result)
+        }
+
+        @Test
+        fun `empty string between delimiters does not produce spurious WARN`() {
+            // A trailing semicolon leaves a blank entry; it should be dropped silently.
+            repo.decode("100|8;")
+            val warns = DiagnosticLog.snapshot()
+                .filter { it.level == DiagnosticLog.Level.WARN && it.message.contains("malformed") }
+            assertTrue(warns.isEmpty(), "Blank trailing entries must not generate malformed warnings")
+        }
+
+        @Test
+        fun `re-encoding migrated legacy data produces v1 format`() {
+            val migrated = repo.decode("100|8;200|350")
+            val reencoded = repo.encode(migrated)
+            assertTrue(reencoded.startsWith("v1:"))
+            // Verify the re-encoded value is stable through another decode cycle
+            assertEquals(migrated, repo.decode(reencoded))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Replaces the hand-rolled `"showId|providerId;..."` pipe format in `LastUsedProviderRepository` with a `kotlinx.serialization` JSON format prefixed with `v1:`, enabling future schema versioning without ambiguity.
- Corrupt or unrecognisable `v1:` payloads now emit a `WARN` via `DiagnosticLog` instead of silently discarding entries with no telemetry.
- Malformed legacy pipe entries (wrong number of `|`-delimited parts) also log a `WARN`; blank trailing entries (e.g. from a trailing `;`) are dropped silently.
- Legacy entries are migrated on first read; the next `recordUsed()` call rewrites the preference in `v1` format automatically — no explicit migration step required.
- `encode`/`decode` are marked `internal` to allow direct unit testing without the Android DataStore / Context stack.
- 17 new unit tests covering: round-trips, `v1` decode, legacy migration, corrupt-input handling, and `DiagnosticLog` emission verification.

Closes #550

## Test plan

- [ ] All 17 new unit tests in `LastUsedProviderRepositoryTest` pass
- [ ] `./gradlew :app-tv:test` green
- [ ] `./gradlew detektAll` — no new findings
- [ ] Manual: launch a deep link on TV → provider is remembered for the show → subsequent open of ShowDetailScreen ranks the same provider first

> **Note:** Gradle checks were skipped locally (no Android SDK in this sandboxed environment). CI (`build-android.yml`) is the real gate for Kotlin/Android validation.

https://claude.ai/code/session_015ubR3PNxpGG8zidDp567Lg

---
_Generated by [Claude Code](https://claude.ai/code/session_015ubR3PNxpGG8zidDp567Lg)_