### PR TITLE
chore: fix Gradle deprecations and upgrade wrapper to 9.5.0

### DIFF
--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -3,6 +3,7 @@ import com.github.triplet.gradle.androidpublisher.ResolutionStrategy
 
 plugins {
     id("watchbuddy.android.application")
+    id("watchbuddy.detekt")
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.gradle.play.publisher)

--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -123,11 +123,9 @@ dependencies {
 // applicationId requires a single release on the track.
 play {
     serviceAccountCredentials.set(
-        layout.file(
-            providers.environmentVariable("GOOGLE_PLAY_SERVICE_ACCOUNT_FILE")
-                .orElse("/dev/null")
-                .map { file(it) }
-        )
+        providers.environmentVariable("GOOGLE_PLAY_SERVICE_ACCOUNT_FILE")
+            .orElse("/dev/null")
+            .map { path -> layout.projectDirectory.file(path) }
     )
 
     track.set(providers.gradleProperty("playTrack").orElse("internal"))

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("watchbuddy.android.application")
+    id("watchbuddy.detekt")
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.kotlin.serialization)
 }
@@ -78,6 +79,6 @@ dependencies {
 // issue #232 and the 0.12.0 trace on #244). Dropping the group removes both
 // the DEX classes and the merged-manifest contribution, so WorkManager cannot
 // be registered as an androidx.startup initializer in the first place.
-configurations.configureEach {
+configurations.all {
     exclude(group = "androidx.work")
 }

--- a/app-tv/build.gradle.kts
+++ b/app-tv/build.gradle.kts
@@ -78,6 +78,6 @@ dependencies {
 // issue #232 and the 0.12.0 trace on #244). Dropping the group removes both
 // the DEX classes and the merged-manifest contribution, so WorkManager cannot
 // be registered as an androidx.startup initializer in the first place.
-configurations.all {
+configurations.configureEach {
     exclude(group = "androidx.work")
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
     compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.ksp.gradlePlugin)
     compileOnly(libs.hilt.gradlePlugin)
+    compileOnly(libs.detekt.gradlePlugin)
 }

--- a/build-logic/convention/src/main/kotlin/watchbuddy.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/watchbuddy.android.application.gradle.kts
@@ -102,7 +102,7 @@ kotlin {
     }
 }
 
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }
 

--- a/build-logic/convention/src/main/kotlin/watchbuddy.android.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/watchbuddy.android.library.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
     }
 }
 
-tasks.withType<Test> {
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }
 

