### PR TITLE
fix: four quick-win security, stability, and test improvements (#530, #528, #536, #569)

### DIFF
--- a/app-phone/build.gradle.kts
+++ b/app-phone/build.gradle.kts
@@ -103,6 +103,9 @@ dependencies {
     // WorkManager (background model updates)
     implementation(libs.work.runtime)
 
+    // HTML sanitization for LLM recap output (prevents XSS in WebView)
+    implementation(libs.jsoup)
+
     // Security / Encrypted Storage (Tink AEAD + Android Keystore-wrapped KEK)
     implementation(libs.tink.android)
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/RecapGenerator.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/RecapGenerator.kt
@@ -7,6 +7,8 @@ import com.justb81.watchbuddy.core.locale.LocaleHelper
 import com.justb81.watchbuddy.core.model.TmdbEpisode
 import com.justb81.watchbuddy.core.model.TmdbShow
 import com.justb81.watchbuddy.core.tmdb.TmdbImageHelper
+import org.jsoup.Jsoup
+import org.jsoup.safety.Safelist
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -29,23 +31,21 @@ class RecapGenerator @Inject constructor(
         // TMDB still placeholder pattern: data-tmdb-still="S{season}E{episode}"
         private val STILL_PLACEHOLDER_REGEX = Regex("""data-tmdb-still="S(\d+)E(\d+)"""")
 
-        // HTML sanitization: strip dangerous tags and event handlers to prevent XSS
-        private val DANGEROUS_TAGS_REGEX = Regex(
-            """<\s*/?\s*(script|iframe|object|embed|form|link|meta|base|applet)\b[^>]*>""",
-            setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)
-        )
-        private val DANGEROUS_TAG_CONTENT_REGEX = Regex(
-            """<\s*(script|style)\b[^>]*>.*?<\s*/\s*\1\s*>""",
-            setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)
-        )
-        private val EVENT_HANDLER_REGEX = Regex(
-            """\s+on\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]*)""",
-            RegexOption.IGNORE_CASE
-        )
-        private val JAVASCRIPT_URL_REGEX = Regex(
-            """(href|src|action)\s*=\s*["']?\s*javascript:""",
-            RegexOption.IGNORE_CASE
-        )
+        // JSoup allowlist: only the tags the LLM slideshow template legitimately uses.
+        // Inline `style` is allowed on layout/text tags (needed for CSS slide animations).
+        // `<img data-tmdb-still="...">` placeholders are allowed here; the attribute is
+        // replaced with a real TMDB src= URL by replaceTmdbPlaceholders() afterwards.
+        private val RECAP_SAFELIST: Safelist = Safelist()
+            .addTags("div", "span", "p", "br",
+                     "h1", "h2", "h3", "strong", "em",
+                     "ul", "ol", "li", "img")
+            .addAttributes("div",  "style", "class")
+            .addAttributes("span", "style", "class")
+            .addAttributes("p",    "style", "class")
+            .addAttributes("h1",   "style")
+            .addAttributes("h2",   "style")
+            .addAttributes("h3",   "style")
+            .addAttributes("img",  "data-tmdb-still", "alt", "style")
     }
 
     /**
@@ -109,17 +109,7 @@ Respond in $language.
         )
     }
 
-    /**
-     * Strips dangerous HTML elements and attributes to prevent XSS when rendered in WebView.
-     * Removes: script/iframe/object/embed/form tags, on* event handlers, javascript: URLs.
-     */
-    private fun sanitizeHtml(html: String): String {
-        var sanitized = DANGEROUS_TAG_CONTENT_REGEX.replace(html, "")
-        sanitized = DANGEROUS_TAGS_REGEX.replace(sanitized, "")
-        sanitized = EVENT_HANDLER_REGEX.replace(sanitized, "")
-        sanitized = JAVASCRIPT_URL_REGEX.replace(sanitized, """$1="about:blank""")
-        return sanitized
-    }
+    private fun sanitizeHtml(html: String): String = Jsoup.clean(html, RECAP_SAFELIST)
 
     private fun replaceTmdbPlaceholders(
         html: String,

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/RecapGenerator.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/RecapGenerator.kt
@@ -39,13 +39,13 @@ class RecapGenerator @Inject constructor(
             .addTags("div", "span", "p", "br",
                      "h1", "h2", "h3", "strong", "em",
                      "ul", "ol", "li", "img")
-            .addAttributes("div",  "style", "class")
+            .addAttributes("div", "style", "class")
             .addAttributes("span", "style", "class")
-            .addAttributes("p",    "style", "class")
-            .addAttributes("h1",   "style")
-            .addAttributes("h2",   "style")
-            .addAttributes("h3",   "style")
-            .addAttributes("img",  "data-tmdb-still", "alt", "style")
+            .addAttributes("p", "style", "class")
+            .addAttributes("h1", "style")
+            .addAttributes("h2", "style")
+            .addAttributes("h3", "style")
+            .addAttributes("img", "data-tmdb-still", "alt", "style")
     }
 
     /**

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -183,8 +183,7 @@ internal fun Application.configureCompanionRoutes(
             if (!avatarImageStore.exists()) {
                 return@get call.respond(HttpStatusCode.NotFound, ErrorResponse("No custom avatar"))
             }
-            val version = settingsRepository.settings.first().customAvatarVersion
-            val etag = "\"$version\""
+            val etag = "\"${sha256Hex(file.readBytes())}\""
             if (call.request.headers[HttpHeaders.IfNoneMatch] == etag) {
                 return@get call.respond(HttpStatusCode.NotModified)
             }
@@ -405,6 +404,11 @@ private suspend fun ApplicationCall.handleScrobble(
         DiagnosticLog.error(TAG, "scrobble ${action.name.lowercase()} failed", e)
         respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Scrobble failed"))
     }
+}
+
+private fun sha256Hex(bytes: ByteArray): String {
+    val digest = java.security.MessageDigest.getInstance("SHA-256")
+    return digest.digest(bytes).joinToString("") { "%02x".format(it) }
 }
 
 @Serializable

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/EpisodeRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/EpisodeRepository.kt
@@ -32,7 +32,12 @@ class EpisodeRepository @Inject constructor(
 ) {
     private data class Cached(val fetchedAt: Long, val seasons: List<TraktSeasonWithEpisodes>)
 
-    private val cache = mutableMapOf<String, Cached>()
+    // LRU-capped map: evicts the least-recently-accessed entry once MAX_CACHE_SIZE is
+    // exceeded, bounding memory use for users with large Trakt libraries.
+    private val cache: MutableMap<String, Cached> =
+        object : LinkedHashMap<String, Cached>(MAX_CACHE_SIZE + 1, 0.75f, true) {
+            override fun removeEldestEntry(eldest: Map.Entry<String, Cached>) = size > MAX_CACHE_SIZE
+        }
     private val mutex = Mutex()
 
     suspend fun getSeasonsWithEpisodes(showId: String): List<TraktSeasonWithEpisodes> {
@@ -92,5 +97,6 @@ class EpisodeRepository @Inject constructor(
 
     private companion object {
         const val CACHE_TTL_MS = 10 * 60 * 1000L
+        const val MAX_CACHE_SIZE = 50
     }
 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/RecapGeneratorTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/RecapGeneratorTest.kt
@@ -123,7 +123,10 @@ class RecapGeneratorTest {
         fun `strips javascript URLs`() = runTest {
             val result = sanitize("""<a href="javascript:alert(1)">link</a>""")
             assertFalse(result.contains("javascript:"))
-            assertTrue(result.contains("about:blank"))
+            // JSoup removes <a> entirely (not in the allowlist), which is stricter than
+            // the old regex that replaced with about:blank; the link text is preserved.
+            assertFalse(result.contains("about:blank"))
+            assertTrue(result.contains("link"))
         }
 
         @Test

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -161,12 +161,16 @@ class CompanionHttpServerTest {
         }
 
         @Test
-        fun `returns 304 when request ETag matches stored version`() = testApp {
+        fun `returns 304 when request ETag matches file content hash`() = testApp {
+            val avatarBytes = byteArrayOf(0xFF.toByte(), 0xD8.toByte(), 0xFF.toByte())
+            val avatarFile = File(tempDir, "avatar_304.jpg").apply { writeBytes(avatarBytes) }
             every { avatarImageStore.exists() } returns true
-            every { settingsRepository.settings } returns flowOf(AppSettings(customAvatarVersion = 5L))
+            every { avatarImageStore.file() } returns avatarFile
+            val sha256 = java.security.MessageDigest.getInstance("SHA-256")
+                .digest(avatarBytes).joinToString("") { "%02x".format(it) }
 
             val response = client.get("/avatar") {
-                header(HttpHeaders.IfNoneMatch, "\"5\"")
+                header(HttpHeaders.IfNoneMatch, "\"$sha256\"")
             }
 
             assertEquals(HttpStatusCode.NotModified, response.status)
@@ -187,15 +191,17 @@ class CompanionHttpServerTest {
         }
 
         @Test
-        fun `sets ETag header matching current avatar version`() = testApp {
-            val avatarFile = File(tempDir, "avatar.jpg").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        fun `sets ETag header as SHA-256 of file content`() = testApp {
+            val avatarBytes = byteArrayOf(1, 2, 3)
+            val avatarFile = File(tempDir, "avatar.jpg").apply { writeBytes(avatarBytes) }
             every { avatarImageStore.exists() } returns true
             every { avatarImageStore.file() } returns avatarFile
-            every { settingsRepository.settings } returns flowOf(AppSettings(customAvatarVersion = 42L))
 
             val response = client.get("/avatar")
 
-            assertEquals("\"42\"", response.headers[HttpHeaders.ETag])
+            val sha256 = java.security.MessageDigest.getInstance("SHA-256")
+                .digest(avatarBytes).joinToString("") { "%02x".format(it) }
+            assertEquals("\"$sha256\"", response.headers[HttpHeaders.ETag])
         }
 
         @Test

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/AppProfilesTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/AppProfilesTest.kt
@@ -107,10 +107,10 @@ class AppProfilesTest {
         fun `all marker regexes complete within 200ms on adversarial input`() {
             // Adversarial inputs that trigger catastrophic backtracking in poorly-written patterns.
             val adversarialInputs = listOf(
-                "S".repeat(1000) + ":",           // triggers backtracking on S/digit anchors
-                "Staffel ".repeat(200),            // triggers backtracking on German marker
-                "T" + "0".repeat(500) + " E",      // triggers backtracking on T##E## patterns
-                "a".repeat(1000),                  // long non-matching string
+                "S".repeat(1000) + ":", // triggers backtracking on S/digit anchors
+                "Staffel ".repeat(200), // triggers backtracking on German marker
+                "T" + "0".repeat(500) + " E", // triggers backtracking on T##E## patterns
+                "a".repeat(1000), // long non-matching string
             )
             AppProfiles.ALL.values.forEach { profile ->
                 profile.markerRegexes.forEach { regex ->

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/AppProfilesTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/AppProfilesTest.kt
@@ -102,6 +102,30 @@ class AppProfilesTest {
                 "Only the YouTube TV profile should have skipPhase1=true",
             )
         }
+
+        @Test
+        fun `all marker regexes complete within 200ms on adversarial input`() {
+            // Adversarial inputs that trigger catastrophic backtracking in poorly-written patterns.
+            val adversarialInputs = listOf(
+                "S".repeat(1000) + ":",           // triggers backtracking on S/digit anchors
+                "Staffel ".repeat(200),            // triggers backtracking on German marker
+                "T" + "0".repeat(500) + " E",      // triggers backtracking on T##E## patterns
+                "a".repeat(1000),                  // long non-matching string
+            )
+            AppProfiles.ALL.values.forEach { profile ->
+                profile.markerRegexes.forEach { regex ->
+                    adversarialInputs.forEach { input ->
+                        val start = System.currentTimeMillis()
+                        regex.find(input)
+                        val elapsed = System.currentTimeMillis() - start
+                        assertTrue(
+                            elapsed < 200,
+                            "Regex in ${profile.packageName} took ${elapsed}ms on adversarial input",
+                        )
+                    }
+                }
+            }
+        }
     }
 
     // ── Netflix fixture ───────────────────────────────────────────────────────
@@ -385,6 +409,91 @@ class AppProfilesTest {
         fun `joyn profile has llmHint`() {
             val profile = AppProfiles.forPackage("de.prosiebensat1digital.seventv")!!
             assertNotNull(profile.llmHint)
+        }
+    }
+
+    // ── Apple TV+ fixture ─────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Apple TV+ (com.apple.atve.androidtv.appletv)")
+    inner class AppleTvFixture {
+
+        @Test
+        fun `forPackage returns profile for apple tv`() {
+            val profile = AppProfiles.forPackage("com.apple.atve.androidtv.appletv")
+            assertNotNull(profile)
+            assertEquals("com.apple.atve.androidtv.appletv", profile!!.packageName)
+        }
+
+        @Test
+        fun `apple tv profile has no markerRegexes`() {
+            val profile = AppProfiles.forPackage("com.apple.atve.androidtv.appletv")!!
+            assertTrue(profile.markerRegexes.isEmpty())
+        }
+
+        @Test
+        fun `apple tv profile prefers watchNext title and notification title`() {
+            val profile = AppProfiles.forPackage("com.apple.atve.androidtv.appletv")!!
+            assertEquals("watchNext.title", profile.preferredSourceTags[0])
+            assertEquals("notification.title", profile.preferredSourceTags[1])
+        }
+
+        @Test
+        fun `apple tv profile has llmHint about Episode N format`() {
+            val profile = AppProfiles.forPackage("com.apple.atve.androidtv.appletv")!!
+            assertNotNull(profile.llmHint)
+            assertTrue(profile.llmHint!!.contains("Episode", ignoreCase = true))
+        }
+    }
+
+    // ── Kodi fixture ──────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("Kodi (org.xbmc.kodi)")
+    inner class KodiFixture {
+
+        private val extractor: TitleExtractor = mockk()
+        private val gameOfThrones = TraktShow(
+            title = "Game of Thrones",
+            year = 2011,
+            ids = TraktIds(trakt = 1390, tmdb = 1399),
+        )
+
+        @Test
+        fun `forPackage returns profile for kodi`() {
+            val profile = AppProfiles.forPackage("org.xbmc.kodi")
+            assertNotNull(profile)
+            assertEquals("org.xbmc.kodi", profile!!.packageName)
+        }
+
+        @Test
+        fun `kodi profile has no markerRegexes`() {
+            val profile = AppProfiles.forPackage("org.xbmc.kodi")!!
+            assertTrue(profile.markerRegexes.isEmpty())
+        }
+
+        @Test
+        fun `kodi profile prefers mediaSession title only`() {
+            val profile = AppProfiles.forPackage("org.xbmc.kodi")!!
+            assertEquals(listOf("mediaSession.title"), profile.preferredSourceTags)
+        }
+
+        @Test
+        fun `resolves show from mediaSession title with standard S##E## marker`() = runTest {
+            coEvery { extractor.extract(any()) } returns null
+            val scrobbler = makeScrobbler(listOf(gameOfThrones), extractor)
+            val snapshot = buildTaggedSnapshot(
+                packageName = "org.xbmc.kodi",
+                lines = listOf("mediaSession.title: Game of Thrones S01E09"),
+            )
+
+            val result = scrobbler.matchSnapshot(snapshot)
+
+            assertNotNull(result)
+            assertEquals("Game of Thrones", result!!.matchedShow?.title)
+            assertEquals(1, result.matchedEpisode?.season)
+            assertEquals(9, result.matchedEpisode?.number)
+            coVerify(exactly = 0) { extractor.extract(any()) }
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ androidx-arch-core = "2.2.0"
 errorprone-annotations = "2.49.0"
 gradlePlayPublisher = "4.0.0"
 detekt = "1.23.8"
-jsoup = "1.18.3"
+jsoup = "1.22.2"
 room = "2.8.4"
 androidx-tvprovider = "1.1.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ androidx-arch-core = "2.2.0"
 errorprone-annotations = "2.49.0"
 gradlePlayPublisher = "4.0.0"
 detekt = "1.23.8"
+jsoup = "1.18.3"
 room = "2.8.4"
 androidx-tvprovider = "1.1.0"
 
@@ -112,6 +113,7 @@ robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "
 androidx-test-core = { group = "androidx.test", name = "core-ktx", version.ref = "androidx-test-core" }
 androidx-arch-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "androidx-arch-core" }
 errorprone-annotations = { group = "com.google.errorprone", name = "error_prone_annotations", version.ref = "errorprone-annotations" }
+jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 
 # TV Provider (WatchNext programs content provider — TV-side only)
 androidx-tvprovider = { group = "androidx.tvprovider", name = "tvprovider", version.ref = "androidx-tvprovider" }


### PR DESCRIPTION
## Summary

- **#530 (security)** `RecapGenerator`: replace regex HTML blocklist with a JSoup `Safelist` allowlist. The old approach used four regexes that missed edge-cases (`>` inside tag content, CSS `expression()`, SVG `<use>`). JSoup's allowlist is structurally safe — only the specific tags/attributes the LLM slideshow template legitimately uses are permitted; everything else is stripped.
- **#528 (stability)** `EpisodeRepository`: replace the unbounded `mutableMapOf` with a 50-entry access-ordered LRU `LinkedHashMap`. Users with large Trakt libraries could previously grow this singleton indefinitely; now the eldest entry is evicted once the cap is exceeded.
- **#536 (privacy/correctness)** `CompanionHttpServer /avatar`: derive the `ETag` from a SHA-256 hash of the JPEG bytes instead of the monotonic `customAvatarVersion` counter. The counter leaked how many times the user changed their avatar and was not a true content identity.
- **#569 (quality)** `AppProfilesTest`: add dedicated Apple TV+ and Kodi per-profile fixtures (previously untested), and an adversarial-backtracking test that asserts every `markerRegex` completes in < 200 ms on worst-case inputs (long repeated prefixes, all-non-matching strings).

## Files changed

| File | Change |
|------|--------|
| `gradle/libs.versions.toml` | Add `jsoup = "1.18.3"` version + library entry |
| `app-phone/build.gradle.kts` | Add `implementation(libs.jsoup)` |
| `phone/llm/RecapGenerator.kt` | Replace 4 regex constants + `sanitizeHtml` with `Jsoup.clean(html, RECAP_SAFELIST)` |
| `phone/server/EpisodeRepository.kt` | LRU-capped `LinkedHashMap` (50 entries, access-ordered) |
| `phone/server/CompanionHttpServer.kt` | `sha256Hex()` helper; use it for `/avatar` ETag |
| `core/.../AppProfilesTest.kt` | Apple TV+, Kodi fixtures; adversarial backtracking test |

## Test plan

- [ ] CI `Test & Build` green (Gradle scope: Kotlin/Android changes touch `app-phone/**` and `core/**`)
- [ ] `RecapGenerator` — JSoup rejects `<script>`, `onclick=`, `javascript:href`, SVG `<use>` while preserving `<div style="…">`, `<img data-tmdb-still="…">`, `<h2>`, `<strong>`
- [ ] `EpisodeRepository` — after 51 distinct show IDs are cached, the map stays at 50 entries
- [ ] `/avatar` — two requests with unchanged JPEG return the same ETag and `304 Not Modified`; replacing the file produces a different ETag
- [ ] `AppProfilesTest` — all new fixtures pass; adversarial-backtracking test completes in < 1 s total

> **Note:** Android SDK unavailable in this environment — Gradle scope was skipped by `precommit.sh` (expected in sandboxed CI). The `Test & Build` workflow is the real gate.

https://claude.ai/code/session_01Bw6f8chqqoDwQs4rk95FJQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bw6f8chqqoDwQs4rk95FJQ)_