### PR TITLE
docs: remove temporal/change language from documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,7 +140,7 @@ flowchart TD
 ```
 
 Model updates: WorkManager (`ModelDownloadWorker`), WiFi only.
-Auto-migrate to AICore if OS update adds support.
+Automatically use AICore when OS update adds support.
 Model download URL is configurable in Advanced Settings (default: HuggingFace `litert-community`).
 
 ## Scrobbling Flow
@@ -322,7 +322,7 @@ this flow and shows a "Now Watching" card with the show title, episode number, a
 
 ### Private APK (sideload)
 - `client_secret` embedded via NDK + hidden-secrets-gradle-plugin (XOR + signature binding)
-- On first run: migrated to Android Keystore (TEE/hardware-backed)
+- On first run: stored in Android Keystore (TEE/hardware-backed)
 - `access_token` / `refresh_token`: always in Android Keystore
 
 ### Play Store APK

--- a/docs/tmdb-integration.md
+++ b/docs/tmdb-integration.md
@@ -167,8 +167,8 @@ When no LLM backend is available (AICore unavailable, insufficient RAM for LiteR
 ### 2. Deep Link Resolution (TV App)
 
 When the user opens a show's detail screen on the TV, `ShowDetailViewModel.loadDeepLinks()` resolves
-per-episode streaming URLs via JustWatch's unofficial GraphQL API. Static deep-link templates were
-removed; every link is resolved at runtime and cached in a Room database on the TV.
+per-episode streaming URLs via JustWatch's unofficial GraphQL API. Deep-link URLs are resolved at
+runtime and cached in a Room database on the TV.
 
 ```mermaid
 flowchart TD

--- a/docs/trakt-flow.md
+++ b/docs/trakt-flow.md
@@ -90,7 +90,7 @@ flowchart TD
 
 1. After Trakt login, user enables the **Companion Service** in Settings.
 2. The phone starts a foreground service with a persistent notification.
-3. The phone is now discoverable by TV apps on the same Wi-Fi network.
+3. The phone is discoverable by TV apps on the same Wi-Fi network.
 
 ### Technical Flow
 


### PR DESCRIPTION
## Summary
- Remove temporal word "now" from docs/trakt-flow.md (line 93)
- Replace "Auto-migrate" with present-tense "Automatically use AICore when OS update adds support." in docs/architecture.md (line ~143)
- Replace "migrated to Android Keystore" with "stored in Android Keystore" in docs/architecture.md (line ~325)
- Replace past-tense removal reference with current-state description in docs/tmdb-integration.md (line ~171)

## Test plan
- [x] Verify all four text changes are present and accurate
- [x] Confirm no other temporal/change language remains in the modified sections

> Note: Gradle scope skipped locally (no Android SDK in CI runner); CI is the gate for any Kotlin/Android changes (docs-only PR, no Kotlin changes).

Closes #676

https://claude.ai/code/session_013PNZkpfbQfqXhidTsziQak

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwhRPfww8qQ68zfqcA6Ahq)_