### PR TITLE
fix(ci): rebase before push in stats workflow to avoid non-fast-forward failures

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -67,4 +67,20 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add README.md
           git commit -m "chore(readme): refresh code statistics [skip ci]"
-          git push origin main
+
+          # Rebase onto the current remote HEAD before pushing to handle any
+          # commits that landed on main while tests were running (non-fast-forward guard).
+          for attempt in 1 2 3; do
+            git fetch origin main
+            git rebase origin/main
+            if git push origin main; then
+              echo "Pushed on attempt ${attempt}."
+              break
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Push attempt ${attempt} failed — retrying after rebase..."
+            else
+              echo "Push failed after 3 attempts."
+              exit 1
+            fi
+          done


### PR DESCRIPTION
## Summary

- The `stats.yml` "Commit and push if changed" step was doing a bare `git push origin main` after a multi-minute test run (`./gradlew testDebugUnitTest` + `npm test`).
- Any commit landing on `main` during that window (e.g. release-please, another PR merge) caused a non-fast-forward rejection — explaining why the workflow fails **regularly on the first run** but succeeds on a manual re-run (which starts from the current HEAD with a narrower race window).
- Fixed by replacing the bare push with a `git fetch origin main → git rebase origin/main → git push` loop, retried up to 3 times. The single stats commit is always replayed on top of the current remote HEAD before pushing.

> **Note:** The Gradle scope was not exercised locally (no Android SDK in this environment). CI (`build-android.yml`) is the gate for Kotlin/Android changes; this PR only touches `.github/workflows/stats.yml`, so no Android build is expected.

## Test plan

- [ ] Merge a PR that touches Android code so `build-android.yml` runs on `main` and triggers `stats.yml`
- [ ] Confirm `stats.yml` completes on its **first** attempt with log line `Pushed on attempt 1.`
- [ ] Alternatively, trigger via `workflow_dispatch` and verify the push step succeeds without retrying

https://claude.ai/code/session_01N9TXEtB5wVSNwHJUTJvH1G

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9TXEtB5wVSNwHJUTJvH1G)_