### PR TITLE
refactor(phone): remove unused GET /auth/token endpoint

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -62,7 +62,6 @@ private const val MAX_PAGE_SIZE = 200
  *   GET  /capability           → DeviceCapability (unauthenticated)
  *   GET  /shows                → List of watched shows for this user (from Trakt cache)
  *   POST /recap/{traktShowId}  → Generate + return HTML recap for a show
- *   GET  /auth/token           → Current access token for TV app usage (show search)
  *   POST /scrobble/start       → Forward scrobble start to this user's Trakt account
  *   POST /scrobble/pause       → Forward scrobble pause to this user's Trakt account
  *   POST /scrobble/stop        → Forward scrobble stop to this user's Trakt account
@@ -293,12 +292,6 @@ internal fun Application.configureCompanionRoutes(
             }
         }
 
-        get("/auth/token") {
-            val token = tokenRefreshManager.getValidAccessToken()
-                ?: return@get call.respond(HttpStatusCode.Unauthorized, ErrorResponse("No access token"))
-            call.respond(TokenResponse(accessToken = token))
-        }
-
         ScrobbleAction.entries.forEach { action ->
             post("/scrobble/${action.name.lowercase()}") {
                 call.handleScrobble(action, tokenRefreshManager, traktApiService, stateManager)
@@ -417,11 +410,6 @@ private suspend fun ApplicationCall.handleScrobble(
 @Serializable
 private data class RecapRequest(
     val tmdbApiKey: String = ""
-)
-
-@Serializable
-private data class TokenResponse(
-    val accessToken: String
 )
 
 @Serializable

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -669,32 +669,6 @@ class CompanionHttpServerTest {
         }
     }
 
-    // ── GET /auth/token ───────────────────────────────────────────────────────
-
-    @Nested
-    @DisplayName("GET /auth/token")
-    inner class AuthTokenEndpoint {
-
-        @Test
-        fun `returns 401 when token refresh returns null`() = testApp {
-            coEvery { tokenRefreshManager.getValidAccessToken() } returns null
-
-            val response = client.get("/auth/token")
-
-            assertEquals(HttpStatusCode.Unauthorized, response.status)
-        }
-
-        @Test
-        fun `returns 200 with valid access token after refresh`() = testApp {
-            coEvery { tokenRefreshManager.getValidAccessToken() } returns "my-secret-token"
-
-            val response = client.get("/auth/token")
-
-            assertEquals(HttpStatusCode.OK, response.status)
-            assertTrue(response.bodyAsText().contains("my-secret-token"))
-        }
-    }
-
     // ── POST /scrobble/start, /scrobble/pause, /scrobble/stop ────────────────
 
     @Nested

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,6 @@ distributed via BLE scan response; see above). Missing or wrong bearer returns H
 | GET | `/avatar` | Custom avatar JPEG (200 bytes, ETag-revalidated; 404 when `avatarSource != CUSTOM`) |
 | GET | `/shows` | User's Trakt watched shows (cached), paginated via `offset` + `limit` query params |
 | POST | `/recap/{traktShowId}` | Generate HTML recap for a show |
-| GET | `/auth/token` | Current Trakt access token (used by TV to obtain a token for authenticated calls) |
 | POST | `/scrobble/start` | Forward scrobble start to this user's Trakt account |
 | POST | `/scrobble/pause` | Forward scrobble pause to this user's Trakt account |
 | POST | `/scrobble/stop` | Forward scrobble stop to this user's Trakt account |

--- a/docs/trakt-flow.md
+++ b/docs/trakt-flow.md
@@ -108,7 +108,6 @@ flowchart TD
 | `GET` | `/capability` | Device info, LLM backend, RAM, model quality score, TMDB API key | No |
 | `GET` | `/shows` | User's Trakt watched shows (5-min cache) | Token required |
 | `POST` | `/recap/{traktShowId}` | Generate HTML recap via LLM | Token required |
-| `GET` | `/auth/token` | Return current Trakt access token | Token required |
 | `POST` | `/scrobble/start` | Forward scrobble start to Trakt | Token required |
 | `POST` | `/scrobble/pause` | Forward scrobble pause to Trakt | Token required |
 | `POST` | `/scrobble/stop` | Forward scrobble stop to Trakt | Token required |


### PR DESCRIPTION
## Summary

- `GET /auth/token` was defined in `CompanionHttpServer` but never called by the TV app — the TV proxies all Trakt operations through the phone's scrobble/shows endpoints, so a token-vending route was never needed
- Removes the route handler, the private `TokenResponse` data class, and its 2 unit tests
- Removes the endpoint from the HTTP API tables in `docs/architecture.md` and `docs/trakt-flow.md`

> **Note:** Gradle checks were skipped locally (no Android SDK in this environment). CI (`Test & Build`) is the gate for the Kotlin changes.

## Test plan

- [ ] CI `Test & Build` passes — confirms the deleted `TokenResponse` class isn't referenced anywhere and no compile errors were introduced
- [ ] `grep -r "auth/token" app-phone/ app-tv/ docs/` returns only the unrelated `/oauth/token` (Trakt OAuth) hits

https://claude.ai/code/session_01PeMNdZdy9M7qvUwWC2WMQs

---
_Generated by [Claude Code](https://claude.ai/code/session_01PeMNdZdy9M7qvUwWC2WMQs)_