### PR TITLE
fix(core): log DiagnosticLog warning for unmapped JustWatch technicalNames and add TMDB provider validation

### DIFF
--- a/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMap.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMap.kt
@@ -1,5 +1,7 @@
 package com.justb81.watchbuddy.core.justwatch
 
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+
 /**
  * Maps JustWatch `technicalName` values to TMDB `provider_id` integers.
  *
@@ -7,6 +9,8 @@ package com.justb81.watchbuddy.core.justwatch
  * TMDB's watch-provider list still renders them with their logo and name.
  */
 object JustWatchPackageMap {
+
+    private const val TAG = "JustWatchPackageMap"
 
     val technicalNameToProviderId: Map<String, Int> = mapOf(
         "nfx" to 8, // Netflix
@@ -26,6 +30,12 @@ object JustWatchPackageMap {
         "ytv" to 192, // YouTube (TV variant alias)
     )
 
-    fun resolveProviderId(technicalName: String): Int? =
-        technicalNameToProviderId[technicalName.lowercase()]
+    fun resolveProviderId(technicalName: String): Int? {
+        val key = technicalName.lowercase()
+        val id = technicalNameToProviderId[key]
+        if (id == null) {
+            DiagnosticLog.warn(TAG, "unmapped technicalName: $key")
+        }
+        return id
+    }
 }

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -367,6 +367,12 @@ data class WatchProviderResponse(
     val results: Map<String, WatchProviderResult> = emptyMap(),
 )
 
+/** Response from TMDB `/watch/providers/tv` — the global catalogue of all TV watch providers. */
+@Serializable
+data class AllTvWatchProvidersResponse(
+    val results: List<WatchProviderEntry> = emptyList(),
+)
+
 /**
  * A fully resolved streaming provider for a show, ready for the UI.
  * Combines TMDB provider data with the [ProviderCatalog] mapping and

--- a/core/src/main/java/com/justb81/watchbuddy/core/tmdb/TmdbApiService.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/tmdb/TmdbApiService.kt
@@ -1,5 +1,6 @@
 package com.justb81.watchbuddy.core.tmdb
 
+import com.justb81.watchbuddy.core.model.AllTvWatchProvidersResponse
 import com.justb81.watchbuddy.core.model.TmdbEpisode
 import com.justb81.watchbuddy.core.model.TmdbShow
 import com.justb81.watchbuddy.core.model.TmdbTvSearchResponse
@@ -42,6 +43,13 @@ interface TmdbApiService {
         @Path("series_id") id: Int,
         @Query("api_key") apiKey: String
     ): WatchProviderResponse
+
+    /** Returns the global catalogue of all TV watch providers known to TMDB. */
+    @GET("watch/providers/tv")
+    suspend fun getAllTvWatchProviders(
+        @Query("api_key") apiKey: String,
+        @Query("language") language: String = "en-US"
+    ): AllTvWatchProvidersResponse
 }
 
 // Image URL helper

