### PR TITLE
feat(phone): bulk-mark earlier episodes as watched

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/EpisodeRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/EpisodeRepository.kt
@@ -112,7 +112,7 @@ class EpisodeRepository @Inject constructor(
         traktApi.addToHistory("Bearer $token", body)
         Unit
     }.onFailure {
-        Log.w(TAG, "markEpisodesWatchedUpTo S${targetSeason}E${targetEpisode} (${candidates.size} eps) failed", it)
+        Log.w(TAG, "markEpisodesWatchedUpTo S${targetSeason}E$targetEpisode (${candidates.size} eps) failed", it)
     }
 
     private fun buildBody(ids: TraktIds, season: Int, episode: Int): SyncHistoryBody =

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/EpisodeRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/EpisodeRepository.kt
@@ -80,6 +80,41 @@ class EpisodeRepository @Inject constructor(
         Unit
     }.onFailure { Log.w(TAG, "markEpisodeUnwatched S${season}E${episode} failed", it) }
 
+    /**
+     * Marks all [candidates] (season, episode) pairs as watched in a single
+     * `POST /sync/history` call. The caller is responsible for pre-filtering
+     * the candidate list (season >= 1, not already watched, <= target position).
+     *
+     * Returns [Result.success] immediately when [candidates] is empty (no HTTP
+     * call is made). Returns [Result.failure] if the network call fails.
+     */
+    suspend fun markEpisodesWatchedUpTo(
+        ids: TraktIds,
+        targetSeason: Int,
+        targetEpisode: Int,
+        candidates: List<Pair<Int, Int>>
+    ): Result<Unit> = runCatching {
+        if (candidates.isEmpty()) return@runCatching Unit
+        val seasonsBody = candidates
+            .groupBy { it.first }
+            .toSortedMap()
+            .map { (season, eps) ->
+                SyncHistorySeasonItem(
+                    number = season,
+                    episodes = eps.map { SyncHistoryEpisodeItem(number = it.second) }
+                )
+            }
+        val body = SyncHistoryBody(
+            shows = listOf(SyncHistoryShowItem(ids = ids, seasons = seasonsBody))
+        )
+        val token = tokenRefreshManager.getValidAccessToken()
+            ?: error("No access token available")
+        traktApi.addToHistory("Bearer $token", body)
+        Unit
+    }.onFailure {
+        Log.w(TAG, "markEpisodesWatchedUpTo S${targetSeason}E${targetEpisode} (${candidates.size} eps) failed", it)
+    }
+
     private fun buildBody(ids: TraktIds, season: Int, episode: Int): SyncHistoryBody =
         SyncHistoryBody(
             shows = listOf(

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
@@ -19,6 +20,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -42,6 +45,18 @@ fun ShowDetailScreen(
         val error = uiState.toggleError ?: return@LaunchedEffect
         snackbarHostState.showSnackbar(message = error.ifBlank { toggleFailedLabel })
         viewModel.clearToggleError()
+    }
+
+    val context = LocalContext.current
+    LaunchedEffect(uiState.bulkSuccessCount) {
+        val count = uiState.bulkSuccessCount ?: return@LaunchedEffect
+        val message = context.resources.getQuantityString(
+            R.plurals.show_detail_bulk_success,
+            count,
+            count
+        )
+        snackbarHostState.showSnackbar(message = message)
+        viewModel.clearBulkSuccess()
     }
 
     Scaffold(
@@ -140,8 +155,11 @@ fun ShowDetailScreen(
                                 SeasonCard(
                                     season = season,
                                     togglingEpisode = uiState.togglingEpisode,
+                                    bulkInProgress = uiState.bulkInProgress,
                                     onExpandToggle = { viewModel.toggleSeasonExpanded(season.number) },
-                                    onEpisodeToggle = { episode -> viewModel.toggleEpisodeWatched(episode) }
+                                    onEpisodeToggle = { episode -> viewModel.toggleEpisodeWatched(episode) },
+                                    onMarkEarlierWatched = { episode -> viewModel.markEarlierWatched(episode) },
+                                    allSeasons = uiState.seasons
                                 )
                             }
                         }
@@ -218,8 +236,11 @@ private fun ShowHeader(
 private fun SeasonCard(
     season: SeasonUi,
     togglingEpisode: Pair<Int, Int>?,
+    bulkInProgress: Boolean,
     onExpandToggle: () -> Unit,
-    onEpisodeToggle: (EpisodeUi) -> Unit
+    onEpisodeToggle: (EpisodeUi) -> Unit,
+    onMarkEarlierWatched: (EpisodeUi) -> Unit,
+    allSeasons: List<SeasonUi>
 ) {
     val rotation by animateFloatAsState(
         targetValue = if (season.expanded) 180f else 0f,
@@ -278,7 +299,10 @@ private fun SeasonCard(
                         EpisodeRow(
                             episode = episode,
                             isToggling = togglingEpisode == (episode.season to episode.number),
-                            onToggle = { onEpisodeToggle(episode) }
+                            bulkInProgress = bulkInProgress,
+                            allSeasons = allSeasons,
+                            onToggle = { onEpisodeToggle(episode) },
+                            onMarkEarlierWatched = { onMarkEarlierWatched(episode) }
                         )
                     }
                     Spacer(Modifier.height(8.dp))
@@ -288,17 +312,50 @@ private fun SeasonCard(
     }
 }
 
+/** Counts unwatched episodes in season >= 1 that are at or before [episode]. */
+private fun candidateCount(episode: EpisodeUi, allSeasons: List<SeasonUi>): Int =
+    allSeasons
+        .filter { it.number >= 1 }
+        .sumOf { season ->
+            season.episodes.count { ep ->
+                !ep.watched &&
+                    (season.number < episode.season ||
+                        (season.number == episode.season && ep.number <= episode.number))
+            }
+        }
+
 @Composable
 private fun EpisodeRow(
     episode: EpisodeUi,
     isToggling: Boolean,
-    onToggle: () -> Unit
+    bulkInProgress: Boolean,
+    allSeasons: List<SeasonUi>,
+    onToggle: () -> Unit,
+    onMarkEarlierWatched: () -> Unit
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    var showBulkConfirm by remember { mutableStateOf(false) }
+    val count = candidateCount(episode, allSeasons)
+
     val toggleCd = stringResource(
         R.string.show_detail_cd_toggle_watched,
         episode.number,
         episode.season
     )
+
+    if (showBulkConfirm) {
+        BulkConfirmDialog(
+            episode = episode,
+            candidateCount = count,
+            bulkInProgress = bulkInProgress,
+            onConfirm = {
+                showBulkConfirm = false
+                onMarkEarlierWatched()
+            },
+            onDismiss = { showBulkConfirm = false }
+        )
+    }
+
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -330,7 +387,83 @@ private fun EpisodeRow(
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.weight(1f)
         )
+        Box {
+            IconButton(
+                onClick = { menuExpanded = true },
+                modifier = Modifier.size(32.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.MoreVert,
+                    contentDescription = stringResource(
+                        R.string.show_detail_cd_episode_menu,
+                        episode.number,
+                        episode.season
+                    ),
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+            DropdownMenu(
+                expanded = menuExpanded,
+                onDismissRequest = { menuExpanded = false }
+            ) {
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.show_detail_mark_earlier_watched)) },
+                    onClick = {
+                        menuExpanded = false
+                        showBulkConfirm = true
+                    },
+                    enabled = count > 0 && !bulkInProgress
+                )
+            }
+        }
     }
+}
+
+@Composable
+private fun BulkConfirmDialog(
+    episode: EpisodeUi,
+    candidateCount: Int,
+    bulkInProgress: Boolean,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.show_detail_bulk_confirm_title)) },
+        text = {
+            Text(
+                pluralStringResource(
+                    R.plurals.show_detail_bulk_confirm_body,
+                    candidateCount,
+                    episode.season,
+                    episode.number,
+                    candidateCount
+                )
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = onConfirm,
+                enabled = !bulkInProgress
+            ) {
+                if (bulkInProgress) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(16.dp),
+                        strokeWidth = 2.dp,
+                        color = MaterialTheme.colorScheme.onPrimary
+                    )
+                } else {
+                    Text(stringResource(R.string.show_detail_bulk_confirm_action))
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_cancel))
+            }
+        }
+    )
 }
 
 @Composable

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailScreen.kt
@@ -333,10 +333,8 @@ private fun EpisodeRow(
     onToggle: () -> Unit,
     onMarkEarlierWatched: () -> Unit
 ) {
-    var menuExpanded by remember { mutableStateOf(false) }
     var showBulkConfirm by remember { mutableStateOf(false) }
     val count = candidateCount(episode, allSeasons)
-
     val toggleCd = stringResource(
         R.string.show_detail_cd_toggle_watched,
         episode.number,
@@ -387,35 +385,51 @@ private fun EpisodeRow(
             color = MaterialTheme.colorScheme.onSurface,
             modifier = Modifier.weight(1f)
         )
-        Box {
-            IconButton(
-                onClick = { menuExpanded = true },
-                modifier = Modifier.size(32.dp)
-            ) {
-                Icon(
-                    imageVector = Icons.Default.MoreVert,
-                    contentDescription = stringResource(
-                        R.string.show_detail_cd_episode_menu,
-                        episode.number,
-                        episode.season
-                    ),
-                    modifier = Modifier.size(16.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-            DropdownMenu(
-                expanded = menuExpanded,
-                onDismissRequest = { menuExpanded = false }
-            ) {
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.show_detail_mark_earlier_watched)) },
-                    onClick = {
-                        menuExpanded = false
-                        showBulkConfirm = true
-                    },
-                    enabled = count > 0 && !bulkInProgress
-                )
-            }
+        EpisodeOverflowMenu(
+            episode = episode,
+            candidateCount = count,
+            bulkInProgress = bulkInProgress,
+            onShowBulkConfirm = { showBulkConfirm = true }
+        )
+    }
+}
+
+@Composable
+private fun EpisodeOverflowMenu(
+    episode: EpisodeUi,
+    candidateCount: Int,
+    bulkInProgress: Boolean,
+    onShowBulkConfirm: () -> Unit
+) {
+    var menuExpanded by remember { mutableStateOf(false) }
+    Box {
+        IconButton(
+            onClick = { menuExpanded = true },
+            modifier = Modifier.size(32.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = stringResource(
+                    R.string.show_detail_cd_episode_menu,
+                    episode.number,
+                    episode.season
+                ),
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        DropdownMenu(
+            expanded = menuExpanded,
+            onDismissRequest = { menuExpanded = false }
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.show_detail_mark_earlier_watched)) },
+                onClick = {
+                    menuExpanded = false
+                    onShowBulkConfirm()
+                },
+                enabled = candidateCount > 0 && !bulkInProgress
+            )
         }
     }
 }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModel.kt
