### PR TITLE
fix(justwatch): update technicalName keys to match current JustWatch API

### DIFF
--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/data/JustWatchDeepLinkRepositoryTest.kt
@@ -122,7 +122,7 @@ class JustWatchDeepLinkRepositoryTest {
 
     private fun makeOffer(
         url: String = "https://www.netflix.com/watch/99",
-        technicalName: String = "nfx",
+        technicalName: String = "netflix",
         monetizationType: String = "FLATRATE",
     ) = JustWatchOffer(
         standardWebURL = url,
@@ -380,7 +380,7 @@ class JustWatchDeepLinkRepositoryTest {
         fun `filters out non-FLATRATE-ADS-FREE offers`() = runTest {
             val rentalOffer = makeOffer(
                 url = "https://www.amazon.com/rent/99",
-                technicalName = "atp",
+                technicalName = "appletvplus",
                 monetizationType = "RENT",
             )
             coEvery { dao.get(100, 1, 2, 350, "US") } returns null andThen null

--- a/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMap.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMap.kt
@@ -13,19 +13,19 @@ object JustWatchPackageMap {
     private const val TAG = "JustWatchPackageMap"
 
     val technicalNameToProviderId: Map<String, Int> = mapOf(
-        "netflix"                 to 8,    // Netflix
-        "netflixbasicwithads"     to 8,    // Netflix with Ads (same app)
-        "amazonprime"             to 119,  // Prime Video
-        "amazonprimevideowithads" to 119,  // Prime Video with Ads (same app)
-        "disneyplus"              to 337,  // Disney+
-        "appletvplus"             to 350,  // Apple TV+
-        "paramountplus"           to 531,  // Paramount+
-        "max"                     to 1899, // Max (HBO Max)
-        "joynde"                  to 2184, // Joyn
-        "daserstemediathek"       to 195,  // ARD Mediathek (free)
-        "ardplus"                 to 195,  // ARD+ (paid tier, same Android app)
-        "zdf"                     to 231,  // ZDF Mediathek
-        "youtubered"              to 192,  // YouTube Premium
+        "netflix" to 8, // Netflix
+        "netflixbasicwithads" to 8, // Netflix with Ads (same app)
+        "amazonprime" to 119, // Prime Video
+        "amazonprimevideowithads" to 119, // Prime Video with Ads (same app)
+        "disneyplus" to 337, // Disney+
+        "appletvplus" to 350, // Apple TV+
+        "paramountplus" to 531, // Paramount+
+        "max" to 1899, // Max (HBO Max)
+        "joynde" to 2184, // Joyn
+        "daserstemediathek" to 195, // ARD Mediathek (free)
+        "ardplus" to 195, // ARD+ (paid tier, same Android app)
+        "zdf" to 231, // ZDF Mediathek
+        "youtubered" to 192, // YouTube Premium
     )
 
     fun resolveProviderId(technicalName: String): Int? {

--- a/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMap.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMap.kt
@@ -13,21 +13,19 @@ object JustWatchPackageMap {
     private const val TAG = "JustWatchPackageMap"
 
     val technicalNameToProviderId: Map<String, Int> = mapOf(
-        "nfx" to 8, // Netflix
-        "prv" to 119, // Prime Video
-        "dnp" to 337, // Disney+
-        "atp" to 350, // Apple TV+
-        "pmp" to 531, // Paramount+
-        "hbm" to 1899, // Max (legacy HBO Max id)
-        "max" to 1899, // Max
-        "jyn" to 2184, // Joyn
-        "wpu" to 2187, // WaipuTV
-        "ard" to 195, // ARD Mediathek
-        "zdf" to 231, // ZDF Mediathek
-        // YouTube: JustWatch has shuffled aliases over time; map all known variants to TMDB 192
-        "yti" to 192, // YouTube (primary alias)
-        "yot" to 192, // YouTube (alternate alias)
-        "ytv" to 192, // YouTube (TV variant alias)
+        "netflix"                 to 8,    // Netflix
+        "netflixbasicwithads"     to 8,    // Netflix with Ads (same app)
+        "amazonprime"             to 119,  // Prime Video
+        "amazonprimevideowithads" to 119,  // Prime Video with Ads (same app)
+        "disneyplus"              to 337,  // Disney+
+        "appletvplus"             to 350,  // Apple TV+
+        "paramountplus"           to 531,  // Paramount+
+        "max"                     to 1899, // Max (HBO Max)
+        "joynde"                  to 2184, // Joyn
+        "daserstemediathek"       to 195,  // ARD Mediathek (free)
+        "ardplus"                 to 195,  // ARD+ (paid tier, same Android app)
+        "zdf"                     to 231,  // ZDF Mediathek
+        "youtubered"              to 192,  // YouTube Premium
     )
 
     fun resolveProviderId(technicalName: String): Int? {

--- a/core/src/test/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMapTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/justwatch/JustWatchPackageMapTest.kt
@@ -26,36 +26,33 @@ class JustWatchPackageMapTest {
 
     @ParameterizedTest(name = "{0} → TMDB {1}")
     @CsvSource(
-        "nfx, 8",
-        "prv, 119",
-        "dnp, 337",
-        "atp, 350",
-        "pmp, 531",
-        "hbm, 1899",
+        "netflix, 8",
+        "netflixbasicwithads, 8",
+        "amazonprime, 119",
+        "amazonprimevideowithads, 119",
+        "disneyplus, 337",
+        "appletvplus, 350",
+        "paramountplus, 531",
         "max, 1899",
-        "jyn, 2184",
-        "wpu, 2187",
-        "ard, 195",
+        "joynde, 2184",
+        "daserstemediathek, 195",
+        "ardplus, 195",
         "zdf, 231",
-        "yti, 192",
-        "yot, 192",
-        "ytv, 192",
+        "youtubered, 192",
     )
     fun `resolves known technical names to TMDB provider ids`(technicalName: String, expectedId: Int) {
         assertEquals(expectedId, JustWatchPackageMap.resolveProviderId(technicalName))
     }
 
     @Test
-    fun `youtubeAliasesResolveToProvider192`() {
-        assertEquals(192, JustWatchPackageMap.resolveProviderId("yti"))
-        assertEquals(192, JustWatchPackageMap.resolveProviderId("yot"))
-        assertEquals(192, JustWatchPackageMap.resolveProviderId("ytv"))
+    fun `youtubeRedResolvesToProvider192`() {
+        assertEquals(192, JustWatchPackageMap.resolveProviderId("youtubered"))
     }
 
     @Test
     fun `resolveProviderId is case-insensitive`() {
-        assertEquals(8, JustWatchPackageMap.resolveProviderId("NFX"))
-        assertEquals(8, JustWatchPackageMap.resolveProviderId("Nfx"))
+        assertEquals(8, JustWatchPackageMap.resolveProviderId("NETFLIX"))
+        assertEquals(8, JustWatchPackageMap.resolveProviderId("Netflix"))
     }
 
     @Test
@@ -77,7 +74,7 @@ class JustWatchPackageMapTest {
 
     @Test
     fun `resolveProviderId does not log a warning for known technical names`() {
-        JustWatchPackageMap.resolveProviderId("nfx")
+        JustWatchPackageMap.resolveProviderId("netflix")
 
         val warnings = DiagnosticLog.snapshot().filter {
             it.level == DiagnosticLog.Level.WARN
@@ -100,7 +97,7 @@ class JustWatchPackageMapTest {
 
     @Test
     fun `map does not contain duplicates for known entries`() {
-        // hbm and max both map to 1899 — that is intentional, not a bug
+        // Multiple keys sharing a TMDB id (e.g. netflix/netflixbasicwithads → 8) is intentional
         val uniqueEntries = JustWatchPackageMap.technicalNameToProviderId.keys
         assertEquals(uniqueEntries.size, uniqueEntries.toSet().size)
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -385,7 +385,7 @@ The available-provider list for each show is fetched from TMDB `/tv/{id}/watch/p
 
 **Batch dedup:** A `Mutex`-protected `Map<FetchKey, Mutex>` prevents duplicate in-flight JustWatch API calls when multiple coroutines request the same `(showId, season, episode, countryCode)` simultaneously. After acquiring the per-key lock, the cache is re-checked before calling the API.
 
-**Provider mapping:** `JustWatchPackageMap` (`core/justwatch/`) maps JustWatch `technicalName` strings (e.g. `nfx`, `prv`, `dnp`) to TMDB `provider_id` integers. The same map drives negative-cache writes for known-but-absent providers.
+**Provider mapping:** `JustWatchPackageMap` (`core/justwatch/`) maps JustWatch `technicalName` strings (e.g. `netflix`, `amazonprime`, `disneyplus`) to TMDB `provider_id` integers. The same map drives negative-cache writes for known-but-absent providers.
 
 **ViewModel integration:** `ShowDetailViewModel.loadDeepLinks()` is triggered once `ProviderListUiState.Success` arrives. Each provider gets a `viewModelScope.async` backed by `JustWatchDeepLinkRepository`; in-flight dedup at the ViewModel level prevents duplicate `Deferred` jobs per key. State is `deepLinks: StateFlow<Map<Int, DeepLinkState>>` with `DeepLinkState = Loading | Available(url) | Unavailable`. The UI shows a spinner overlay on loading chips, disables unavailable chips, and displays a JustWatch attribution badge when any link is `Available`.
 

--- a/docs/tmdb-integration.md
+++ b/docs/tmdb-integration.md
@@ -184,7 +184,7 @@ flowchart TD
 ```
 
 `ProviderCatalog` maps TMDB `provider_id` integers to Android package names so deep links can be
-attributed to the correct app. JustWatch `technicalName` strings (e.g. `nfx`, `prv`, `dnp`) are
+attributed to the correct app. JustWatch `technicalName` strings (e.g. `netflix`, `amazonprime`, `disneyplus`) are
 translated to TMDB `provider_id` integers by `JustWatchPackageMap`.
 
 Note: This journey calls the JustWatch GraphQL API, not the TMDB API. TMDB data (the TMDB show ID


### PR DESCRIPTION
## Summary

- Replaces all stale short-code keys (`nfx`, `dnp`, `prv`, `atp`, `pmp`, `jyn`, `ard`, `yti`/`yot`/`ytv`) in `JustWatchPackageMap` with the full provider slugs the JustWatch GraphQL API actually returns today
- Adds two missing ad-tier entries: `netflixbasicwithads` and `amazonprimevideowithads` (both map to the same TMDB provider ID as the base tier)
- Adds `ardplus` (ARD+ paid subscription, same Android app as ARD Mediathek → TMDB 195)
- Removes stale aliases `hbm` (replaced by `max` in the API) and `wpu` (Waipu.tv is IPTV-only and never appears in JustWatch VOD responses)

All corrections were verified via live GraphQL queries against `apis.justwatch.com` for country `DE` on 2026-05-02. The two screenshots attached to the issue showed `disneyplus`, `netflix`, and `netflixbasicwithads` as the first unmapped names hitting the diagnostic log.

## Providers verified via live API

| technicalName | TMDB ID | Verified with show |
|---|---|---|
| `netflix` | 8 | Stranger Things |
| `netflixbasicwithads` | 8 | Stranger Things |
| `amazonprime` | 119 | The Boys |
| `amazonprimevideowithads` | 119 | The Boys |
| `disneyplus` | 337 | The Mandalorian |
| `appletvplus` | 350 | Ted Lasso |
| `paramountplus` | 531 | 1883 |
| `max` | 1899 | Game of Thrones, The Last of Us |
| `joynde` | 2184 | Germany's Next Topmodel |
| `daserstemediathek` | 195 | Charité, In aller Freundschaft |
| `ardplus` | 195 | In aller Freundschaft, Lindenstraße |
| `zdf` | 231 | Der Staatsanwalt, Der Bergdoktor |
| `youtubered` | 192 | Wayne |

## Test plan

- [ ] Open TV app on a Netflix show (e.g. TMDB 66732 "Stranger Things") — deep link button appears and opens `com.netflix.ninja`
- [ ] Open TV app on a Disney+ show (e.g. TMDB 82856 "The Mandalorian") — opens `com.disney.disneyplus`
- [ ] Open TV app on a Prime Video show (e.g. TMDB 73586 "The Boys") — opens `com.amazon.amazonvideo.livingroom`
- [ ] DiagnosticsScreen shows no `unmapped technicalName` warnings for the above providers
- [ ] CI (`build-android.yml`) passes

> **Note:** Gradle scope was skipped locally (no Android SDK in this environment). CI is the real gate for Kotlin/detekt/lint checks.

https://claude.ai/code/session_01HGFuJ32fzTFpA3JHatYiJc

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGFuJ32fzTFpA3JHatYiJc)_