### PR TITLE
fix(phone): prevent LLM inference from exhausting Ktor worker pool (#526)

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
@@ -8,15 +8,15 @@ import com.justb81.watchbuddy.core.model.TmdbEpisode
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.Executors
-import javax.inject.Inject
-import javax.inject.Singleton
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import javax.inject.Inject
+import javax.inject.Singleton
 
 /** Thrown when the LLM request queue is full. Callers should return HTTP 503. */
 class LlmBusyException(message: String) : Exception(message)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
@@ -8,8 +8,8 @@ import com.justb81.watchbuddy.core.model.TmdbEpisode
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
-import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.Executors
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.TimeoutCancellationException

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
@@ -8,11 +8,15 @@ import com.justb81.watchbuddy.core.model.TmdbEpisode
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.Lazy
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.coroutines.TimeoutCancellationException
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.withTimeout
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 
 /**
  * Creates [LlmProvider] instances based on [LlmOrchestrator.selectConfig] and
@@ -45,11 +49,40 @@ class LlmProviderFactory @Inject constructor(
         private const val MAX_ERROR_MESSAGE = 200
 
         // Per-provider inference timeout. The TV-side OkHttp client allows 90 s
-        // for the recap response (`PhoneApiClientFactory.kt`); 75 s gives the
-        // cascade enough headroom to also try the next provider before the TV
-        // tears down the request, and it bounds the wait so a hung JNI call
-        // can't block the Ktor request thread indefinitely.
-        const val LLM_TIMEOUT_MS = 75_000L
+        // for the recap response (`PhoneApiClientFactory.kt`); 30 s per provider
+        // still leaves headroom to try the next provider before the TV tears
+        // down the request, and bounds the wait so a hung JNI call cannot block
+        // the dedicated inference thread indefinitely.
+        const val LLM_TIMEOUT_MS = 30_000L
+
+        private const val MAX_LLM_QUEUE_DEPTH = 3
+
+        /** Thrown when the LLM request queue is full. Callers should return HTTP 503. */
+        class LlmBusyException(message: String) : Exception(message)
+    }
+
+    // Single-thread executor keeps LLM inference off Ktor's worker pool. JNI
+    // calls from LiteRT-LM block this thread, not any shared dispatcher thread.
+    private val llmDispatcher = Executors
+        .newSingleThreadExecutor { r -> Thread(r, "llm-inference").also { it.isDaemon = true } }
+        .asCoroutineDispatcher()
+
+    // Tracks requests that are either waiting for the inference thread or
+    // actively running. Capped at MAX_LLM_QUEUE_DEPTH; excess requests are
+    // rejected immediately with LlmBusyException.
+    private val llmQueueDepth = AtomicInteger(0)
+
+    private suspend fun <T> withLlmQueue(block: suspend () -> T): T {
+        val depth = llmQueueDepth.incrementAndGet()
+        if (depth > MAX_LLM_QUEUE_DEPTH) {
+            llmQueueDepth.decrementAndGet()
+            throw LlmBusyException("LLM busy — $MAX_LLM_QUEUE_DEPTH requests already queued")
+        }
+        return try {
+            withContext(llmDispatcher) { block() }
+        } finally {
+            llmQueueDepth.decrementAndGet()
+        }
     }
 
     /**
@@ -71,44 +104,46 @@ class LlmProviderFactory @Inject constructor(
         val providers = buildProviderCascade(config, episodes)
         val errors = mutableListOf<String>()
 
-        for (provider in providers) {
-            try {
-                Log.d(TAG, "Trying provider: ${provider.displayName}")
-                val result = invokeWithTimeout(provider, prompt)
-                Log.d(TAG, "Success with provider: ${provider.displayName}")
-                recordEvent(
-                    enabled = loggingEnabled,
-                    caller = caller,
-                    backend = provider.displayName,
-                    startedAt = startedAt,
-                    prompt = prompt,
-                    response = result,
-                    status = LlmEventLog.Status.SUCCESS,
-                )
-                return result
-            } catch (e: TimeoutCancellationException) {
-                Log.w(TAG, "Provider ${provider.displayName} timed out after ${LLM_TIMEOUT_MS}ms", e)
-                errors += "${provider.displayName}: timeout(${LLM_TIMEOUT_MS}ms)"
-            } catch (e: Exception) {
-                Log.w(TAG, "Provider ${provider.displayName} failed: ${e.message}")
-                errors += "${provider.displayName}: ${summarize(e)}"
+        return withLlmQueue {
+            for (provider in providers) {
+                try {
+                    Log.d(TAG, "Trying provider: ${provider.displayName}")
+                    val result = invokeWithTimeout(provider, prompt)
+                    Log.d(TAG, "Success with provider: ${provider.displayName}")
+                    recordEvent(
+                        enabled = loggingEnabled,
+                        caller = caller,
+                        backend = provider.displayName,
+                        startedAt = startedAt,
+                        prompt = prompt,
+                        response = result,
+                        status = LlmEventLog.Status.SUCCESS,
+                    )
+                    return@withLlmQueue result
+                } catch (e: TimeoutCancellationException) {
+                    Log.w(TAG, "Provider ${provider.displayName} timed out after ${LLM_TIMEOUT_MS}ms", e)
+                    errors += "${provider.displayName}: timeout(${LLM_TIMEOUT_MS}ms)"
+                } catch (e: Exception) {
+                    Log.w(TAG, "Provider ${provider.displayName} failed: ${e.message}")
+                    errors += "${provider.displayName}: ${summarize(e)}"
+                }
             }
-        }
 
-        // All providers failed — return minimal fallback
-        Log.e(TAG, "All LLM providers failed, returning empty fallback")
-        val fallback = buildMinimalFallback()
-        recordEvent(
-            enabled = loggingEnabled,
-            caller = caller,
-            backend = BACKEND_FALLBACK,
-            startedAt = startedAt,
-            prompt = prompt,
-            response = fallback,
-            status = LlmEventLog.Status.ERROR,
-            errorSummary = errors.joinToString(" | ").ifEmpty { "no providers available" },
-        )
-        return fallback
+            // All providers failed — return minimal fallback
+            Log.e(TAG, "All LLM providers failed, returning empty fallback")
+            val fallback = buildMinimalFallback()
+            recordEvent(
+                enabled = loggingEnabled,
+                caller = caller,
+                backend = BACKEND_FALLBACK,
+                startedAt = startedAt,
+                prompt = prompt,
+                response = fallback,
+                status = LlmEventLog.Status.ERROR,
+                errorSummary = errors.joinToString(" | ").ifEmpty { "no providers available" },
+            )
+            fallback
+        }
     }
 
     /**
@@ -138,40 +173,46 @@ class LlmProviderFactory @Inject constructor(
             return null
         }
         val errors = mutableListOf<String>()
-        for (provider in providers) {
-            try {
-                Log.d(TAG, "Trying provider: ${provider.displayName}")
-                val result = invokeWithTimeout(provider, prompt)
-                Log.d(TAG, "Success with provider: ${provider.displayName}")
+        return withLlmQueue {
+            var result: String? = null
+            for (provider in providers) {
+                try {
+                    Log.d(TAG, "Trying provider: ${provider.displayName}")
+                    val text = invokeWithTimeout(provider, prompt)
+                    Log.d(TAG, "Success with provider: ${provider.displayName}")
+                    recordEvent(
+                        enabled = loggingEnabled,
+                        caller = caller,
+                        backend = provider.displayName,
+                        startedAt = startedAt,
+                        prompt = prompt,
+                        response = text,
+                        status = LlmEventLog.Status.SUCCESS,
+                    )
+                    result = text
+                    break
+                } catch (e: TimeoutCancellationException) {
+                    Log.w(TAG, "Provider ${provider.displayName} timed out after ${LLM_TIMEOUT_MS}ms", e)
+                    errors += "${provider.displayName}: timeout(${LLM_TIMEOUT_MS}ms)"
+                } catch (e: Exception) {
+                    Log.w(TAG, "Provider ${provider.displayName} failed: ${e.message}")
+                    errors += "${provider.displayName}: ${summarize(e)}"
+                }
+            }
+            if (result == null) {
                 recordEvent(
                     enabled = loggingEnabled,
                     caller = caller,
-                    backend = provider.displayName,
+                    backend = providers.last().displayName,
                     startedAt = startedAt,
                     prompt = prompt,
-                    response = result,
-                    status = LlmEventLog.Status.SUCCESS,
+                    response = null,
+                    status = LlmEventLog.Status.ERROR,
+                    errorSummary = errors.joinToString(" | "),
                 )
-                return result
-            } catch (e: TimeoutCancellationException) {
-                Log.w(TAG, "Provider ${provider.displayName} timed out after ${LLM_TIMEOUT_MS}ms", e)
-                errors += "${provider.displayName}: timeout(${LLM_TIMEOUT_MS}ms)"
-            } catch (e: Exception) {
-                Log.w(TAG, "Provider ${provider.displayName} failed: ${e.message}")
-                errors += "${provider.displayName}: ${summarize(e)}"
             }
+            result
         }
-        recordEvent(
-            enabled = loggingEnabled,
-            caller = caller,
-            backend = providers.last().displayName,
-            startedAt = startedAt,
-            prompt = prompt,
-            response = null,
-            status = LlmEventLog.Status.ERROR,
-            errorSummary = errors.joinToString(" | "),
-        )
-        return null
     }
 
     /**

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactory.kt
@@ -18,6 +18,9 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 
+/** Thrown when the LLM request queue is full. Callers should return HTTP 503. */
+class LlmBusyException(message: String) : Exception(message)
+
 /**
  * Creates [LlmProvider] instances based on [LlmOrchestrator.selectConfig] and
  * implements a cascade fallback:  AICore -> LiteRT-LM -> TMDB Fallback.
@@ -56,9 +59,6 @@ class LlmProviderFactory @Inject constructor(
         const val LLM_TIMEOUT_MS = 30_000L
 
         private const val MAX_LLM_QUEUE_DEPTH = 3
-
-        /** Thrown when the LLM request queue is full. Callers should return HTTP 503. */
-        class LlmBusyException(message: String) : Exception(message)
     }
 
     // Single-thread executor keeps LLM inference off Ktor's worker pool. JNI

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -287,7 +287,7 @@ internal fun Application.configureCompanionRoutes(
                 DiagnosticLog.error(TAG, "Keystore unavailable", e)
                 call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Service unavailable"))
             } catch (e: LlmBusyException) {
-                DiagnosticLog.warn(TAG, "recap: LLM busy, rejecting request for show $showId")
+                DiagnosticLog.warn(TAG, "recap: LLM busy, rejecting request for show $showId", e)
                 call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("LLM busy, try again later"))
             } catch (e: Exception) {
                 DiagnosticLog.error(TAG, "Recap generation failed for show $showId", e)
@@ -320,7 +320,7 @@ internal fun Application.configureCompanionRoutes(
                     ?: TitleExtractionResponse(confidence = 0f)
                 call.respond(response)
             } catch (e: LlmBusyException) {
-                DiagnosticLog.warn(TAG, "extract: LLM busy, rejecting request")
+                DiagnosticLog.warn(TAG, "extract: LLM busy, rejecting request", e)
                 call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("LLM busy, try again later"))
             } catch (e: Exception) {
                 DiagnosticLog.warn(TAG, "title extraction failed", e)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -21,7 +21,7 @@ import com.justb81.watchbuddy.core.trakt.SyncHistoryShowItem
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.auth.TokenRepository
-import com.justb81.watchbuddy.phone.llm.LlmProviderFactory
+import com.justb81.watchbuddy.phone.llm.LlmBusyException
 import com.justb81.watchbuddy.phone.llm.LlmTitleExtractor
 import com.justb81.watchbuddy.phone.llm.RecapGenerator
 import com.justb81.watchbuddy.phone.settings.AvatarImageStore
@@ -286,7 +286,7 @@ internal fun Application.configureCompanionRoutes(
             } catch (e: SecurityException) {
                 DiagnosticLog.error(TAG, "Keystore unavailable", e)
                 call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Service unavailable"))
-            } catch (e: LlmProviderFactory.LlmBusyException) {
+            } catch (e: LlmBusyException) {
                 DiagnosticLog.warn(TAG, "recap: LLM busy, rejecting request for show $showId")
                 call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("LLM busy, try again later"))
             } catch (e: Exception) {
@@ -319,7 +319,7 @@ internal fun Application.configureCompanionRoutes(
                 val response = titleExtractor.extract(body.snapshot, body.libraryHints)
                     ?: TitleExtractionResponse(confidence = 0f)
                 call.respond(response)
-            } catch (e: LlmProviderFactory.LlmBusyException) {
+            } catch (e: LlmBusyException) {
                 DiagnosticLog.warn(TAG, "extract: LLM busy, rejecting request")
                 call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("LLM busy, try again later"))
             } catch (e: Exception) {

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -21,6 +21,7 @@ import com.justb81.watchbuddy.core.trakt.SyncHistoryShowItem
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.llm.LlmProviderFactory
 import com.justb81.watchbuddy.phone.llm.LlmTitleExtractor
 import com.justb81.watchbuddy.phone.llm.RecapGenerator
 import com.justb81.watchbuddy.phone.settings.AvatarImageStore
@@ -285,6 +286,9 @@ internal fun Application.configureCompanionRoutes(
             } catch (e: SecurityException) {
                 DiagnosticLog.error(TAG, "Keystore unavailable", e)
                 call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Service unavailable"))
+            } catch (e: LlmProviderFactory.LlmBusyException) {
+                DiagnosticLog.warn(TAG, "recap: LLM busy, rejecting request for show $showId")
+                call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("LLM busy, try again later"))
             } catch (e: Exception) {
                 DiagnosticLog.error(TAG, "Recap generation failed for show $showId", e)
                 call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Recap generation failed"))
@@ -315,6 +319,9 @@ internal fun Application.configureCompanionRoutes(
                 val response = titleExtractor.extract(body.snapshot, body.libraryHints)
                     ?: TitleExtractionResponse(confidence = 0f)
                 call.respond(response)
+            } catch (e: LlmProviderFactory.LlmBusyException) {
+                DiagnosticLog.warn(TAG, "extract: LLM busy, rejecting request")
+                call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("LLM busy, try again later"))
             } catch (e: Exception) {
                 DiagnosticLog.warn(TAG, "title extraction failed", e)
                 call.respond(HttpStatusCode.ServiceUnavailable, ErrorResponse("Extraction failed"))

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactoryTest.kt
@@ -7,7 +7,6 @@ import com.justb81.watchbuddy.phone.settings.AppSettings
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.Lazy
 import io.mockk.*
-import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
@@ -18,6 +17,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.util.concurrent.atomic.AtomicInteger
 
 @DisplayName("LlmProviderFactory")
 class LlmProviderFactoryTest {

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactoryTest.kt
@@ -121,7 +121,7 @@ class LlmProviderFactoryTest {
             )
             setQueueDepth(3) // MAX_LLM_QUEUE_DEPTH
             try {
-                assertThrows<LlmProviderFactory.LlmBusyException> {
+                assertThrows<LlmBusyException> {
                     factory.generateWithCascade("recap", "p", emptyList())
                 }
             } finally {
@@ -136,7 +136,7 @@ class LlmProviderFactoryTest {
             )
             setQueueDepth(3)
             try {
-                assertThrows<LlmProviderFactory.LlmBusyException> {
+                assertThrows<LlmBusyException> {
                     factory.generateOrNull("extract", "p")
                 }
             } finally {

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/llm/LlmProviderFactoryTest.kt
@@ -7,6 +7,7 @@ import com.justb81.watchbuddy.phone.settings.AppSettings
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import dagger.Lazy
 import io.mockk.*
+import java.util.concurrent.atomic.AtomicInteger
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
@@ -100,6 +101,58 @@ class LlmProviderFactoryTest {
             )
             val result = factory.generateWithCascade("recap", "prompt", episodes)
             assertNotNull(result)
+        }
+    }
+
+    @Nested
+    @DisplayName("queue depth limiting")
+    inner class QueueDepthTest {
+
+        private fun setQueueDepth(value: Int) {
+            val field = LlmProviderFactory::class.java.getDeclaredField("llmQueueDepth")
+            field.isAccessible = true
+            (field.get(factory) as AtomicInteger).set(value)
+        }
+
+        @Test
+        fun `generateWithCascade throws LlmBusyException when queue is at max depth`() = runTest {
+            every { orchestrator.selectConfig() } returns LlmOrchestrator.LlmConfig(
+                LlmBackend.NONE, null, 0
+            )
+            setQueueDepth(3) // MAX_LLM_QUEUE_DEPTH
+            try {
+                assertThrows<LlmProviderFactory.LlmBusyException> {
+                    factory.generateWithCascade("recap", "p", emptyList())
+                }
+            } finally {
+                setQueueDepth(0)
+            }
+        }
+
+        @Test
+        fun `generateOrNull throws LlmBusyException when queue is at max depth`() = runTest {
+            every { orchestrator.selectConfig() } returns LlmOrchestrator.LlmConfig(
+                LlmBackend.AICORE, null, 150
+            )
+            setQueueDepth(3)
+            try {
+                assertThrows<LlmProviderFactory.LlmBusyException> {
+                    factory.generateOrNull("extract", "p")
+                }
+            } finally {
+                setQueueDepth(0)
+            }
+        }
+
+        @Test
+        fun `slot is released after a call completes so next call succeeds`() = runTest {
+            every { orchestrator.selectConfig() } returns LlmOrchestrator.LlmConfig(
+                LlmBackend.NONE, null, 0
+            )
+            factory.generateWithCascade("recap", "prompt", emptyList())
+            // Slot must be released — second call must also succeed.
+            val result = factory.generateWithCascade("recap", "prompt", emptyList())
+            assertTrue(result.isNotBlank())
         }
     }
 

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -35,7 +35,6 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import io.mockk.*
-import java.io.File
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
@@ -43,6 +42,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import java.io.File
 
 @DisplayName("CompanionHttpServer routes")
 class CompanionHttpServerTest {

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -35,14 +35,14 @@ import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import io.mockk.*
+import java.io.File
+import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import java.io.File
-import kotlinx.coroutines.flow.flowOf
 
 @DisplayName("CompanionHttpServer routes")
 class CompanionHttpServerTest {

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -21,7 +21,7 @@ import com.justb81.watchbuddy.core.trakt.SyncHistoryResult
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.auth.TokenRepository
-import com.justb81.watchbuddy.phone.llm.LlmProviderFactory
+import com.justb81.watchbuddy.phone.llm.LlmBusyException
 import com.justb81.watchbuddy.phone.llm.LlmTitleExtractor
 import com.justb81.watchbuddy.phone.llm.RecapGenerator
 import com.justb81.watchbuddy.phone.settings.AppSettings
@@ -682,7 +682,7 @@ class CompanionHttpServerTest {
             coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
             coEvery { tmdbApiService.getEpisode(any(), any(), any(), any(), any()) } returns ep1
             coEvery { recapGenerator.generateRecap(any(), any(), any()) } throws
-                LlmProviderFactory.LlmBusyException("LLM busy")
+                LlmBusyException("LLM busy")
 
             val response = client.post("/recap/1") {
                 contentType(ContentType.Application.Json)
@@ -1001,7 +1001,7 @@ class CompanionHttpServerTest {
         @Test
         fun `returns 503 with LLM busy message when title extractor is at capacity`() = testApp {
             coEvery { titleExtractor.extract(any<MediaMetadataSnapshot>(), any()) } throws
-                LlmProviderFactory.LlmBusyException("LLM busy")
+                LlmBusyException("LLM busy")
 
             val response = client.post("/scrobble/extract") {
                 contentType(ContentType.Application.Json)

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -21,6 +21,7 @@ import com.justb81.watchbuddy.core.trakt.SyncHistoryResult
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.auth.TokenRepository
+import com.justb81.watchbuddy.phone.llm.LlmProviderFactory
 import com.justb81.watchbuddy.phone.llm.LlmTitleExtractor
 import com.justb81.watchbuddy.phone.llm.RecapGenerator
 import com.justb81.watchbuddy.phone.settings.AppSettings
@@ -673,6 +674,24 @@ class CompanionHttpServerTest {
             assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
             assertTrue(response.bodyAsText().contains("Service unavailable"))
         }
+
+        @Test
+        fun `returns 503 with LLM busy message when recap generator is at capacity`() = testApp {
+            every { tokenRepository.getAccessToken() } returns "token"
+            coEvery { showRepository.getShows() } returns listOf(enrichedEntry)
+            coEvery { tmdbApiService.getShow(100, "api-key", any()) } returns tmdbShow
+            coEvery { tmdbApiService.getEpisode(any(), any(), any(), any(), any()) } returns ep1
+            coEvery { recapGenerator.generateRecap(any(), any(), any()) } throws
+                LlmProviderFactory.LlmBusyException("LLM busy")
+
+            val response = client.post("/recap/1") {
+                contentType(ContentType.Application.Json)
+                setBody("""{"tmdbApiKey":"api-key"}""")
+            }
+
+            assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+            assertTrue(response.bodyAsText().contains("LLM busy"))
+        }
     }
 
     // ── POST /scrobble/start, /scrobble/pause, /scrobble/stop ────────────────
@@ -977,6 +996,20 @@ class CompanionHttpServerTest {
                 setBody(extractRequestBody)
             }
             assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+        }
+
+        @Test
+        fun `returns 503 with LLM busy message when title extractor is at capacity`() = testApp {
+            coEvery { titleExtractor.extract(any<MediaMetadataSnapshot>(), any()) } throws
+                LlmProviderFactory.LlmBusyException("LLM busy")
+
+            val response = client.post("/scrobble/extract") {
+                contentType(ContentType.Application.Json)
+                setBody(extractRequestBody)
+            }
+
+            assertEquals(HttpStatusCode.ServiceUnavailable, response.status)
+            assertTrue(response.bodyAsText().contains("LLM busy"))
         }
 
         @Test


### PR DESCRIPTION
## Summary

Fixes #526 — LLM inference was running on Ktor's shared worker-thread pool, allowing a single long `/recap` or `/scrobble/extract` call (up to 75 s) to stall every other endpoint including `/capability` and `/shows`.

- **Dedicated dispatcher**: `generateWithCascade()` and `generateOrNull()` now run inside `withContext(llmDispatcher)`, where `llmDispatcher` is backed by a `newSingleThreadExecutor("llm-inference")`. JNI/blocking inference never touches Ktor's worker pool.
- **Bounded queue (depth 3)**: An `AtomicInteger` counter tracks in-flight requests. A 4th concurrent call increments past `MAX_LLM_QUEUE_DEPTH` and immediately throws `LlmBusyException`. The `/recap` and `/scrobble/extract` handlers catch it and return **HTTP 503** with `"LLM busy, try again later"`.
- **Timeout reduced 75 s → 30 s**: Bad UX beyond that anyway; 30 s × 2 providers still fits inside the TV-side 90 s OkHttp timeout with headroom.

`202 Accepted` + polling (issue suggestion 4) is out of scope — it requires TV-side polling logic and is a separate feature.

## Test plan

- [ ] `LlmProviderFactoryTest` — new `QueueDepthTest` class: `generateWithCascade` throws `LlmBusyException` when counter is at max; slot is released after a call completes
- [ ] `LlmProviderFactoryTest` — existing `TimeoutTest` continues to pass (uses `LlmProviderFactory.LLM_TIMEOUT_MS` constant, picks up the reduced value automatically)
- [ ] `CompanionHttpServerTest` — new test in `RecapEndpoint`: `returns 503 with LLM busy message when recap generator is at capacity`
- [ ] `CompanionHttpServerTest` — new test in `ExtractEndpoint`: `returns 503 with LLM busy message when title extractor is at capacity`
- [ ] CI `build-android.yml` green

> **Note:** Gradle checks were skipped locally (no Android SDK in this sandbox). CI is the real gate per CLAUDE.md policy.

https://claude.ai/code/session_01VZ6Ltpvo3CsgXxtsS3EodJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZ6Ltpvo3CsgXxtsS3EodJ)_