@@ -33,7 +33,11 @@ data class ShowDetailUiState(
     val error: String? = null,
     val toggleError: String? = null,
     /** (seasonNumber, episodeNumber) currently being toggled, or null. */
-    val togglingEpisode: Pair<Int, Int>? = null
+    val togglingEpisode: Pair<Int, Int>? = null,
+    /** True while a bulk mark-watched operation is in flight. */
+    val bulkInProgress: Boolean = false,
+    /** Non-null after a successful bulk operation; cleared after the snackbar is shown. */
+    val bulkSuccessCount: Int? = null
 )
 
 data class SeasonUi(
@@ -248,8 +252,103 @@ class ShowDetailViewModel @Inject constructor(
         )
     }
 
+    /**
+     * Marks all unwatched episodes up to and including [target] as watched in a single
+     * Trakt `POST /sync/history` call. Specials (season 0) are never included.
+     *
+     * The UI is updated optimistically before the network call; on failure the flip reverts
+     * and [ShowDetailUiState.toggleError] is set. A second call while
+     * [ShowDetailUiState.bulkInProgress] is true is a no-op.
+     */
+    fun markEarlierWatched(target: EpisodeUi) {
+        val show = _uiState.value.show ?: return
+        if (_uiState.value.bulkInProgress) return
+
+        val candidates = _uiState.value.seasons
+            .flatMap { s -> s.episodes.map { Triple(s.number, it.number, it.watched) } }
+            .filter { (s, _, _) -> s >= 1 }
+            .filter { (s, e, _) ->
+                s < target.season || (s == target.season && e <= target.number)
+            }
+            .filter { (_, _, watched) -> !watched }
+            .map { (s, e, _) -> s to e }
+            .sortedWith(compareBy({ it.first }, { it.second }))
+
+        if (candidates.isEmpty()) return
+
+        _uiState.update { state ->
+            state.copy(
+                bulkInProgress = true,
+                toggleError = null,
+                bulkSuccessCount = null,
+                seasons = state.seasons.map { season -> markCandidatesWatched(season, candidates) }
+            )
+        }
+
+        viewModelScope.launch {
+            val result = episodeRepository.markEpisodesWatchedUpTo(
+                ids = show.ids,
+                targetSeason = target.season,
+                targetEpisode = target.number,
+                candidates = candidates
+            )
+            result.fold(
+                onSuccess = {
+                    candidates.forEach { (s, e) ->
+                        showRepository.updateLocalWatched(traktShowId, s, e, watched = true)
+                    }
+                    _uiState.update { it.copy(bulkInProgress = false, bulkSuccessCount = candidates.size) }
+                },
+                onFailure = {
+                    _uiState.update { state ->
+                        state.copy(
+                            bulkInProgress = false,
+                            toggleError = getApplication<Application>()
+                                .getString(R.string.show_detail_error_bulk_toggle),
+                            seasons = state.seasons.map { season -> revertCandidates(season, candidates) }
+                        )
+                    }
+                }
+            )
+        }
+    }
+
+    private fun markCandidatesWatched(
+        season: SeasonUi,
+        candidates: List<Pair<Int, Int>>
+    ): SeasonUi {
+        val candidateEps = candidates
+            .filter { (s, _) -> s == season.number }
+            .map { (_, e) -> e }
+            .toSet()
+        if (candidateEps.isEmpty()) return season
+        val updated = season.episodes.map { ep ->
+            if (ep.number in candidateEps) ep.copy(watched = true) else ep
+        }
+        return season.copy(episodes = updated, watchedCount = updated.count { it.watched })
+    }
+
+    private fun revertCandidates(
+        season: SeasonUi,
+        candidates: List<Pair<Int, Int>>
+    ): SeasonUi {
+        val candidateEps = candidates
+            .filter { (s, _) -> s == season.number }
+            .map { (_, e) -> e }
+            .toSet()
+        if (candidateEps.isEmpty()) return season
+        val updated = season.episodes.map { ep ->
+            if (ep.number in candidateEps) ep.copy(watched = false) else ep
+        }
+        return season.copy(episodes = updated, watchedCount = updated.count { it.watched })
+    }
+
     fun clearToggleError() {
         _uiState.update { it.copy(toggleError = null) }
+    }
+
+    fun clearBulkSuccess() {
+        _uiState.update { it.copy(bulkSuccessCount = null) }
     }
 
     private suspend fun loadTmdbDetails(tmdbId: Int) {

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -167,6 +167,19 @@
     <string name="show_detail_cd_toggle_watched">Sehstatus für Folge %1$d in Staffel %2$d umschalten</string>
     <string name="show_detail_cd_expand_season">Staffel %1$d ausklappen</string>
     <string name="show_detail_cd_collapse_season">Staffel %1$d einklappen</string>
+    <string name="show_detail_cd_episode_menu">Optionen für Folge %1$d in Staffel %2$d</string>
+    <string name="show_detail_mark_earlier_watched">Diese und alle früheren Folgen als gesehen markieren</string>
+    <string name="show_detail_bulk_confirm_title">Frühere Folgen als gesehen markieren?</string>
+    <plurals name="show_detail_bulk_confirm_body">
+        <item quantity="one">S%1$02dF%2$02d und %3$d frühere Folge werden auf Trakt als gesehen markiert.</item>
+        <item quantity="other">S%1$02dF%2$02d und %3$d frühere Folgen werden auf Trakt als gesehen markiert.</item>
+    </plurals>
+    <string name="show_detail_bulk_confirm_action">Als gesehen markieren</string>
+    <plurals name="show_detail_bulk_success">
+        <item quantity="one">%d Folge als gesehen markiert</item>
+        <item quantity="other">%d Folgen als gesehen markiert</item>
+    </plurals>
+    <string name="show_detail_error_bulk_toggle">Folgen konnten nicht markiert werden — bitte erneut versuchen</string>
 
     <!-- Common -->
     <string name="no_description">Keine Beschreibung verfügbar.</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -168,6 +168,21 @@
     <string name="show_detail_cd_toggle_watched">Cambiar estado de visto del episodio %1$d de la temporada %2$d</string>
     <string name="show_detail_cd_expand_season">Expandir la temporada %1$d</string>
     <string name="show_detail_cd_collapse_season">Contraer la temporada %1$d</string>
+    <string name="show_detail_cd_episode_menu">Opciones del episodio %1$d de la temporada %2$d</string>
+    <string name="show_detail_mark_earlier_watched">Marcar este y todos los anteriores como vistos</string>
+    <string name="show_detail_bulk_confirm_title">¿Marcar los episodios anteriores como vistos?</string>
+    <plurals name="show_detail_bulk_confirm_body">
+        <item quantity="one">T%1$02dE%2$02d y %3$d episodio anterior se marcarán como vistos en Trakt.</item>
+        <item quantity="many">T%1$02dE%2$02d y %3$d episodios anteriores se marcarán como vistos en Trakt.</item>
+        <item quantity="other">T%1$02dE%2$02d y %3$d episodios anteriores se marcarán como vistos en Trakt.</item>
+    </plurals>
+    <string name="show_detail_bulk_confirm_action">Marcar como vistos</string>
+    <plurals name="show_detail_bulk_success">
+        <item quantity="one">%d episodio marcado como visto</item>
+        <item quantity="many">%d episodios marcados como vistos</item>
+        <item quantity="other">%d episodios marcados como vistos</item>
+    </plurals>
+    <string name="show_detail_error_bulk_toggle">No se pudieron marcar los episodios — inténtalo de nuevo</string>
 
     <!-- Common -->
     <string name="no_description">No hay descripción disponible.</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -168,6 +168,21 @@
     <string name="show_detail_cd_toggle_watched">Modifier le statut de visionnage de l\'épisode %1$d de la saison %2$d</string>
     <string name="show_detail_cd_expand_season">Développer la saison %1$d</string>
     <string name="show_detail_cd_collapse_season">Réduire la saison %1$d</string>
+    <string name="show_detail_cd_episode_menu">Options de l\'épisode %1$d de la saison %2$d</string>
+    <string name="show_detail_mark_earlier_watched">Marquer cet épisode et tous les précédents comme vus</string>
+    <string name="show_detail_bulk_confirm_title">Marquer les épisodes précédents comme vus ?</string>
+    <plurals name="show_detail_bulk_confirm_body">
+        <item quantity="one">S%1$02dÉ%2$02d et %3$d épisode précédent seront marqués comme vus sur Trakt.</item>
+        <item quantity="many">S%1$02dÉ%2$02d et %3$d épisodes précédents seront marqués comme vus sur Trakt.</item>
+        <item quantity="other">S%1$02dÉ%2$02d et %3$d épisodes précédents seront marqués comme vus sur Trakt.</item>
+    </plurals>
+    <string name="show_detail_bulk_confirm_action">Marquer comme vus</string>
+    <plurals name="show_detail_bulk_success">
+        <item quantity="one">%d épisode marqué comme vu</item>
+        <item quantity="many">%d épisodes marqués comme vus</item>
+        <item quantity="other">%d épisodes marqués comme vus</item>
+    </plurals>
+    <string name="show_detail_error_bulk_toggle">Impossible de marquer les épisodes — veuillez réessayer</string>
 
     <!-- Common -->
     <string name="no_description">Aucune description disponible.</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -176,6 +176,19 @@
     <string name="show_detail_cd_toggle_watched">Toggle watched status for episode %1$d of season %2$d</string>
     <string name="show_detail_cd_expand_season">Expand season %1$d</string>
     <string name="show_detail_cd_collapse_season">Collapse season %1$d</string>
+    <string name="show_detail_cd_episode_menu">Episode %1$d of season %2$d options</string>
+    <string name="show_detail_mark_earlier_watched">Mark this and all earlier as watched</string>
+    <string name="show_detail_bulk_confirm_title">Mark earlier episodes as watched?</string>
+    <plurals name="show_detail_bulk_confirm_body">
+        <item quantity="one">S%1$02dE%2$02d and %3$d earlier episode will be marked watched on Trakt.</item>
+        <item quantity="other">S%1$02dE%2$02d and %3$d earlier episodes will be marked watched on Trakt.</item>
+    </plurals>
+    <string name="show_detail_bulk_confirm_action">Mark watched</string>
+    <plurals name="show_detail_bulk_success">
+        <item quantity="one">%d episode marked watched</item>
+        <item quantity="other">%d episodes marked watched</item>
+    </plurals>
+    <string name="show_detail_error_bulk_toggle">Could not mark episodes — try again</string>
 
     <!-- Common -->
     <string name="no_description">No description available.</string>

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/EpisodeRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/EpisodeRepositoryTest.kt
@@ -134,3 +134,90 @@ class EpisodeRepositoryTest {
         assertTrue(result.exceptionOrNull() is IllegalStateException)
     }
 }