--- a/core/src/test/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMapTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMapTest.kt
@@ -1,7 +1,11 @@
 package com.justb81.watchbuddy.core.justwatch
 
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -9,6 +13,16 @@ import org.junit.jupiter.params.provider.CsvSource
 
 @DisplayName("JustWatchPackageMap")
 class JustWatchPackageMapTest {
+
+    @BeforeEach
+    fun clearLog() {
+        DiagnosticLog.clear()
+    }
+
+    @AfterEach
+    fun resetLog() {
+        DiagnosticLog.clear()
+    }
 
     @ParameterizedTest(name = "{0} → TMDB {1}")
     @CsvSource(
@@ -52,8 +66,40 @@ class JustWatchPackageMapTest {
     }
 
     @Test
+    fun `resolveProviderId emits a WARN diagnostic for unknown technical names`() {
+        JustWatchPackageMap.resolveProviderId("new_streaming_service")
+
+        val warnings = DiagnosticLog.snapshot().filter {
+            it.level == DiagnosticLog.Level.WARN && it.message.contains("new_streaming_service")
+        }
+        assertTrue(warnings.isNotEmpty(), "Expected a WARN entry for unmapped technicalName")
+    }
+
+    @Test
+    fun `resolveProviderId does not log a warning for known technical names`() {
+        JustWatchPackageMap.resolveProviderId("nfx")
+
+        val warnings = DiagnosticLog.snapshot().filter {
+            it.level == DiagnosticLog.Level.WARN
+        }
+        assertTrue(warnings.isEmpty(), "Expected no WARN entries when technicalName resolves successfully")
+    }
+
+    @Test
+    fun `resolveProviderId warning includes the lowercased technical name`() {
+        JustWatchPackageMap.resolveProviderId("UNKNOWN_PROVIDER")
+
+        val entry = DiagnosticLog.snapshot().firstOrNull {
+            it.level == DiagnosticLog.Level.WARN
+        }
+        assertTrue(
+            entry?.message?.contains("unknown_provider") == true,
+            "Warning message should contain the lowercased technicalName"
+        )
+    }
+
+    @Test
     fun `map does not contain duplicates for known entries`() {
-        val values = JustWatchPackageMap.technicalNameToProviderId.values.toList()
         // hbm and max both map to 1899 — that is intentional, not a bug
         val uniqueEntries = JustWatchPackageMap.technicalNameToProviderId.keys
         assertEquals(uniqueEntries.size, uniqueEntries.toSet().size)

--- a/core/src/test/java/com/justb81/watchbuddy/core/justwatch/JustWatchProviderMapIntegrationTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/justwatch/JustWatchProviderMapIntegrationTest.kt
@@ -1,0 +1,65 @@
+package com.justb81.watchbuddy.core.justwatch
+
+import com.justb81.watchbuddy.core.network.WatchBuddyJson
+import com.justb81.watchbuddy.core.tmdb.TmdbApiService
+import kotlinx.coroutines.runBlocking
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+/**
+ * Integration test that validates the [JustWatchPackageMap] against TMDB's live
+ * `/watch/providers/tv` catalogue.
+ *
+ * The test is CI-skippable: it requires a TMDB API key available via the
+ * `TMDB_API_KEY` environment variable or the `tmdb.api.key` JVM system property.
+ * If neither is present the test is skipped via [assumeTrue] so that CI
+ * (which doesn't have the key) is never blocked.
+ *
+ * To run locally:
+ *   TMDB_API_KEY=<your-key> ./gradlew :core:test --tests "*JustWatchProviderMapIntegrationTest*"
+ * or via Gradle property:
+ *   ./gradlew :core:test -Dtmdb.api.key=<your-key> --tests "*JustWatchProviderMapIntegrationTest*"
+ */
+@Tag("integration")
+@DisplayName("JustWatchPackageMap — TMDB provider ID validation (integration)")
+class JustWatchProviderMapIntegrationTest {
+
+    private fun resolveApiKey(): String? =
+        System.getenv("TMDB_API_KEY")?.takeIf { it.isNotBlank() }
+            ?: System.getProperty("tmdb.api.key")?.takeIf { it.isNotBlank() }
+
+    private fun buildTmdbService(): TmdbApiService =
+        Retrofit.Builder()
+            .baseUrl("https://api.themoviedb.org/3/")
+            .client(OkHttpClient())
+            .addConverterFactory(WatchBuddyJson.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(TmdbApiService::class.java)
+
+    @Test
+    @DisplayName("all mapped TMDB provider IDs exist in the live TMDB provider catalogue")
+    fun `all JustWatchPackageMap provider IDs are present in TMDB catalogue`() {
+        val apiKey = resolveApiKey()
+        assumeTrue(apiKey != null, "TMDB API key not available — skipping integration test")
+
+        val service = buildTmdbService()
+        val response = runBlocking { service.getAllTvWatchProviders(apiKey = apiKey!!) }
+
+        val tmdbProviderIds = response.results.map { it.providerId }.toSet()
+        val mappedIds = JustWatchPackageMap.technicalNameToProviderId.values.toSet()
+
+        val missing = mappedIds - tmdbProviderIds
+        assertTrue(
+            missing.isEmpty(),
+            "The following TMDB provider IDs are in JustWatchPackageMap but not in " +
+                "TMDB's /watch/providers/tv catalogue — they may have been renumbered: $missing"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- `resolveProviderId()` now emits a `WARN` entry to `DiagnosticLog` whenever a JustWatch `technicalName` cannot be resolved, making previously-silent provider drift visible in diagnostics and logcat
- New `AllTvWatchProvidersResponse` model and `getAllTvWatchProviders()` endpoint added to `TmdbApiService` for TMDB's global `/watch/providers/tv` catalogue
- New CI-skippable `JustWatchProviderMapIntegrationTest` validates that all provider IDs in `JustWatchPackageMap` exist in the live TMDB catalogue; auto-skipped when `TMDB_API_KEY` / `tmdb.api.key` is absent
- `JustWatchPackageMapTest` extended with three new tests verifying the `WARN` diagnostic is emitted (with lowercased name) for unknown `technicalNames` and absent for known ones

## Test plan

- [ ] All existing `JustWatchPackageMapTest` cases still pass
- [ ] New warning tests confirm `DiagnosticLog.WARN` is emitted for unknown names and absent for known names
- [ ] `JustWatchProviderMapIntegrationTest` is skipped in CI (no API key) and can be run locally with `TMDB_API_KEY=<key> ./gradlew :core:test --tests "*JustWatchProviderMapIntegrationTest*"`
- [ ] `RetrofitServiceSmokeTest` still passes (service count unchanged at 4)

> **Note:** Gradle checks were skipped locally (no Android SDK in this environment). CI (`build-android.yml`) is the real gate.

Closes #570

https://claude.ai/code/session_011TFfUF8Mh41iAJ3H2QiG67

---
_Generated by [Claude Code](https://claude.ai/code/session_011TFfUF8Mh41iAJ3H2QiG67)_