### PR TITLE
feat: one-tap mark-as-watched button on TV show detail screen (#671)

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -2,6 +2,13 @@ package com.justb81.watchbuddy.tv.ui.showdetail
 
 import android.content.Context
 import android.content.Intent
+import android.widget.Toast
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.*
@@ -36,14 +43,17 @@ import com.justb81.watchbuddy.core.model.ResolvedProvider
 import com.justb81.watchbuddy.core.tmdb.TmdbImageHelper
 import com.justb81.watchbuddy.tv.ui.components.SeasonEpisodeListPicker
 import com.justb81.watchbuddy.tv.ui.components.UserScopePickerDialog
+import kotlinx.coroutines.delay
 
 private const val TMDB_POSTER_WIDTH = 500
+private const val MARK_WATCHED_TOAST_DELAY_MS = 3_000L
 
 private data class ShowDetailActions(
     val onWatchNow: () -> Unit,
     val onProviderClick: (ResolvedProvider) -> Unit,
     val onRetryProviders: () -> Unit,
     val onRecapClick: () -> Unit,
+    val onMarkWatched: () -> Unit,
     val onEpisodeToggle: (season: Int, episode: Int, currentlyWatched: Boolean) -> Unit,
 )
 
@@ -59,12 +69,16 @@ fun ShowDetailScreen(
     viewModel: ShowDetailViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
-    val entry = enriched.entry
+    val advanced by viewModel.advancedEntry.collectAsState()
+    // Transparently switch to the optimistically-advanced entry once a mark-watched succeeds.
+    val effectiveEntry = advanced ?: enriched
+    val entry = effectiveEntry.entry
     val nextEpisodeUi by viewModel.nextEpisode.collectAsState()
     val providerState by viewModel.providers.collectAsState()
     val deepLinks by viewModel.deepLinks.collectAsState()
     val watchNowState by viewModel.watchNowState.collectAsState()
     val episodeListState by viewModel.episodeList.collectAsState()
+    val markState by viewModel.markWatchedState.collectAsState()
     val watchNowFocus = remember { FocusRequester() }
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -73,6 +87,8 @@ fun ShowDetailScreen(
 
     val allFailedMsg = stringResource(R.string.tv_detail_toggle_failed_all)
     val partialFailedMsg = stringResource(R.string.tv_detail_toggle_failed_partial)
+    val markWatchedNoPhonesMsg = stringResource(R.string.tv_mark_watched_no_phones)
+    val markWatchedErrorMsg = stringResource(R.string.tv_mark_watched_error)
 
     ShowDetailEffects(
         viewModel = viewModel,
@@ -84,18 +100,31 @@ fun ShowDetailScreen(
         partialFailedMsg = partialFailedMsg,
     )
 
-    val imageUrl = nextEpisodeUi.stillUrl ?: TmdbImageHelper.poster(enriched.posterPath, TMDB_POSTER_WIDTH)
+    // One-shot toast for mark-watched feedback, then acknowledge to reset to Idle.
+    LaunchedEffect(markState) {
+        val msg = when (markState) {
+            MarkWatchedState.NoPhones -> markWatchedNoPhonesMsg
+            MarkWatchedState.Error -> markWatchedErrorMsg
+            else -> null
+        } ?: return@LaunchedEffect
+        Toast.makeText(context, msg, Toast.LENGTH_LONG).show()
+        delay(MARK_WATCHED_TOAST_DELAY_MS)
+        viewModel.acknowledgeMarkWatchedFeedback()
+    }
+
+    val imageUrl = nextEpisodeUi.stillUrl ?: TmdbImageHelper.poster(effectiveEntry.posterPath, TMDB_POSTER_WIDTH)
 
     Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
         ShowDetailImagePanel(imageUrl, modifier = Modifier.align(Alignment.CenterStart))
         ShowDetailGradient()
         ShowDetailContent(
-            enriched = enriched,
+            enriched = effectiveEntry,
             nextEpisode = nextEpisodeUi,
             providerState = providerState,
             deepLinks = deepLinks,
             watchNowState = watchNowState,
             episodeListState = episodeListState,
+            markState = markState,
             watchNowFocus = watchNowFocus,
             actions = ShowDetailActions(
                 onWatchNow = {
@@ -107,11 +136,12 @@ fun ShowDetailScreen(
                     }
                 },
                 onProviderClick = { provider ->
-                    val link = viewModel.onProviderSelected(provider, enriched)
+                    val link = viewModel.onProviderSelected(provider, effectiveEntry)
                     launchProvider(context, provider, link)
                 },
-                onRetryProviders = { viewModel.loadProviders(enriched) },
+                onRetryProviders = { viewModel.loadProviders(effectiveEntry) },
                 onRecapClick = onRecapClick,
+                onMarkWatched = { viewModel.markCurrentEpisodeWatched(effectiveEntry) },
                 onEpisodeToggle = { season, episode, currentlyWatched ->
                     if (viewModel.skipScopePickerThisSession) {
                         val allIds = viewModel.connectedUsers().map { it.id }.toSet()
@@ -143,7 +173,7 @@ fun ShowDetailScreen(
 
     ShowDetailScopePicker(
         viewModel = viewModel,
-        enriched = enriched,
+        enriched = effectiveEntry,
         pendingToggle = pendingToggle,
         onDismiss = { pendingToggle = null },
     )
@@ -236,6 +266,7 @@ private fun ShowDetailContent(
     deepLinks: Map<Int, DeepLinkState>,
     watchNowState: WatchNowState,
     episodeListState: EpisodeListUiState,
+    markState: MarkWatchedState,
     watchNowFocus: FocusRequester,
     actions: ShowDetailActions,
     modifier: Modifier = Modifier,
@@ -268,21 +299,39 @@ private fun ShowDetailContent(
         }
         Spacer(Modifier.height(8.dp))
         Text(text = stringResource(R.string.tv_next_episode), fontSize = 14.sp, color = Color.White.copy(alpha = 0.5f))
-        Text(
-            text = episodeTitle ?: stringResource(R.string.tv_next_episode),
-            fontSize = 20.sp,
-            fontWeight = FontWeight.SemiBold,
-            color = Color.White,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis
-        )
-        Text(text = episodeCode, fontSize = 14.sp, color = Color.White.copy(alpha = 0.6f))
+        // AnimatedContent slides the episode info out left and slides new episode in from the right
+        // whenever the episodeCode changes (driven by advancedEntry optimistic update).
+        AnimatedContent(
+            targetState = episodeCode,
+            transitionSpec = {
+                (slideInHorizontally { it } + fadeIn()) togetherWith
+                    (slideOutHorizontally { -it } + fadeOut())
+            },
+            label = "next-episode",
+        ) { code ->
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    text = episodeTitle ?: stringResource(R.string.tv_next_episode),
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.White,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(text = code, fontSize = 14.sp, color = Color.White.copy(alpha = 0.6f))
+            }
+        }
         Spacer(Modifier.height(8.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
             WatchNowButton(
                 state = watchNowState,
                 onClick = actions.onWatchNow,
                 focusRequester = watchNowFocus,
+            )
+            MarkWatchedButton(
+                state = markState,
+                hasNextEpisode = nextEpisode.episodeCode != null,
+                onClick = actions.onMarkWatched,
             )
             OutlinedButton(onClick = actions.onRecapClick) { Text(stringResource(R.string.tv_recap)) }
         }
@@ -354,6 +403,38 @@ private fun WatchNowButton(
                 Text(text = stringResource(R.string.tv_watch_now_no_provider), fontWeight = FontWeight.Bold)
             }
         }
+    }
+}
+
+/**
+ * "Mark as watched" button for the current next-unwatched episode.
+ *
+ * - Disabled while [state] is [MarkWatchedState.Loading] or [hasNextEpisode] is false.
+ * - Shows a small spinner inline while [state] is [MarkWatchedState.Loading].
+ * - Error / no-phones states are surfaced via one-shot toasts in [ShowDetailScreen];
+ *   the button renders as Idle in those states (they reset back to Idle after the toast).
+ */
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun MarkWatchedButton(
+    state: MarkWatchedState,
+    hasNextEpisode: Boolean,
+    onClick: () -> Unit,
+) {
+    val isLoading = state is MarkWatchedState.Loading
+    OutlinedButton(
+        onClick = onClick,
+        enabled = !isLoading && hasNextEpisode,
+    ) {
+        if (isLoading) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(16.dp),
+                color = Color.White,
+                strokeWidth = 2.dp,
+            )
+            Spacer(Modifier.width(8.dp))
+        }
+        Text(stringResource(R.string.tv_mark_watched))
     }
 }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailViewModel.kt
@@ -7,6 +7,8 @@ import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.ResolvedProvider
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktSeasonWithEpisodes
+import com.justb81.watchbuddy.core.model.TraktWatchedEpisode
+import com.justb81.watchbuddy.core.model.TraktWatchedSeason
 import com.justb81.watchbuddy.core.progress.ShowProgressCalculator
 import com.justb81.watchbuddy.core.scrobbler.PlaybackIntent
 import com.justb81.watchbuddy.core.scrobbler.PlaybackIntentProvider
@@ -114,6 +116,23 @@ sealed interface EpisodeListUiState {
     object Error : EpisodeListUiState
 }
 
+/**
+ * State machine for the one-tap "Mark as watched" button on [ShowDetailScreen].
+ *
+ * - [Idle] — the button is ready for the next press.
+ * - [Loading] — a mark-watched request is in flight; the button shows a spinner.
+ * - [NoPhones] — no phones were connected at the time of the press; card does not advance.
+ *   The UI should surface a one-shot toast and then reset to [Idle].
+ * - [Error] — all connected phones failed the write; card does not advance.
+ *   The UI should surface a one-shot toast and then reset to [Idle].
+ */
+sealed interface MarkWatchedState {
+    data object Idle : MarkWatchedState
+    data object Loading : MarkWatchedState
+    data object NoPhones : MarkWatchedState
+    data object Error : MarkWatchedState
+}
+
 /** One-shot events emitted when a toggle operation partially or fully fails. */
 sealed interface EpisodeToggleEvent {
     /** Every selected phone failed — the UI reverts the optimistic toggle. */
@@ -162,6 +181,20 @@ class ShowDetailViewModel @Inject constructor(
 
     private val _episodeToggleEvents = MutableSharedFlow<EpisodeToggleEvent>()
     val episodeToggleEvents: SharedFlow<EpisodeToggleEvent> = _episodeToggleEvents.asSharedFlow()
+
+    private val _markWatchedState = MutableStateFlow<MarkWatchedState>(MarkWatchedState.Idle)
+
+    /** UI state for the one-tap "Mark as watched" button. */
+    val markWatchedState: StateFlow<MarkWatchedState> = _markWatchedState.asStateFlow()
+
+    /**
+     * Optimistically-advanced [EnrichedShowEntry] after at least one successful mark.
+     * The screen uses `advancedEntry ?: enriched` so it transparently switches to the
+     * advanced entry once the first mark-watched write succeeds, without waiting for
+     * the next `/shows` poll.
+     */
+    private val _advancedEntry = MutableStateFlow<EnrichedShowEntry?>(null)
+    val advancedEntry: StateFlow<EnrichedShowEntry?> = _advancedEntry.asStateFlow()
 
     /**
      * When true, [toggleEpisodeWatched] skips showing the scope picker and uses
@@ -366,6 +399,107 @@ class ShowDetailViewModel @Inject constructor(
                 val name = phone.capability?.userName?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
                 ConnectedUser(id = phone.baseUrl, displayName = name)
             }
+
+    /**
+     * Marks the currently-displayed next episode as watched for **every** connected phone.
+     *
+     * - If no phones are connected, emits [MarkWatchedState.NoPhones] and does not advance.
+     * - If all phone writes fail, emits [MarkWatchedState.Error] and does not advance.
+     * - If at least one phone succeeds (partial failure is still a success), advances the
+     *   next-episode card via [_advancedEntry] and reloads deep links for the new episode.
+     *
+     * Reuses #217's fan-out infrastructure via [clientFactory] and [phoneDiscovery].
+     * No new transport or endpoint is added here.
+     */
+    fun markCurrentEpisodeWatched(enriched: EnrichedShowEntry) {
+        val (season, episode) = ShowProgressCalculator
+            .nextUnwatchedEpisodeNumbers(enriched.entry, enriched.tmdb) ?: return
+
+        viewModelScope.launch {
+            val phones = phoneDiscovery.discoveredPhones.value
+            if (phones.isEmpty()) {
+                _markWatchedState.value = MarkWatchedState.NoPhones
+                return@launch
+            }
+            _markWatchedState.value = MarkWatchedState.Loading
+
+            val pendingKey = phones.firstNotNullOfOrNull { it.capability?.lastResolvedSessionKey }
+            val request = WatchedToggleRequest(
+                showIds = enriched.entry.show.ids,
+                season = season,
+                episode = episode,
+                resolvesSessionKey = pendingKey,
+            )
+
+            data class PhoneResult(val success: Boolean)
+
+            val results = coroutineScope {
+                phones.map { phone ->
+                    async {
+                        val success = runCatching {
+                            val client = clientFactory.createClient(phone.baseUrl, phone.bearerToken)
+                            client.markWatched(request).isSuccessful
+                        }.getOrDefault(false)
+                        PhoneResult(success)
+                    }
+                }.awaitAll()
+            }
+
+            val anySuccess = results.any { it.success }
+            if (!anySuccess) {
+                _markWatchedState.value = MarkWatchedState.Error
+                return@launch
+            }
+
+            // Optimistic local advance — drives AnimatedContent in the screen.
+            val advanced = advanceWatched(enriched, season, episode)
+            _advancedEntry.value = advanced
+            loadNextEpisode(advanced)
+            _deepLinks.value = emptyMap()
+            loadDeepLinks(advanced)
+            _markWatchedState.value = MarkWatchedState.Idle
+        }
+    }
+
+    /**
+     * Resets [markWatchedState] to [MarkWatchedState.Idle] after the UI has shown the
+     * one-shot [MarkWatchedState.NoPhones] or [MarkWatchedState.Error] toast.
+     */
+    fun acknowledgeMarkWatchedFeedback() {
+        _markWatchedState.value = MarkWatchedState.Idle
+    }
+
+    /**
+     * Returns a copy of [enriched] in which (season, episode) is recorded as watched
+     * with the current timestamp. This drives the optimistic UI update in [markCurrentEpisodeWatched]
+     * and does not wait for the phone's `/shows` poll.
+     */
+    private fun advanceWatched(
+        enriched: EnrichedShowEntry,
+        season: Int,
+        episode: Int,
+    ): EnrichedShowEntry {
+        val nowIso = java.time.Instant.now().toString()
+        val existing = enriched.entry.seasons.find { it.number == season }
+        val updatedSeasons = when {
+            existing == null -> (enriched.entry.seasons + TraktWatchedSeason(
+                number = season,
+                episodes = listOf(TraktWatchedEpisode(number = episode, last_watched_at = nowIso)),
+            )).sortedBy { it.number }
+            existing.episodes.any { it.number == episode } -> enriched.entry.seasons
+            else -> enriched.entry.seasons.map { s ->
+                if (s.number != season) {
+                    s
+                } else {
+                    s.copy(
+                        episodes = (s.episodes + TraktWatchedEpisode(number = episode, last_watched_at = nowIso))
+                            .sortedBy { it.number },
+                    )
+                }
+            }
+        }
+        return enriched.copy(entry = enriched.entry.copy(seasons = updatedSeasons))
+    }
 
     /**
      * Fetches all seasons + episodes for [enriched] from the best available phone and

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -57,6 +57,10 @@
     <string name="tv_error_phone_unreachable">Begleit-App nicht erreichbar. Zwischengespeicherte Daten werden angezeigt.</string>
     <string name="tv_error_phone_unreachable_no_cache">Begleit-App nicht erreichbar. Stelle sicher, dass WatchBuddy auf deinem Handy läuft.</string>
     <string name="tv_stale_cache_banner">Gespeicherte Liste wird angezeigt – Handy offline</string>
+    <!-- Show detail — one-tap mark as watched (#671) -->
+    <string name="tv_mark_watched">Als gesehen markieren</string>
+    <string name="tv_mark_watched_no_phones">Kein verbundenes Telefon — bitte ein Telefon verbinden, um Folgen zu markieren.</string>
+    <string name="tv_mark_watched_error">Folge konnte nicht als gesehen markiert werden.</string>
 
     <!-- Show detail — manually mark episodes watched (#217) -->
     <string name="tv_detail_episodes">Folgen</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -60,6 +60,10 @@
     <string name="tv_error_phone_unreachable">Aplicación compañera inaccesible. Mostrando datos en caché.</string>
     <string name="tv_error_phone_unreachable_no_cache">Aplicación compañera inaccesible. Asegúrate de que WatchBuddy está en ejecución en tu teléfono.</string>
     <string name="tv_stale_cache_banner">Mostrando lista en caché — teléfono sin conexión</string>
+    <!-- Show detail — one-tap mark as watched (#671) -->
+    <string name="tv_mark_watched">Marcar como visto</string>
+    <string name="tv_mark_watched_no_phones">Ningún teléfono conectado — conecta un teléfono para marcar episodios.</string>
+    <string name="tv_mark_watched_error">No se pudo marcar el episodio como visto.</string>
 
     <!-- Show detail — manually mark episodes watched (#217) -->
     <string name="tv_detail_episodes">Episodios</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -60,6 +60,10 @@
     <string name="tv_error_phone_unreachable">Application compagnon inaccessible. Affichage des données en cache.</string>
     <string name="tv_error_phone_unreachable_no_cache">Application compagnon inaccessible. Assurez-vous que WatchBuddy est en cours d\'exécution sur votre téléphone.</string>
     <string name="tv_stale_cache_banner">Liste en cache affichée — téléphone hors ligne</string>
+    <!-- Show detail — one-tap mark as watched (#671) -->
+    <string name="tv_mark_watched">Marquer comme vu</string>
+    <string name="tv_mark_watched_no_phones">Aucun téléphone connecté — connectez un téléphone pour marquer les épisodes.</string>
+    <string name="tv_mark_watched_error">Impossible de marquer l\'episode comme vu.</string>
 
     <!-- Show detail — manually mark episodes watched (#217) -->
     <string name="tv_detail_episodes">Épisodes</string>
@@ -114,7 +118,7 @@
     <string name="tv_settings_show_non_installed_subtitle">Afficher aussi les services de streaming non installés sur ce téléviseur</string>
     <string name="tv_settings_diagnostics">Diagnostics</string>
     <string name="tv_settings_debug_log_media_session_title">Débogage : consigner chaque session média</string>
-    <string name="tv_settings_debug_log_media_session_subtitle">Consigne chaque session média détectée dans le journal d\'événements</string>
+    <string name="tv_settings_debug_log_media_session_subtitle">Consigne chaque session média détectée dans le journal d\'vénements</string>
     <string name="tv_settings_notification_access_title">Accès aux notifications</string>
     <string name="tv_settings_notification_access_subtitle">Requis pour le scrobble — WatchBuddy lit les notifications multimédias et les sessions actives pour identifier ce qui est en cours de lecture sur votre téléviseur</string>
     <string name="tv_settings_status_granted">Accordé</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -57,6 +57,10 @@
     <string name="tv_error_phone_unreachable">Companion app unreachable. Showing cached data.</string>
     <string name="tv_error_phone_unreachable_no_cache">Companion app unreachable. Make sure WatchBuddy is running on your phone.</string>
     <string name="tv_stale_cache_banner">Showing cached list — phone offline</string>
+    <!-- Show detail — one-tap mark as watched (#671) -->
+    <string name="tv_mark_watched">Mark as watched</string>
+    <string name="tv_mark_watched_no_phones">No connected phone — connect a phone to mark episodes.</string>
+    <string name="tv_mark_watched_error">Could not mark episode as watched.</string>
 
     <!-- Show detail — manually mark episodes watched (#217) -->
     <string name="tv_detail_episodes">Episodes</string>


### PR DESCRIPTION
## Summary

- Adds a **Mark as watched** `OutlinedButton` next to Watch Now on the TV show detail screen
- `MarkWatchedState` sealed interface (Idle / Loading / NoPhones / Error) drives button and one-shot toast feedback
- `markCurrentEpisodeWatched()` fans out to all connected phones via the existing `PhoneApiClientFactory` infrastructure (no new transport or endpoints)
- `advanceWatched()` builds an optimistic `EnrichedShowEntry` so the next-episode card advances immediately via `AnimatedContent` slide transition, without waiting for the next `/shows` poll
- String resources added for EN / DE / FR / ES

Replaces #690 (rebased clean branch — previous branch had a git topology conflict with `tv_stale_cache_banner` from #547).

Closes #671

## Test plan

- [ ] CI green (`build-android.yml`)
- [ ] Tapping Mark as watched with phone connected: button shows spinner, episode card slides to next episode
- [ ] Tapping with no phone connected: toast "No connected phone — connect a phone to mark episodes"
- [ ] Tapping when all phones fail: toast "Could not mark episode as watched"
- [ ] Button disabled when `hasNextEpisode` is false (show caught up / completed)

---
_Generated by [Claude Code](https://claude.ai/code/session_019EZ7A6Vfmj9k54y81h9ov6)_