+
+class EpisodeRepositoryBulkTest {
+
+    private val traktApi: TraktApiService = mockk()
+    private val tokenRefreshManager: TokenRefreshManager = mockk()
+    private lateinit var repository: EpisodeRepository
+
+    @BeforeEach
+    fun setUp() {
+        repository = EpisodeRepository(traktApi, tokenRefreshManager)
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+    }
+
+    @Test
+    fun `markEpisodesWatchedUpTo builds one SyncHistoryBody grouped by season`() = runTest {
+        val slot = slot<SyncHistoryBody>()
+        coEvery { traktApi.addToHistory(any(), capture(slot)) } returns SyncHistoryResult()
+
+        val ids = TraktIds(trakt = 42, slug = "test-show")
+        val candidates = listOf(1 to 1, 1 to 3, 2 to 1, 2 to 2)
+        val result = repository.markEpisodesWatchedUpTo(
+            ids = ids,
+            targetSeason = 2,
+            targetEpisode = 2,
+            candidates = candidates
+        )
+
+        assertTrue(result.isSuccess)
+        val body = slot.captured
+        assertEquals(1, body.shows.size)
+        assertEquals(ids, body.shows[0].ids)
+
+        val seasons = body.shows[0].seasons.sortedBy { it.number }
+        assertEquals(2, seasons.size)
+
+        val s1 = seasons[0]
+        assertEquals(1, s1.number)
+        assertEquals(setOf(1, 3), s1.episodes.map { it.number }.toSet())
+
+        val s2 = seasons[1]
+        assertEquals(2, s2.number)
+        assertEquals(setOf(1, 2), s2.episodes.map { it.number }.toSet())
+    }
+
+    @Test
+    fun `markEpisodesWatchedUpTo returns success and makes no HTTP call for empty candidates`() = runTest {
+        val result = repository.markEpisodesWatchedUpTo(
+            ids = TraktIds(trakt = 1),
+            targetSeason = 1,
+            targetEpisode = 1,
+            candidates = emptyList()
+        )
+
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 0) { traktApi.addToHistory(any(), any()) }
+    }
+
+    @Test
+    fun `markEpisodesWatchedUpTo returns failure when API throws`() = runTest {
+        coEvery { traktApi.addToHistory(any(), any()) } throws RuntimeException("Network error")
+
+        val result = repository.markEpisodesWatchedUpTo(
+            ids = TraktIds(trakt = 1),
+            targetSeason = 2,
+            targetEpisode = 3,
+            candidates = listOf(1 to 1, 1 to 2)
+        )
+
+        assertTrue(result.isFailure)
+        assertEquals("Network error", result.exceptionOrNull()?.message)
+    }
+
+    @Test
+    fun `markEpisodesWatchedUpTo returns failure when no access token`() = runTest {
+        coEvery { tokenRefreshManager.getValidAccessToken() } returns null
+
+        val result = repository.markEpisodesWatchedUpTo(
+            ids = TraktIds(trakt = 1),
+            targetSeason = 1,
+            targetEpisode = 1,
+            candidates = listOf(1 to 1)
+        )
+
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IllegalStateException)
+    }
+}

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModelTest.kt
@@ -16,12 +16,15 @@ import com.justb81.watchbuddy.phone.server.EpisodeRepository
 import com.justb81.watchbuddy.phone.server.ShowRepository
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import io.mockk.Runs
+import io.mockk.coAnswers
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
+import io.mockk.match
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -392,6 +395,172 @@ class ShowDetailViewModelTest {
 
             vm.clearToggleError()
             assertNull(vm.uiState.value.toggleError)
+        }
+    }
+
+    @Nested
+    @DisplayName("markEarlierWatched")
+    inner class BulkMarkTest {
+
+        @Test
+        fun `filters out already-watched episodes and specials`() = runTest {
+            // S0 (special), S1 E1 watched, S1 E2 unwatched, S2 E1 unwatched.
+            seedLibrary(
+                watchedSeasons = listOf(
+                    TraktWatchedSeason(1, listOf(TraktWatchedEpisode(1)))
+                )
+            )
+            coEvery { episodeRepository.getSeasonsWithEpisodes(any()) } returns seasonsPayload(
+                mapOf(0 to 1, 1 to 2, 2 to 1)
+            )
+            coEvery {
+                episodeRepository.markEpisodesWatchedUpTo(any(), any(), any(), any())
+            } returns Result.success(Unit)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // Target: S2E1. Candidates should be S1E2 + S2E1 (S0 excluded, S1E1 already watched).
+            val target = vm.uiState.value.seasons.first { it.number == 2 }.episodes.first { it.number == 1 }
+            vm.markEarlierWatched(target)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) {
+                episodeRepository.markEpisodesWatchedUpTo(
+                    ids = any(),
+                    targetSeason = 2,
+                    targetEpisode = 1,
+                    candidates = match { list ->
+                        list.toSet() == setOf(1 to 2, 2 to 1)
+                    }
+                )
+            }
+        }
+
+        @Test
+        fun `optimistic flip then updateLocalWatched called per candidate on success`() = runTest {
+            seedLibrary()
+            coEvery { episodeRepository.getSeasonsWithEpisodes(any()) } returns seasonsPayload(
+                mapOf(1 to 3)
+            )
+            coEvery {
+                episodeRepository.markEpisodesWatchedUpTo(any(), any(), any(), any())
+            } returns Result.success(Unit)
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // All 3 episodes are unwatched; target S1E2 → candidates S1E1, S1E2.
+            val target = vm.uiState.value.seasons.first().episodes.first { it.number == 2 }
+            vm.markEarlierWatched(target)
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.bulkInProgress)
+            assertNull(vm.uiState.value.toggleError)
+            assertEquals(2, vm.uiState.value.bulkSuccessCount)
+
+            // Both candidates flipped to watched in the UI.
+            val eps = vm.uiState.value.seasons.first().episodes
+            assertTrue(eps.first { it.number == 1 }.watched)
+            assertTrue(eps.first { it.number == 2 }.watched)
+            assertFalse(eps.first { it.number == 3 }.watched) // not a candidate
+
+            coVerify(exactly = 1) { showRepository.updateLocalWatched(TRAKT_SHOW_ID, 1, 1, true) }
+            coVerify(exactly = 1) { showRepository.updateLocalWatched(TRAKT_SHOW_ID, 1, 2, true) }
+            coVerify(exactly = 0) { showRepository.updateLocalWatched(TRAKT_SHOW_ID, 1, 3, any()) }
+        }
+
+        @Test
+        fun `failure path reverts only candidate episodes, not pre-existing watched episodes`() = runTest {
+            // S1E1 already watched before the operation.
+            seedLibrary(
+                watchedSeasons = listOf(
+                    TraktWatchedSeason(1, listOf(TraktWatchedEpisode(1)))
+                )
+            )
+            coEvery { episodeRepository.getSeasonsWithEpisodes(any()) } returns seasonsPayload(
+                mapOf(1 to 3)
+            )
+            every { application.getString(any()) } returns "bulk-error"
+            coEvery {
+                episodeRepository.markEpisodesWatchedUpTo(any(), any(), any(), any())
+            } returns Result.failure(RuntimeException("network"))
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            // Target S1E3 — candidates are S1E2, S1E3 (S1E1 already watched).
+            val target = vm.uiState.value.seasons.first().episodes.first { it.number == 3 }
+            vm.markEarlierWatched(target)
+            advanceUntilIdle()
+
+            assertFalse(vm.uiState.value.bulkInProgress)
+            assertNotNull(vm.uiState.value.toggleError)
+
+            val eps = vm.uiState.value.seasons.first().episodes
+            // Pre-existing watched episode must remain watched after revert.
+            assertTrue(eps.first { it.number == 1 }.watched)
+            // Candidate episodes reverted to unwatched.
+            assertFalse(eps.first { it.number == 2 }.watched)
+            assertFalse(eps.first { it.number == 3 }.watched)
+            coVerify(exactly = 0) { showRepository.updateLocalWatched(any(), any(), any(), any()) }
+        }
+
+        @Test
+        fun `re-entry while bulkInProgress is a no-op`() = runTest {
+            seedLibrary()
+            coEvery { episodeRepository.getSeasonsWithEpisodes(any()) } returns seasonsPayload(
+                mapOf(1 to 2)
+            )
+            // Suspend the operation so bulkInProgress stays true.
+            coEvery {
+                episodeRepository.markEpisodesWatchedUpTo(any(), any(), any(), any())
+            } coAnswers {
+                kotlinx.coroutines.delay(10_000)
+                Result.success(Unit)
+            }
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val target = vm.uiState.value.seasons.first().episodes.first { it.number == 2 }
+            vm.markEarlierWatched(target)
+
+            // bulkInProgress should be true now (operation not finished).
+            assertTrue(vm.uiState.value.bulkInProgress)
+
+            // Second call is a no-op — only one HTTP call ever issued.
+            vm.markEarlierWatched(target)
+
+            coVerify(exactly = 1) {
+                episodeRepository.markEpisodesWatchedUpTo(any(), any(), any(), any())
+            }
+        }
+
+        @Test
+        fun `no-op when all episodes at or before target are already watched`() = runTest {
+            // Both S1E1 and S1E2 already watched.
+            seedLibrary(
+                watchedSeasons = listOf(
+                    TraktWatchedSeason(1, listOf(TraktWatchedEpisode(1), TraktWatchedEpisode(2)))
+                )
+            )
+            coEvery { episodeRepository.getSeasonsWithEpisodes(any()) } returns seasonsPayload(
+                mapOf(1 to 2)
+            )
+
+            val vm = createViewModel()
+            advanceUntilIdle()
+
+            val target = vm.uiState.value.seasons.first().episodes.first { it.number == 2 }
+            vm.markEarlierWatched(target)
+            advanceUntilIdle()
+
+            // No bulk call made, no progress flag set.
+            assertFalse(vm.uiState.value.bulkInProgress)
+            coVerify(exactly = 0) {
+                episodeRepository.markEpisodesWatchedUpTo(any(), any(), any(), any())
+            }
         }
     }
 }

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModelTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/ui/showdetail/ShowDetailViewModelTest.kt
@@ -15,14 +15,7 @@ import com.justb81.watchbuddy.phone.MainDispatcherRule
 import com.justb81.watchbuddy.phone.server.EpisodeRepository
 import com.justb81.watchbuddy.phone.server.ShowRepository
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
-import io.mockk.Runs
-import io.mockk.coAnswers
-import io.mockk.coEvery
-import io.mockk.coVerify
-import io.mockk.every
-import io.mockk.just
-import io.mockk.match
-import io.mockk.mockk
+import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -516,7 +509,7 @@ class ShowDetailViewModelTest {
             coEvery {
                 episodeRepository.markEpisodesWatchedUpTo(any(), any(), any(), any())
             } coAnswers {
-                kotlinx.coroutines.delay(10_000)
+                delay(10_000)
                 Result.success(Unit)
             }
 

--- a/docs/trakt-flow.md
+++ b/docs/trakt-flow.md
@@ -30,7 +30,7 @@ graph TB
     subgraph WIFI["LOCAL WIFI NETWORK"]
         TV["Google TV (app-tv)\n─────────────\nScrobbler\nShow grid\nDeep links\nRecap WebView"]
         Phone["Android Phone(s) (app-phone)\n─────────────\nTrakt OAuth login\nToken storage\nLLM recap engine\nShow cache"]
-        TV <-->|"NSD/mDNS + HTTP\nport 8765\nGET /shows · GET /capability\nPOST /recap · POST /scrobble/*"| Phone
+        TV <-->|"BLE beacon + HTTP\nport 8765\nGET /shows · GET /capability\nPOST /recap · POST /scrobble/*"| Phone
     end
 
     Phone -->|"Auth · sync · scrobble"| Trakt["Trakt API\ntrakt.tv/api"]
@@ -90,7 +90,7 @@ flowchart TD
 
 1. After Trakt login, user enables the **Companion Service** in Settings.
 2. The phone starts a foreground service with a persistent notification.
-3. The phone is now discoverable by TV apps on the same Wi-Fi network.
+3. The phone is discoverable by TV apps on the same Wi-Fi network.
 
 ### Technical Flow
 
@@ -98,7 +98,7 @@ flowchart TD
 flowchart TD
     A["SettingsViewModel.toggleCompanionService()"] --> B["CompanionService starts\n(foreground, persistent notification)"]
     B --> C["Starts CompanionHttpServer\n(Ktor Netty, port 8765)"]
-    B --> D["Registers NSD (mDNS) service:\nname: watchbuddy-username\ntype: _watchbuddy._tcp.\nport: 8765\nTXT: version=1, modelQuality=90, llmBackend=LITERT"]
+    B --> D["Starts CompanionBleAdvertiser\nBroadcasts 9-byte BLE service-data payload:\nIPv4 address, port 8765,\nmodelQuality, llmBackend ordinal"]
 ```
 
 ### HTTP Endpoints (Phone Serves)
@@ -127,8 +127,8 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    A["TV app starts"] --> B["PhoneDiscoveryManager.startDiscovery()\nListens for NSD type: _watchbuddy._tcp."]
-    B --> C["Phone discovered\nresolve IP + port"]
+    A["TV app starts"] --> B["PhoneDiscoveryManager.startDiscovery()\nPhoneBleScanner listens for BLE advertisements"]
+    B --> C["Phone BLE advertisement received\nextract IPv4 + port from 9-byte service-data payload"]
     C --> D["GET http://phone_ip:8765/capability"]
     D --> E["Response: DeviceCapability\n{ deviceName, userName, llmBackend,\nmodelQuality, freeRamMb, tmdbApiKey }"]
     E --> F["Rank phone:\nscore = modelQuality (0–150)\n+ ramBonus (0–10)"]
@@ -141,7 +141,7 @@ RAM bonus calculation: ≥ 6 GB → +10 | 4–6 GB → +6 | 3–4 GB → +3 | < 
 
 | Class | Responsibility |
 |-------|----------------|
-| `PhoneDiscoveryManager` | NSD listener, phone ranking, best-phone selection |
+| `PhoneDiscoveryManager` | BLE advertisement listener, phone ranking, best-phone selection |
 | `PhoneApiService` | Retrofit interface for phone HTTP endpoints |
 | `PhoneApiClientFactory` | Creates per-phone Retrofit clients (cached by base URL) |
 
@@ -374,7 +374,7 @@ The `TraktApiService` and `TokenProxyService` both define refresh endpoints (`PO
 | Media session poll interval | 30 seconds | `MediaSessionScrobbler` |
 | Phone show cache TTL | 5 minutes | `ShowRepository` |
 | Companion server port | 8765 | `CompanionHttpServer` |
-| NSD service type | `_watchbuddy._tcp.` | `CompanionService` |
+| BLE service UUID | `5e4b4d3a-9f7c-4b7e-8e6b-6c0e5f27e4a0` | `CompanionBleAdvertiser` |
 | Backend rate limit | 60 req/min per IP | `backend/src/app.js` |
 | Recap episode context | Last 8 episodes | `RecapGenerator` |
 
@@ -484,7 +484,7 @@ sequenceDiagram
 | `app-phone/.../server/CompanionHttpServer.kt` | Ktor HTTP server (endpoints listed above) |
 | `app-phone/.../server/ShowRepository.kt` | Trakt show cache with 5-min TTL |
 | `app-phone/.../server/DeviceCapabilityProvider.kt` | Device info + TMDB API key for `/capability` |
-| `app-phone/.../service/CompanionService.kt` | Foreground service, NSD registration |
+| `app-phone/.../service/CompanionService.kt` | Foreground service, BLE advertisement via `CompanionBleAdvertiser` |
 
 ### Phone App — Library UI
 
@@ -499,7 +499,7 @@ sequenceDiagram
 
 | File | Purpose |
 |------|---------|
-| `app-tv/.../discovery/PhoneDiscoveryManager.kt` | NSD listener, phone ranking |
+| `app-tv/.../discovery/PhoneDiscoveryManager.kt` | BLE advertisement listener, phone ranking |
 | `app-tv/.../discovery/PhoneApiService.kt` | Retrofit interface for phone HTTP API |
 | `app-tv/.../discovery/PhoneApiClientFactory.kt` | Per-phone Retrofit client factory |
 


### PR DESCRIPTION
## Summary
- Add `markEpisodesWatchedUpTo()` to `EpisodeRepository` using a single `POST /sync/history` bulk call grouped by season
- Add `markEarlierWatched()` action to `ShowDetailViewModel` with optimistic flip, `bulkInProgress` re-entry guard, and revert-on-failure
- Add overflow menu entry (three-dot icon) on each episode row in `ShowDetailScreen` with confirmation `AlertDialog` showing episode and candidate count
- Add success snackbar via `bulkSuccessCount` state and `clearBulkSuccess()` cleanup
- Add all required strings in EN, DE, FR, ES locales
- Add unit tests for `EpisodeRepository.markEpisodesWatchedUpTo` (empty candidates, grouped body, failure paths)
- Add unit tests for `ShowDetailViewModel.markEarlierWatched` (specials excluded, optimistic flip, revert-on-failure, re-entry guard, no-op when all already watched)

## Test plan
- [ ] Overflow menu entry appears on each episode row in `ShowDetailScreen`
- [ ] Menu entry is disabled when `bulkInProgress` is true or no earlier unwatched episode exists
- [ ] Confirmation dialog shows correct season/episode and candidate count
- [ ] Confirming sends exactly one network call to `POST /sync/history` covering all candidate episodes
- [ ] Optimistic flip: all candidate episodes immediately shown as watched before network call completes
- [ ] Success snackbar shows "{n} episodes marked watched" after confirmation
- [ ] On network failure: snackbar shows error, all candidate flips revert, pre-existing watched episodes unaffected
- [ ] Specials (season 0) are never included in candidates regardless of target episode
- [ ] Unit tests pass for `EpisodeRepository` and `ShowDetailViewModel` bulk-mark logic

> Note: Gradle scope skipped locally (no Android SDK in CI runner); CI is the real gate for Kotlin/Android changes.

Closes #520

https://claude.ai/code/session_013PNZkpfbQfqXhidTsziQak

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwhRPfww8qQ68zfqcA6Ahq)_