### PR TITLE
fix(core): add PII redactor to DiagnosticLog ring buffer

### DIFF
--- a/core/src/main/java/com/justb81/watchbuddy/core/logging/DiagnosticLog.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/logging/DiagnosticLog.kt
@@ -24,6 +24,11 @@ import java.util.TimeZone
  * Each entry is lightweight (timestamp + level + tag + message + optional throwable
  * summary) and all calls mirror to [android.util.Log] so logcat continues to work
  * unchanged during development.
+ *
+ * Every message and throwable summary is passed through the active [Redactor]
+ * before storage to prevent PII leakage via the share sheet (see issue #563).
+ * The default implementation is [DefaultRedactor]; tests may swap it via
+ * [setRedactorForTest].
  */
 object DiagnosticLog {
 
@@ -38,6 +43,8 @@ object DiagnosticLog {
     )
 
     private const val MAX_ENTRIES = 500
+
+    @Volatile private var redactor: Redactor = DefaultRedactor
 
     private val buffer = ArrayDeque<Entry>(MAX_ENTRIES)
     private val lock = Any()
@@ -77,6 +84,16 @@ object DiagnosticLog {
 
     fun clear() = synchronized(lock) { buffer.clear() }
 
+    /** Replaces the active [Redactor]; intended for tests only. */
+    internal fun setRedactorForTest(r: Redactor) {
+        redactor = r
+    }
+
+    /** Restores the default [Redactor]; intended for tests only. */
+    internal fun resetRedactorForTest() {
+        redactor = DefaultRedactor
+    }
+
     /** Renders the current buffer as a human-readable block for sharing. */
     fun formatForShare(): String {
         val entries = snapshot()
@@ -105,7 +122,7 @@ object DiagnosticLog {
             timestampMs = System.currentTimeMillis(),
             level = level,
             tag = tag,
-            message = message,
+            message = redactor.redact(message),
             throwableSummary = throwable?.let(::summarizeThrowable)
         )
         synchronized(lock) {
@@ -117,10 +134,9 @@ object DiagnosticLog {
     }
 
     private fun summarizeThrowable(t: Throwable): String {
-        val first = "${t.javaClass.name}: ${t.message ?: ""}".trim()
-        val topFrame = t.stackTrace.firstOrNull()?.let { "at $it" }
-        val cause = t.cause?.let { "caused by ${it.javaClass.simpleName}: ${it.message ?: ""}".trim() }
-        return listOfNotNull(first, topFrame, cause).joinToString("\n")
+        val typeName = t::class.qualifiedName ?: t.javaClass.name
+        val message = t.message?.take(200)?.let { redactor.redact(it) } ?: ""
+        return if (message.isEmpty()) typeName else "$typeName: $message"
     }
 
     private fun mirrorToLogcat(entry: Entry, throwable: Throwable?) {

--- a/core/src/main/java/com/justb81/watchbuddy/core/logging/DiagnosticLog.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/logging/DiagnosticLog.kt
@@ -43,6 +43,7 @@ object DiagnosticLog {
     )
 
     private const val MAX_ENTRIES = 500
+    private const val MAX_THROWABLE_MESSAGE_CHARS = 200
 
     @Volatile private var redactor: Redactor = DefaultRedactor
 
@@ -135,7 +136,7 @@ object DiagnosticLog {
 
     private fun summarizeThrowable(t: Throwable): String {
         val typeName = t::class.qualifiedName ?: t.javaClass.name
-        val message = t.message?.take(200)?.let { redactor.redact(it) } ?: ""
+        val message = t.message?.take(MAX_THROWABLE_MESSAGE_CHARS)?.let { redactor.redact(it) } ?: ""
         return if (message.isEmpty()) typeName else "$typeName: $message"
     }
 

--- a/core/src/main/java/com/justb81/watchbuddy/core/logging/DiagnosticRedactor.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/logging/DiagnosticRedactor.kt
@@ -25,13 +25,13 @@ fun interface Redactor {
 object DefaultRedactor : Redactor {
 
     private val BEARER_TOKEN = Regex("""Bearer\s+\S+""", RegexOption.IGNORE_CASE)
-    private val ACCESS_TOKEN = Regex("""access_token=[^&\s"']+""", RegexOption.IGNORE_CASE)
+    private val ACCESS_TOKEN = Regex("""(access_token=)[^&\s"']+""", RegexOption.IGNORE_CASE)
     private val MAC_ADDRESS = Regex("""[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}""")
     private val IP_IN_URL = Regex("""(https?://)\d{1,3}(?:\.\d{1,3}){3}""", RegexOption.IGNORE_CASE)
 
     override fun redact(input: String): String = input
         .replace(BEARER_TOKEN, "Bearer [REDACTED]")
-        .replace(ACCESS_TOKEN, "access_token=[REDACTED]")
+        .replace(ACCESS_TOKEN) { match -> "${match.groupValues[1]}[REDACTED]" }
         .replace(MAC_ADDRESS, "[MAC_REDACTED]")
         .replace(IP_IN_URL) { match -> "${match.groupValues[1]}[IP_REDACTED]" }
 }

--- a/core/src/main/java/com/justb81/watchbuddy/core/logging/DiagnosticRedactor.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/logging/DiagnosticRedactor.kt
@@ -1,0 +1,37 @@
+package com.justb81.watchbuddy.core.logging
+
+/**
+ * Strips known PII patterns from a string before it is stored in the
+ * [DiagnosticLog] ring buffer.
+ *
+ * The default implementation ([DefaultRedactor]) covers the four most likely
+ * leak vectors; callers can supply their own instance via
+ * [DiagnosticLog.setRedactorForTest] if test fixtures need deterministic
+ * sanitisation.
+ */
+fun interface Redactor {
+    fun redact(input: String): String
+}
+
+/**
+ * Default [Redactor] applied to every [DiagnosticLog] entry.
+ *
+ * Rules applied in order:
+ * - `Bearer <token>` → `Bearer [REDACTED]`
+ * - `access_token=<value>` → `access_token=[REDACTED]`
+ * - MAC / BSSID patterns (six colon-separated hex octets) → `[MAC_REDACTED]`
+ * - IP address inside a URL → `[IP_REDACTED]`
+ */
+object DefaultRedactor : Redactor {
+
+    private val BEARER_TOKEN = Regex("""Bearer\s+\S+""", RegexOption.IGNORE_CASE)
+    private val ACCESS_TOKEN = Regex("""access_token=[^&\s"']+""", RegexOption.IGNORE_CASE)
+    private val MAC_ADDRESS = Regex("""[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}""")
+    private val IP_IN_URL = Regex("""(https?://)\d{1,3}(?:\.\d{1,3}){3}""", RegexOption.IGNORE_CASE)
+
+    override fun redact(input: String): String = input
+        .replace(BEARER_TOKEN, "Bearer [REDACTED]")
+        .replace(ACCESS_TOKEN, "access_token=[REDACTED]")
+        .replace(MAC_ADDRESS, "[MAC_REDACTED]")
+        .replace(IP_IN_URL) { match -> "${match.groupValues[1]}[IP_REDACTED]" }
+}

--- a/core/src/test/java/com/justb81/watchbuddy/core/logging/DiagnosticLogRedactionTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/logging/DiagnosticLogRedactionTest.kt
@@ -1,0 +1,145 @@
+package com.justb81.watchbuddy.core.logging
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("DiagnosticLog — PII redaction applied on write (#563)")
+class DiagnosticLogRedactionTest {
+
+    @BeforeEach
+    fun setUp() {
+        DiagnosticLog.clear()
+        DiagnosticLog.resetRedactorForTest()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        DiagnosticLog.clear()
+        DiagnosticLog.resetRedactorForTest()
+    }
+
+    // ── Bearer token ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `Bearer token in event message is redacted in snapshot`() {
+        DiagnosticLog.event("Auth", "response: Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig")
+        val entry = DiagnosticLog.snapshot().last()
+        assertFalse(entry.message.contains("eyJhbGciOiJSUzI1NiJ9"), "Raw token must not appear in snapshot")
+        assertTrue(entry.message.contains("[REDACTED]"))
+    }
+
+    // ── access_token ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `access_token in error message is redacted in snapshot`() {
+        DiagnosticLog.error("Network", "failed: https://api.trakt.tv/auth?access_token=supersecret123")
+        val entry = DiagnosticLog.snapshot().last()
+        assertFalse(entry.message.contains("supersecret123"), "Token value must not appear in snapshot")
+        assertTrue(entry.message.contains("access_token=[REDACTED]"))
+    }
+
+    // ── MAC / BSSID ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `BSSID in warn message is redacted in snapshot`() {
+        DiagnosticLog.warn("BLE", "connected to AA:BB:CC:DD:EE:FF")
+        val entry = DiagnosticLog.snapshot().last()
+        assertFalse(entry.message.contains("AA:BB:CC:DD:EE:FF"), "BSSID must not appear in snapshot")
+        assertTrue(entry.message.contains("[MAC_REDACTED]"))
+    }
+
+    // ── IP in URL ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `IP address in URL is redacted in debug message`() {
+        DiagnosticLog.debug("HTTP", "connecting to http://192.168.1.100:8765/capability")
+        val entry = DiagnosticLog.snapshot().last()
+        assertFalse(entry.message.contains("192.168.1.100"), "IP address must not appear in snapshot")
+        assertTrue(entry.message.contains("[IP_REDACTED]"))
+    }
+
+    // ── Throwable summarisation ───────────────────────────────────────────────
+
+    @Test
+    fun `throwable summary contains no stack trace frames`() {
+        val exception = RuntimeException("connection refused to http://10.0.0.1:8765")
+        DiagnosticLog.error("HTTP", "request failed", exception)
+        val entry = DiagnosticLog.snapshot().last()
+        val summary = entry.throwableSummary
+        assertNotNull(summary)
+        assertFalse(summary!!.contains("at com."), "Stack frame must not appear in throwable summary")
+        assertFalse(summary.contains("at java."), "Stack frame must not appear in throwable summary")
+        assertFalse(summary.contains(".kt:"), "Stack frame line number must not appear")
+    }
+
+    @Test
+    fun `throwable summary contains only class name and redacted truncated message`() {
+        val exception = RuntimeException("Bearer tok_secret_abc123 caused the error")
+        DiagnosticLog.error("tag", "failed", exception)
+        val entry = DiagnosticLog.snapshot().last()
+        val summary = entry.throwableSummary!!
+        assertTrue(summary.contains("RuntimeException"), "Class name must appear")
+        assertFalse(summary.contains("tok_secret_abc123"), "Raw Bearer payload must not appear")
+        assertTrue(summary.contains("[REDACTED]"), "Redacted placeholder must appear")
+    }
+
+    @Test
+    fun `throwable message longer than 200 chars is truncated`() {
+        val longMessage = "x".repeat(300)
+        val exception = RuntimeException(longMessage)
+        DiagnosticLog.error("tag", "failed", exception)
+        val summary = entry().throwableSummary!!
+        val messageInSummary = summary.substringAfter(": ")
+        assertTrue(messageInSummary.length <= 200, "Throwable message must be capped at 200 characters")
+    }
+
+    @Test
+    fun `throwable with no message produces summary with only class name`() {
+        val exception = RuntimeException()
+        DiagnosticLog.error("tag", "failed", exception)
+        val summary = entry().throwableSummary!!
+        assertTrue(summary.contains("RuntimeException"))
+        assertFalse(summary.contains(":"), "No colon separator when there is no message")
+    }
+
+    // ── formatForShare ────────────────────────────────────────────────────────
+
+    @Test
+    fun `formatForShare output contains no raw PII from messages`() {
+        DiagnosticLog.event("Auth", "token: Bearer secret_abc")
+        DiagnosticLog.event("BLE", "bssid: AA:BB:CC:DD:EE:FF")
+        val output = DiagnosticLog.formatForShare()
+        assertFalse(output.contains("secret_abc"), "Raw Bearer value must not appear in share output")
+        assertFalse(output.contains("AA:BB:CC:DD:EE:FF"), "BSSID must not appear in share output")
+    }
+
+    // ── Custom redactor ───────────────────────────────────────────────────────
+
+    @Test
+    fun `custom redactor is applied when set`() {
+        DiagnosticLog.setRedactorForTest { input -> input.replace("password", "***") }
+        DiagnosticLog.event("tag", "user entered password correctly")
+        val entry = DiagnosticLog.snapshot().last()
+        assertFalse(entry.message.contains("password"), "Custom redactor must have replaced the word")
+        assertTrue(entry.message.contains("***"))
+    }
+
+    @Test
+    fun `resetRedactorForTest restores default redactor`() {
+        DiagnosticLog.setRedactorForTest { "static" }
+        DiagnosticLog.resetRedactorForTest()
+        DiagnosticLog.event("tag", "Bearer secret123 present")
+        val entry = DiagnosticLog.snapshot().last()
+        assertFalse(entry.message.contains("secret123"), "Default redactor must be active after reset")
+        assertTrue(entry.message.contains("[REDACTED]"))
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private fun entry(): DiagnosticLog.Entry = DiagnosticLog.snapshot().last()
+}

--- a/core/src/test/java/com/justb81/watchbuddy/core/logging/DiagnosticRedactorTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/logging/DiagnosticRedactorTest.kt
@@ -1,0 +1,126 @@
+package com.justb81.watchbuddy.core.logging
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("DefaultRedactor — PII pattern scrubbing (#563)")
+class DiagnosticRedactorTest {
+
+    // ── Bearer tokens ────────────────────────────────────────────────────────
+
+    @Test
+    fun `Bearer token is replaced`() {
+        val result = DefaultRedactor.redact("auth: Bearer eyJhbGciOiJSUzI1NiJ9.payload.sig")
+        assertEquals("auth: Bearer [REDACTED]", result)
+    }
+
+    @Test
+    fun `Bearer token is case-insensitive`() {
+        val result = DefaultRedactor.redact("BEARER abc123token")
+        assertEquals("Bearer [REDACTED]", result)
+    }
+
+    @Test
+    fun `Bearer token at end of string is replaced`() {
+        val result = DefaultRedactor.redact("header value: Bearer tok3n_with-special.chars")
+        assertFalse(result.contains("tok3n_with-special.chars"))
+        assertTrue(result.contains("[REDACTED]"))
+    }
+
+    // ── access_token ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `access_token query param is replaced`() {
+        val result = DefaultRedactor.redact("https://api.example.com/data?access_token=s3cr3t&foo=bar")
+        assertEquals("https://api.example.com/data?access_token=[REDACTED]&foo=bar", result)
+    }
+
+    @Test
+    fun `access_token is case-insensitive`() {
+        val result = DefaultRedactor.redact("ACCESS_TOKEN=mytoken123")
+        assertEquals("ACCESS_TOKEN=[REDACTED]", result)
+    }
+
+    @Test
+    fun `access_token value at end of string is replaced`() {
+        val result = DefaultRedactor.redact("request: access_token=end_value")
+        assertFalse(result.contains("end_value"))
+        assertTrue(result.contains("access_token=[REDACTED]"))
+    }
+
+    // ── MAC / BSSID addresses ─────────────────────────────────────────────────
+
+    @Test
+    fun `BSSID MAC address is replaced`() {
+        val result = DefaultRedactor.redact("connected to BSSID: AA:BB:CC:DD:EE:FF")
+        assertEquals("connected to BSSID: [MAC_REDACTED]", result)
+    }
+
+    @Test
+    fun `lowercase MAC address is replaced`() {
+        val result = DefaultRedactor.redact("bssid=aa:bb:cc:dd:ee:ff")
+        assertEquals("bssid=[MAC_REDACTED]", result)
+    }
+
+    @Test
+    fun `mixed-case MAC address is replaced`() {
+        val result = DefaultRedactor.redact("mac: 0A:1b:2C:3d:4E:5f")
+        assertEquals("mac: [MAC_REDACTED]", result)
+    }
+
+    @Test
+    fun `short hex sequence that is not a full MAC is not replaced`() {
+        val result = DefaultRedactor.redact("partial: AA:BB:CC:DD:EE")
+        assertEquals("partial: AA:BB:CC:DD:EE", result)
+    }
+
+    // ── IP address in URL ─────────────────────────────────────────────────────
+
+    @Test
+    fun `IP address in http URL is replaced`() {
+        val result = DefaultRedactor.redact("connecting to http://192.168.1.100:8765/capability")
+        assertEquals("connecting to http://[IP_REDACTED]:8765/capability", result)
+    }
+
+    @Test
+    fun `IP address in https URL is replaced`() {
+        val result = DefaultRedactor.redact("endpoint: https://10.0.0.1/api/v1")
+        assertEquals("endpoint: https://[IP_REDACTED]/api/v1", result)
+    }
+
+    @Test
+    fun `IP address not in a URL is not replaced`() {
+        val result = DefaultRedactor.redact("address: 192.168.1.100")
+        assertEquals("address: 192.168.1.100", result)
+    }
+
+    // ── Multiple patterns in one string ───────────────────────────────────────
+
+    @Test
+    fun `multiple PII patterns in one string are all replaced`() {
+        val input = "token=Bearer abc123 bssid=AA:BB:CC:DD:EE:FF url=http://10.0.0.1/api"
+        val result = DefaultRedactor.redact(input)
+        assertFalse(result.contains("abc123"))
+        assertFalse(result.contains("AA:BB:CC:DD:EE:FF"))
+        assertFalse(result.contains("10.0.0.1"))
+        assertTrue(result.contains("[REDACTED]"))
+        assertTrue(result.contains("[MAC_REDACTED]"))
+        assertTrue(result.contains("[IP_REDACTED]"))
+    }
+
+    // ── Clean strings pass through unchanged ──────────────────────────────────
+
+    @Test
+    fun `clean string passes through unchanged`() {
+        val input = "HTTP server started on port 8765"
+        assertEquals(input, DefaultRedactor.redact(input))
+    }
+
+    @Test
+    fun `empty string passes through unchanged`() {
+        assertEquals("", DefaultRedactor.redact(""))
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `Redactor` / `DefaultRedactor` in `core/logging/DiagnosticRedactor.kt`. Every entry written to `DiagnosticLog` is now passed through the active redactor before being stored in the ring buffer. Default rules strip: Bearer tokens, `access_token=` query params, BSSID/MAC addresses, and IP addresses embedded in URLs.
- Fixes `summarizeThrowable` to store only `e::class.qualifiedName + e.message?.take(200)` (redacted) — never a raw stack trace, top frame, or cause chain.
- Adds `setRedactorForTest` / `resetRedactorForTest` internal helpers so tests can inject custom redactors and restore the default.
- Adds `DiagnosticRedactorTest` (pattern-level unit tests for all four rules) and `DiagnosticLogRedactionTest` (end-to-end: writes known-bad strings and asserts they are absent from both the snapshot and `formatForShare` output).

## Test plan

- [ ] `DiagnosticRedactorTest`: Bearer, access_token, MAC, IP-in-URL rules each verified in isolation; multi-pattern string; clean strings pass through unchanged
- [ ] `DiagnosticLogRedactionTest`: each log level (event/warn/error/debug) verified; throwable summary contains no stack frames; `formatForShare` output is PII-free; custom redactor injection / reset cycle

> Note: Gradle scope was skipped locally (no Android SDK in this environment). CI (`Test & Build`) is the gate for Kotlin compilation, detekt, and unit tests.

Closes #563

https://claude.ai/code/session_016inwXtMrZXjkBWcQmVrsMM

---
_Generated by [Claude Code](https://claude.ai/code/session_016inwXtMrZXjkBWcQmVrsMM)_