--- a/build-logic/convention/src/main/kotlin/watchbuddy.detekt.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/watchbuddy.detekt.gradle.kts
@@ -1,0 +1,39 @@
+import io.gitlab.arturbosch.detekt.Detekt
+import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import org.gradle.accessors.dm.LibrariesForLibs
+
+plugins {
+    id("io.gitlab.arturbosch.detekt")
+}
+
+val libs = the<LibrariesForLibs>()
+
+configure<DetektExtension> {
+    config.setFrom(files("${rootProject.projectDir}/config/detekt/detekt.yml"))
+    buildUponDefaultConfig = true
+    parallel = true
+    val moduleBaseline = file("detekt-baseline.xml")
+    if (moduleBaseline.exists()) {
+        baseline = moduleBaseline
+    }
+}
+
+dependencies {
+    add("detektPlugins", libs.detekt.formatting)
+}
+
+tasks.withType<Detekt>().configureEach {
+    jvmTarget = "17"
+    reports {
+        xml.required.set(true)
+        sarif.required.set(true)
+        html.required.set(true)
+        txt.required.set(false)
+        md.required.set(false)
+    }
+}
+
+tasks.withType<DetektCreateBaselineTask>().configureEach {
+    jvmTarget = "17"
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,53 +10,20 @@ plugins {
     alias(libs.plugins.detekt) apply false
 }
 
-// detekt is applied to every module holding Kotlin source. Config and baselines
-// live next to each module so a failing rule clearly identifies which module
-// violated it in CI output. See config/detekt/detekt.yml for the shared ruleset.
-val detektVersion = libs.versions.detekt.get()
-
-subprojects {
-    apply(plugin = "io.gitlab.arturbosch.detekt")
-
-    configure<io.gitlab.arturbosch.detekt.extensions.DetektExtension> {
-        config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
-        buildUponDefaultConfig = true
-        parallel = true
-        val moduleBaseline = file("detekt-baseline.xml")
-        if (moduleBaseline.exists()) {
-            baseline = moduleBaseline
-        }
-    }
-
-    dependencies {
-        add("detektPlugins", "io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion")
-    }
-
-    tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
-        jvmTarget = "17"
-        reports {
-            xml.required.set(true)
-            sarif.required.set(true)
-            html.required.set(true)
-            txt.required.set(false)
-            md.required.set(false)
-        }
-    }
-
-    tasks.withType<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>().configureEach {
-        jvmTarget = "17"
-    }
-}
+// detekt is configured per-module via the watchbuddy.detekt convention plugin.
+// Baselines live next to each module so a failing rule clearly identifies which
+// module violated it in CI output. See config/detekt/detekt.yml for the shared ruleset.
+val detektModules = listOf(":core", ":app-phone", ":app-tv")
 
 // Convenience aggregate tasks so CI can run every module's detekt in one shot.
 tasks.register("detektAll") {
     group = "verification"
     description = "Runs detekt on every subproject."
-    dependsOn(subprojects.map { "${it.path}:detekt" })
+    dependsOn(detektModules.map { "$it:detekt" })
 }
 
 tasks.register("detektBaselineAll") {
     group = "verification"
     description = "Regenerates detekt baselines for every subproject."
-    dependsOn(subprojects.map { "${it.path}:detektBaseline" })
+    dependsOn(detektModules.map { "$it:detektBaseline" })
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("watchbuddy.android.library")
+    id("watchbuddy.detekt")
     alias(libs.plugins.kotlin.serialization)
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,3 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.vfs.watch=true
 org.gradle.configuration-cache=true
-org.gradle.warning.mode=all

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,3 +17,4 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.vfs.watch=true
 org.gradle.configuration-cache=true
+org.gradle.warning.mode=all

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -130,6 +130,7 @@ android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", ver
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-gradlePlugin = { group = "com.google.devtools.ksp", name = "symbol-processing-gradle-plugin", version.ref = "ksp" }
 hilt-gradlePlugin = { group = "com.google.dagger", name = "hilt-android-gradle-plugin", version.ref = "hilt" }
+detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

- Upgrade Gradle wrapper from 9.4.1 → 9.5.0 (latest stable; Gradle 10 not yet released)
- Fix all deprecated Gradle API usages **in our own build scripts** that would break under Gradle 10
- Migrate detekt cross-project configuration from `subprojects {}` to a dedicated `watchbuddy.detekt` convention plugin

## Deprecations fixed

| Deprecated pattern | Fix | File(s) |
|---|---|---|
| `tasks.withType<Test> { }` — calls eager `withType(Class, Action)` overload, deprecated since Gradle 5.3 | `tasks.withType<Test>().configureEach { }` | Both convention plugins |
| `Project.file()` inside a `Provider.map {}` lambda — `Project` is not CC-serialisable when captured at execution time | `layout.projectDirectory.file(path)` | `app-phone/build.gradle.kts` |
| `subprojects {}` cross-project configuration — deprecated in Gradle 9.5 | New `watchbuddy.detekt.gradle.kts` convention plugin applied per-module | `build.gradle.kts`, all module build files |
| `subprojects.map {}` inside `tasks.register {}` — cross-project state access at configuration time | Hardcoded module list `listOf(":core", ":app-phone", ":app-tv")` | `build.gradle.kts` |

## Known remaining deprecation (third-party)

`detekt 1.23.8` internally calls `ReportingExtension.file(String)`, which Gradle 9.5 deprecated for removal in Gradle 10. This is inside the detekt plugin's own code and cannot be fixed in our build scripts. The latest stable detekt (1.23.8) does not address it; `detekt 2.0.0` is still in alpha with breaking changes. The build continues to show:

> Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

This will be resolved by upgrading detekt once a stable Gradle-10-compatible release is available.

## Code scanning "configurations not found"

The lint baselines (`app-phone/lint-baseline.xml`, `app-tv/lint-baseline.xml`) each contain 39 stale entries that no longer match any current finding — GitHub code scanning surfaces this as "configurations not found". The baselines are overly conservative (nothing is suppressed that shouldn't be); they should be regenerated locally with `./gradlew :app-phone:updateLintBaseline :app-tv:updateLintBaseline` in a follow-up.

## Test plan

- [x] `Test & Build` CI passes (unit tests, detekt, Android Lint)
- [x] All SARIF reports uploaded — "Android Lint" and "detekt" code-scanning checks are `neutral` (no new errors)
- [x] `./scripts/precommit.sh` — Gradle scope skipped (no Android SDK in sandbox); CI is the gate

https://claude.ai/code/session_01KzFXy1EFzZ7HcxQvrfqdW3