### PR TITLE
docs: add missing GET /provider-catalog endpoint to architecture.md

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,7 @@ distributed via BLE scan response; see above). Missing or wrong bearer returns H
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/capability` | Device info + LLM score + TMDB API key + `avatarSource` + `lastResolvedSessionKey` + `lastResolvedTraktId` (#342, #474) — **unauthenticated** |
+| GET | `/provider-catalog` | Streaming provider catalog (Netflix, Disney+, etc.) with TMDB provider IDs and package names; ETag-revalidated (`Cache-Control: public, max-age=86400`); 404 until the catalog has been fetched from the backend — **unauthenticated** |
 | GET | `/avatar` | Custom avatar JPEG (200 bytes, ETag-revalidated; 404 when `avatarSource != CUSTOM`) |
 | GET | `/shows` | User's Trakt watched shows (cached), paginated via `offset` + `limit` query params |
 | POST | `/recap/{traktShowId}` | Generate HTML recap for a show |


### PR DESCRIPTION
## Summary
- Adds the missing `GET /provider-catalog` endpoint to the HTTP API table in `docs/architecture.md`
- The endpoint was added in PR #666 but was omitted from the documentation
- Details confirmed from `CompanionHttpServer.kt`: unauthenticated, ETag-revalidated, `Cache-Control: public, max-age=86400` (24 h)

## Test plan
- [ ] Verify the new table row appears correctly in docs/architecture.md
- [ ] Verify the endpoint details (method, path, description, auth) match the implementation in CompanionHttpServer.kt

Closes #673

> Note: Gradle scope skipped locally (no Android SDK in CI runner); CI is the gate.

https://claude.ai/code/session_019EZ7A6Vfmj9k54y81h9ov6

---
_Generated by [Claude Code](https://claude.ai/code/session_019EZ7A6Vfmj9k54y81h9ov6)_