### PR TITLE
fix(core): BleDiscoveryContract.decode returns sealed DecodeResult

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneBleScanner.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneBleScanner.kt
@@ -14,6 +14,7 @@ import android.os.ParcelUuid
 import android.util.Log
 import androidx.core.content.ContextCompat
 import com.justb81.watchbuddy.core.discovery.BleDiscoveryContract
+import com.justb81.watchbuddy.core.logging.DiagnosticLog
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.net.Inet4Address
 import javax.inject.Inject
@@ -167,23 +168,37 @@ class PhoneBleScanner @Inject constructor(
         val data = result.scanRecord
             ?.serviceData
             ?.get(ParcelUuid(BleDiscoveryContract.SERVICE_UUID))
-        val payload = BleDiscoveryContract.decode(data) ?: run {
-            Log.v(TAG, "scan result without decodable WatchBuddy payload: ${result.device.address}")
-            return
+        when (val decoded = BleDiscoveryContract.decode(data)) {
+            is BleDiscoveryContract.DecodeResult.Ok -> {
+                val payload = decoded.payload
+                Log.d(
+                    TAG,
+                    "advertisement: ip=${payload.ipv4.hostAddress} port=${payload.port} " +
+                        "quality=${payload.modelQuality} backend=${payload.llmBackendOrdinal} " +
+                        "rssi=${result.rssi}"
+                )
+                listener.onAdvertisement(
+                    ipv4 = payload.ipv4,
+                    port = payload.port,
+                    modelQuality = payload.modelQuality,
+                    llmBackendOrdinal = payload.llmBackendOrdinal,
+                    rssi = result.rssi,
+                )
+            }
+            is BleDiscoveryContract.DecodeResult.WrongVersion -> DiagnosticLog.debug(
+                TAG,
+                "BLE schema mismatch from ${result.device.address}: " +
+                    "v${decoded.found} (expected v${decoded.expected})",
+            )
+            BleDiscoveryContract.DecodeResult.Truncated -> DiagnosticLog.warn(
+                TAG,
+                "Truncated BLE payload from ${result.device.address}",
+            )
+            BleDiscoveryContract.DecodeResult.MalformedIpv4 -> DiagnosticLog.warn(
+                TAG,
+                "Malformed IPv4 in BLE payload from ${result.device.address}",
+            )
         }
-        Log.d(
-            TAG,
-            "advertisement: ip=${payload.ipv4.hostAddress} port=${payload.port} " +
-                "quality=${payload.modelQuality} backend=${payload.llmBackendOrdinal} " +
-                "rssi=${result.rssi}"
-        )
-        listener.onAdvertisement(
-            ipv4 = payload.ipv4,
-            port = payload.port,
-            modelQuality = payload.modelQuality,
-            llmBackendOrdinal = payload.llmBackendOrdinal,
-            rssi = result.rssi,
-        )
     }
 
     private fun hasScanPermission(): Boolean =

--- a/core/src/main/java/com/justb81/watchbuddy/core/discovery/BleDiscoveryContract.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/discovery/BleDiscoveryContract.kt
@@ -61,10 +61,13 @@ object BleDiscoveryContract {
     /** Typed result returned by [decode] so callers can distinguish failure modes. */
     sealed class DecodeResult {
         data class Ok(val payload: Payload) : DecodeResult()
+
         /** Schema version in the advert differs from [PAYLOAD_SCHEMA_VERSION]; expected on old clients. */
         data class WrongVersion(val found: Byte, val expected: Byte) : DecodeResult()
+
         /** Payload is null or shorter than [PAYLOAD_SIZE_BYTES]. */
         data object Truncated : DecodeResult()
+
         /** IPv4 field could not be parsed into an [Inet4Address]. */
         data object MalformedIpv4 : DecodeResult()
     }

--- a/core/src/main/java/com/justb81/watchbuddy/core/discovery/BleDiscoveryContract.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/discovery/BleDiscoveryContract.kt
@@ -58,6 +58,17 @@ object BleDiscoveryContract {
         val llmBackendOrdinal: Int,
     )
 
+    /** Typed result returned by [decode] so callers can distinguish failure modes. */
+    sealed class DecodeResult {
+        data class Ok(val payload: Payload) : DecodeResult()
+        /** Schema version in the advert differs from [PAYLOAD_SCHEMA_VERSION]; expected on old clients. */
+        data class WrongVersion(val found: Byte, val expected: Byte) : DecodeResult()
+        /** Payload is null or shorter than [PAYLOAD_SIZE_BYTES]. */
+        data object Truncated : DecodeResult()
+        /** IPv4 field could not be parsed into an [Inet4Address]. */
+        data object MalformedIpv4 : DecodeResult()
+    }
+
     /**
      * Packs [payload] into its 9-byte wire form.
      *
@@ -86,26 +97,32 @@ object BleDiscoveryContract {
     }
 
     /**
-     * Reads a payload emitted by [encode]. Returns `null` for any malformed or
-     * unknown-version input — never throws, since this runs on every scan
-     * callback and bad data is a normal network condition (other apps using
-     * adjacent UUID space, radio corruption, schema drift from a newer phone
-     * build).
+     * Reads a payload emitted by [encode]. Returns a [DecodeResult] that distinguishes
+     * the failure mode so callers can log unexpected cases separately from expected
+     * schema-version mismatches (old client on the same network).
+     *
+     * Never throws — this runs on every scan callback and bad data is a normal
+     * network condition (other apps using adjacent UUID space, radio corruption,
+     * schema drift from a newer phone build).
      */
-    fun decode(bytes: ByteArray?): Payload? {
-        if (bytes == null || bytes.size < PAYLOAD_SIZE_BYTES) return null
-        if (bytes[0] != PAYLOAD_SCHEMA_VERSION) return null
+    fun decode(bytes: ByteArray?): DecodeResult {
+        if (bytes == null || bytes.size < PAYLOAD_SIZE_BYTES) return DecodeResult.Truncated
+        if (bytes[0] != PAYLOAD_SCHEMA_VERSION) {
+            return DecodeResult.WrongVersion(found = bytes[0], expected = PAYLOAD_SCHEMA_VERSION)
+        }
         val ipv4 = runCatching {
             InetAddress.getByAddress(bytes.copyOfRange(1, 5)) as? Inet4Address
-        }.getOrNull() ?: return null
+        }.getOrNull() ?: return DecodeResult.MalformedIpv4
         val port = ((bytes[5].toInt() and 0xFF) shl 8) or (bytes[6].toInt() and 0xFF)
         val modelQuality = bytes[7].toInt() and 0xFF
         val llmBackendOrdinal = bytes[8].toInt() and 0xFF
-        return Payload(
-            ipv4 = ipv4,
-            port = port,
-            modelQuality = modelQuality,
-            llmBackendOrdinal = llmBackendOrdinal,
+        return DecodeResult.Ok(
+            Payload(
+                ipv4 = ipv4,
+                port = port,
+                modelQuality = modelQuality,
+                llmBackendOrdinal = llmBackendOrdinal,
+            )
         )
     }
 }

--- a/core/src/test/java/com/justb81/watchbuddy/core/discovery/BleDiscoveryContractTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/discovery/BleDiscoveryContractTest.kt
@@ -2,9 +2,8 @@ package com.justb81.watchbuddy.core.discovery
 
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import java.net.Inet4Address
@@ -16,6 +15,12 @@ class BleDiscoveryContractTest {
     private fun ipv4(address: String) =
         InetAddress.getByName(address) as Inet4Address
 
+    private fun decodeOk(bytes: ByteArray): BleDiscoveryContract.Payload {
+        val result = BleDiscoveryContract.decode(bytes)
+        assertTrue(result is BleDiscoveryContract.DecodeResult.Ok, "Expected Ok but got $result")
+        return (result as BleDiscoveryContract.DecodeResult.Ok).payload
+    }
+
     @Test
     fun `round trip preserves all fields`() {
         val payload = BleDiscoveryContract.Payload(
@@ -25,7 +30,7 @@ class BleDiscoveryContractTest {
             llmBackendOrdinal = 2,
         )
 
-        val decoded = BleDiscoveryContract.decode(BleDiscoveryContract.encode(payload))
+        val decoded = decodeOk(BleDiscoveryContract.encode(payload))
 
         assertEquals(payload, decoded)
     }
@@ -53,7 +58,7 @@ class BleDiscoveryContractTest {
             BleDiscoveryContract.Payload(ipv4("255.255.255.255"), 0xFFFF, 255, 255),
             BleDiscoveryContract.Payload(ipv4("127.0.0.1"), 65535, 150, 1),
         ).forEach { payload ->
-            val decoded = BleDiscoveryContract.decode(BleDiscoveryContract.encode(payload))
+            val decoded = decodeOk(BleDiscoveryContract.encode(payload))
             assertEquals(payload, decoded, "round trip failed for $payload")
         }
     }
@@ -79,24 +84,40 @@ class BleDiscoveryContractTest {
     }
 
     @Test
-    fun `decode rejects null`() {
-        assertNull(BleDiscoveryContract.decode(null))
+    fun `decode null returns Truncated`() {
+        assertEquals(BleDiscoveryContract.DecodeResult.Truncated, BleDiscoveryContract.decode(null))
     }
 
     @Test
-    fun `decode rejects short buffer`() {
-        assertNull(
+    fun `decode short buffer returns Truncated`() {
+        assertEquals(
+            BleDiscoveryContract.DecodeResult.Truncated,
             BleDiscoveryContract.decode(ByteArray(BleDiscoveryContract.PAYLOAD_SIZE_BYTES - 1))
         )
     }
 
     @Test
-    fun `decode rejects unknown schema version`() {
+    fun `decode empty buffer returns Truncated`() {
+        assertEquals(
+            BleDiscoveryContract.DecodeResult.Truncated,
+            BleDiscoveryContract.decode(ByteArray(0))
+        )
+    }
+
+    @Test
+    fun `decode unknown schema version returns WrongVersion with correct fields`() {
         val valid = BleDiscoveryContract.encode(
             BleDiscoveryContract.Payload(ipv4("192.168.1.1"), 8765, 70, 1)
         )
         valid[0] = 99
-        assertNull(BleDiscoveryContract.decode(valid))
+        val result = BleDiscoveryContract.decode(valid)
+        assertEquals(
+            BleDiscoveryContract.DecodeResult.WrongVersion(
+                found = 99,
+                expected = BleDiscoveryContract.PAYLOAD_SCHEMA_VERSION,
+            ),
+            result,
+        )
     }
 
     @Test
@@ -105,9 +126,7 @@ class BleDiscoveryContractTest {
             BleDiscoveryContract.Payload(ipv4("192.168.1.1"), 8765, 70, 1)
         )
         val padded = valid + byteArrayOf(0xAA.toByte(), 0xBB.toByte())
-        val decoded = BleDiscoveryContract.decode(padded)
-        assertNotNull(decoded)
-        assertEquals(8765, decoded!!.port)
+        assertEquals(8765, decodeOk(padded).port)
     }
 
     @Test
@@ -136,6 +155,19 @@ class BleDiscoveryContractTest {
                 BleDiscoveryContract.Payload(ipv4("10.0.0.1"), 8765, 256, 0)
             )
         }
+    }
+
+    @Test
+    fun `WrongVersion carries found and expected version bytes`() {
+        val valid = BleDiscoveryContract.encode(
+            BleDiscoveryContract.Payload(ipv4("10.0.0.1"), 8765, 50, 0)
+        )
+        valid[0] = 42
+        val result = BleDiscoveryContract.decode(valid)
+        assertTrue(result is BleDiscoveryContract.DecodeResult.WrongVersion)
+        result as BleDiscoveryContract.DecodeResult.WrongVersion
+        assertEquals(42.toByte(), result.found)
+        assertEquals(BleDiscoveryContract.PAYLOAD_SCHEMA_VERSION, result.expected)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Replaces the silent `Payload?` return type of `BleDiscoveryContract.decode()` with a `DecodeResult` sealed class (`Ok`, `WrongVersion`, `Truncated`, `MalformedIpv4`), making every failure mode explicit and distinguishable
- `PhoneBleScanner.handleResult()` now pattern-matches on the result and logs unexpected failures (`Truncated`, `MalformedIpv4`) via `DiagnosticLog.warn` and expected schema-version mismatches via `DiagnosticLog.debug`
- Test suite updated: `assertNull` checks replaced with typed assertions on `DecodeResult` variants; two additional tests added (`decode empty buffer returns Truncated`, `WrongVersion carries found and expected version bytes`)

Closes #534

## Test plan

- [ ] `BleDiscoveryContractTest` — all existing round-trip, encode, and rejection tests pass with new typed assertions
- [ ] New tests verify `Truncated` for null/empty/short input and `WrongVersion` carries the correct `found`/`expected` bytes
- [ ] CI `Test & Build` passes

> **Note:** Android SDK not available in this sandboxed environment — Gradle/detekt/lint checks were skipped locally. CI is the gate for Kotlin/Android validation.

https://claude.ai/code/session_01TAYMgWa4rN8Mv7LpvrkxBU

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAYMgWa4rN8Mv7LpvrkxBU)_