### PR TITLE
refactor: remove old version/schema fallbacks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,15 @@ The GitHub MCP server tools (prefixed with `mcp__github__`) remain available as 
 
 The only exceptions are **localization string resources** (`values-de/`, `values-fr/`, `values-es/`) which contain translated user-facing strings by design. The default `values/strings.xml` must remain in English.
 
+### Active Early Development — No Cross-Component Fallbacks
+
+The app is in active early development. Phone, TV and backend are always deployed together from the same repository, so **version/schema fallbacks between components are not needed and must not be added**. Concretely:
+
+- The BLE discovery payload supports only the current schema version. Legacy schema versions are rejected.
+- The HTTP server API has no backward-compatibility shims or version negotiation.
+- The token storage format is always the current v1 format. Migration code for older formats is not needed.
+- When changing a shared protocol or data format, update all components in the same commit/PR.
+
 ### Code Style
 - Kotlin official code style (`kotlin.code.style=official`)
 - Compose UI follows single-Activity, screen-level composables

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRepository.kt
@@ -19,11 +19,9 @@ import javax.inject.Singleton
  * plumbing lives in [TokenAeadModule]; this class consumes the primitive via
  * dependency injection so unit tests can inject a fake.
  *
- * ## Ciphertext versioning
- * All new encryptions write a `v1:` prefix before the Base64 ciphertext and use a
- * fixed AAD constant ([AEAD_FIXED_AAD]) independent of the storage key name. Values
- * written by earlier builds (no prefix, key-name AAD) are detected and transparently
- * re-encrypted on first read so the fleet self-migrates without a forced re-auth.
+ * ## Ciphertext format
+ * All encryptions write a `v1:` prefix before the Base64 ciphertext and use a
+ * fixed AAD constant ([AEAD_FIXED_AAD]) independent of the storage key name.
  *
  * ## Error handling
  * - AEAD primitive unavailable (Keystore locked / hardware failure): every call that
@@ -32,12 +30,6 @@ import javax.inject.Singleton
  * - Ciphertext corruption / AAD mismatch: [hadDecryptionFailure] is set to `true`, an
  *   ERROR-level breadcrumb is emitted via [DiagnosticLog], and the affected getter
  *   returns `null` so the app falls back to the sign-in screen with an informative banner.
- *
- * On first launch after an upgrade from a build that used
- * `androidx.security:security-crypto` (deprecated, #430) the legacy
- * `watchbuddy_tokens.xml` shared-prefs file is deleted — the user has to sign in again
- * once. This avoids dragging the abandoned security-crypto dependency into the APK just
- * to decrypt a single file.
  */
 @Singleton
 class TokenRepository @Inject constructor(
@@ -57,7 +49,6 @@ class TokenRepository @Inject constructor(
         private set
 
     init {
-        migrateLegacyStoreIfPresent(context)
         prefs = context.getSharedPreferences(PREFS_FILE, Context.MODE_PRIVATE)
         DiagnosticLog.event(TAG, "init: ready (file=$PREFS_FILE)")
     }
@@ -127,12 +118,7 @@ class TokenRepository @Inject constructor(
     }
 
     /**
-     * Decrypts a stored value, handling both the current v1 format and the legacy
-     * key-name-AAD format written by earlier builds.
-     *
-     * - `v1:` prefix → strip prefix, Base64-decode, decrypt with [AEAD_FIXED_AAD].
-     * - No prefix → Base64-decode, decrypt with [storageKey] as AAD (legacy), then
-     *   immediately re-encrypt in v1 format so the value self-migrates.
+     * Decrypts a stored value in v1 format (`v1:` prefix + Base64 ciphertext with [AEAD_FIXED_AAD]).
      *
      * Returns `null` when [encoded] is `null` (nothing stored) or when decryption
      * fails due to ciphertext corruption — in the latter case [hadDecryptionFailure]
@@ -143,27 +129,10 @@ class TokenRepository @Inject constructor(
     private fun decrypt(storageKey: String, encoded: String?): String? {
         if (encoded == null) return null
         return try {
-            if (encoded.startsWith(V1_PREFIX)) {
-                val b64 = encoded.removePrefix(V1_PREFIX)
-                val ciphertext = Base64.getDecoder().decode(b64)
-                aead.decrypt(ciphertext, AEAD_FIXED_AAD.toByteArray(StandardCharsets.UTF_8))
-                    .toString(StandardCharsets.UTF_8)
-            } else {
-                // Legacy format: no prefix, AAD was the storage key name.
-                val ciphertext = Base64.getDecoder().decode(encoded)
-                val plaintext = aead.decrypt(
-                    ciphertext,
-                    storageKey.toByteArray(StandardCharsets.UTF_8),
-                ).toString(StandardCharsets.UTF_8)
-                // Re-encrypt in v1 format (best-effort; failure is non-fatal here).
-                runCatching {
-                    prefs.edit { putString(storageKey, encrypt(plaintext)) }
-                    DiagnosticLog.event(TAG, "migrated key=$storageKey to v1 AAD format")
-                }.onFailure { e ->
-                    DiagnosticLog.warn(TAG, "re-encrypt migration failed for key=$storageKey", e)
-                }
-                plaintext
-            }
+            val b64 = encoded.removePrefix(V1_PREFIX)
+            val ciphertext = Base64.getDecoder().decode(b64)
+            aead.decrypt(ciphertext, AEAD_FIXED_AAD.toByteArray(StandardCharsets.UTF_8))
+                .toString(StandardCharsets.UTF_8)
         } catch (e: AuthUnavailableException) {
             throw e
         } catch (e: Exception) {
@@ -177,21 +146,6 @@ class TokenRepository @Inject constructor(
         }
     }
 
-    /**
-     * One-shot migration from the legacy `EncryptedSharedPreferences` file written by
-     * `androidx.security:security-crypto` in earlier builds. We cannot decrypt the old
-     * ciphertext without dragging the deprecated library back in, so the file is deleted
-     * outright — the user has to sign in again once. The event is logged via
-     * [DiagnosticLog] so upgrade rollouts can be audited.
-     */
-    private fun migrateLegacyStoreIfPresent(context: Context) {
-        val legacyFile = LEGACY_PREFS_FILE
-        val exists = context.getSharedPreferences(legacyFile, Context.MODE_PRIVATE).all.isNotEmpty()
-        if (!exists) return
-        val deleted = context.deleteSharedPreferences(legacyFile)
-        DiagnosticLog.event(TAG, "migrated legacy EncryptedSharedPreferences (deleted=$deleted); user must re-sign-in")
-    }
-
     private companion object {
         const val KEY_ACCESS_TOKEN = "access_token"
         const val KEY_REFRESH_TOKEN = "refresh_token"
@@ -200,7 +154,6 @@ class TokenRepository @Inject constructor(
         const val TAG = "TokenRepository"
 
         const val PREFS_FILE = "watchbuddy_tokens_v2"
-        const val LEGACY_PREFS_FILE = "watchbuddy_tokens"
 
         /** Prefix prepended to all v1-format stored ciphertexts. */
         const val V1_PREFIX = "v1:"

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/data/ProviderCatalogRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/data/ProviderCatalogRepository.kt
@@ -109,11 +109,6 @@ class ProviderCatalogRepository @Inject constructor(
                     val body = response.body?.string() ?: return false
                     val etag = response.header("ETag")
                     val parsed = parseCatalog(body) ?: return false
-                    val currentVersion = prefs[Keys.CATALOG_VERSION] ?: 0
-                    if (parsed.version < currentVersion) {
-                        DiagnosticLog.warn(TAG, "server version ${parsed.version} < cached $currentVersion, ignoring")
-                        return false
-                    }
                     persist(body, parsed.version, etag)
                     applySnapshot(parsed)
                     DiagnosticLog.event(TAG, "catalog updated to v${parsed.version}")

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/CompanionHttpServer.kt
@@ -428,14 +428,6 @@ internal fun Application.configureCompanionRoutes(
             } catch (_: Exception) {
                 return@post call.respond(HttpStatusCode.BadRequest, ErrorResponse("Invalid request body"))
             }
-            // Old TV clients that pre-date the text-blob migration send the snapshot
-            // with named fields and no `text` field; WatchBuddyJson ignores unknown
-            // keys and defaults `text` to "". Detect this and return confidence=0
-            // gracefully instead of running inference on empty evidence.
-            if (body.snapshot.text.isBlank()) {
-                DiagnosticLog.warn(TAG, "extract: empty snapshot text — likely old-format client, returning confidence=0")
-                return@post call.respond(TitleExtractionResponse(confidence = 0f))
-            }
             try {
                 val response = titleExtractor.extract(body.snapshot, body.libraryHints)
                     ?: TitleExtractionResponse(confidence = 0f)

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRepositoryTest.kt
@@ -22,7 +22,6 @@ import java.util.Base64
 class TokenRepositoryTest {
 
     private val context: Context = mockk(relaxed = true)
-    private val legacyPrefs: SharedPreferences = mockk(relaxed = true)
     private val mockPrefs: SharedPreferences = mockk(relaxed = true)
     private val mockEditor: SharedPreferences.Editor = mockk(relaxed = true)
     private val aead: Aead = mockk()
@@ -30,16 +29,12 @@ class TokenRepositoryTest {
 
     @BeforeEach
     fun setUp() {
-        every { context.getSharedPreferences("watchbuddy_tokens", Context.MODE_PRIVATE) } returns legacyPrefs
-        every { legacyPrefs.all } returns emptyMap()
-
         every { context.getSharedPreferences("watchbuddy_tokens_v2", Context.MODE_PRIVATE) } returns mockPrefs
         every { mockPrefs.edit() } returns mockEditor
         every { mockEditor.putString(any(), any()) } returns mockEditor
         every { mockEditor.remove(any()) } returns mockEditor
 
         // Fixed-AAD AEAD: ciphertext layout is "enc(FIXED_AAD):$plaintext" for v1 format.
-        // Supports both the new fixed-AAD and the legacy key-name AAD for migration tests.
         val plaintextSlot = slot<ByteArray>()
         val encryptAssociatedSlot = slot<ByteArray>()
         every { aead.encrypt(capture(plaintextSlot), capture(encryptAssociatedSlot)) } answers {
@@ -65,32 +60,6 @@ class TokenRepositoryTest {
         val fixed = "watchbuddy_aead_v1"
         val raw = "enc($fixed):$plaintext".toByteArray(Charsets.UTF_8)
         return "v1:" + Base64.getEncoder().encodeToString(raw)
-    }
-
-    /** Builds a legacy-format storage string using the key name as AAD. */
-    private fun legacyCiphertext(key: String, plaintext: String): String {
-        val bytes = "enc($key):$plaintext".toByteArray(Charsets.UTF_8)
-        return Base64.getEncoder().encodeToString(bytes)
-    }
-
-    @Nested
-    @DisplayName("legacy migration (EncryptedSharedPreferences)")
-    inner class LegacyMigration {
-
-        @Test
-        fun `deletes legacy EncryptedSharedPreferences file when present`() {
-            every { legacyPrefs.all } returns mapOf("access_token" to "legacy-blob")
-            every { context.deleteSharedPreferences("watchbuddy_tokens") } returns true
-
-            TokenRepository(context, aead)
-
-            verify { context.deleteSharedPreferences("watchbuddy_tokens") }
-        }
-
-        @Test
-        fun `skips deletion when legacy file is empty`() {
-            verify(exactly = 0) { context.deleteSharedPreferences("watchbuddy_tokens") }
-        }
     }
 
     @Nested
@@ -150,59 +119,6 @@ class TokenRepositoryTest {
         fun `getClientSecret returns empty string when nothing stored`() {
             every { mockPrefs.getString("trakt_client_secret", null) } returns null
             assertEquals("", repository.getClientSecret())
-        }
-    }
-
-    @Nested
-    @DisplayName("legacy AAD migration (key-name to fixed AAD)")
-    inner class LegacyAadMigration {
-
-        @Test
-        fun `decrypts legacy access_token and re-encrypts in v1 format`() {
-            every { mockPrefs.getString("access_token", null) } returns
-                legacyCiphertext("access_token", "legacy-access")
-
-            val result = repository.getAccessToken()
-
-            assertEquals("legacy-access", result)
-            // Verify re-encryption was triggered (putString called with v1: prefix)
-            verify { mockEditor.putString(eq("access_token"), match { it.startsWith("v1:") }) }
-        }
-
-        @Test
-        fun `decrypts legacy refresh_token and re-encrypts in v1 format`() {
-            every { mockPrefs.getString("refresh_token", null) } returns
-                legacyCiphertext("refresh_token", "legacy-refresh")
-
-            val result = repository.getRefreshToken()
-
-            assertEquals("legacy-refresh", result)
-            verify { mockEditor.putString(eq("refresh_token"), match { it.startsWith("v1:") }) }
-        }
-
-        @Test
-        fun `decrypts legacy client_secret and re-encrypts in v1 format`() {
-            every { mockPrefs.getString("trakt_client_secret", null) } returns
-                legacyCiphertext("trakt_client_secret", "old-secret")
-
-            val result = repository.getClientSecret()
-
-            assertEquals("old-secret", result)
-            verify { mockEditor.putString(eq("trakt_client_secret"), match { it.startsWith("v1:") }) }
-        }
-
-        @Test
-        fun `legacy format with wrong key-name AAD fails and sets hadDecryptionFailure`() {
-            // Simulate a ciphertext with AAD "wrong_key" stored under "access_token".
-            // Decrypt with key-name "access_token" will fail due to AAD mismatch.
-            val wrongAad = "enc(wrong_key):bad-plaintext".toByteArray(Charsets.UTF_8)
-            val encoded = Base64.getEncoder().encodeToString(wrongAad)
-            every { mockPrefs.getString("access_token", null) } returns encoded
-
-            val result = repository.getAccessToken()
-
-            assertNull(result)
-            assertTrue(repository.hadDecryptionFailure)
         }
     }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneBleScanner.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneBleScanner.kt
@@ -45,7 +45,6 @@ class PhoneBleScanner @Inject constructor(
             modelQuality: Int,
             llmBackendOrdinal: Int,
             rssi: Int,
-            authCapable: Boolean,
             bearerTokenBytes: ByteArray?,
         )
     }
@@ -81,18 +80,9 @@ class PhoneBleScanner @Inject constructor(
         // Stop any prior scan — e.g. after permission grant or Wi-Fi reconnect.
         stopInternal(leScanner)
 
-        // Two filters: one for schema v1 (legacy phones without bearer auth)
-        // and one for schema v2 (current phones with BLE-distributed bearer token).
-        // Separate filters allow the OS to match either advertisement — a single
-        // filter with mask 0x00 on the version byte would accept any schema version
-        // including unknown future ones and garbled adverts from other apps.
-        val filterV1 = ScanFilter.Builder()
-            .setServiceData(
-                ParcelUuid(BleDiscoveryContract.SERVICE_UUID),
-                byteArrayOf(BleDiscoveryContract.PAYLOAD_SCHEMA_VERSION_LEGACY),
-                byteArrayOf(0xFF.toByte()),
-            )
-            .build()
+        // Filter on schema v2 — the only version we accept. Filtering on the
+        // version byte prevents matching garbled adverts from other apps using
+        // adjacent UUID space (mask 0x00 on that byte would accept any version).
         val filterV2 = ScanFilter.Builder()
             .setServiceData(
                 ParcelUuid(BleDiscoveryContract.SERVICE_UUID),
@@ -133,7 +123,7 @@ class PhoneBleScanner @Inject constructor(
         }
 
         return runCatching {
-            leScanner.startScan(listOf(filterV1, filterV2), settings, callback)
+            leScanner.startScan(listOf(filterV2), settings, callback)
             synchronized(this) {
                 scanner = leScanner
                 activeCallback = callback
@@ -177,18 +167,14 @@ class PhoneBleScanner @Inject constructor(
         when (val decoded = BleDiscoveryContract.decode(data)) {
             is BleDiscoveryContract.DecodeResult.Ok -> {
                 val payload = decoded.payload
-                val bearerTokenBytes = if (decoded.authCapable) {
-                    BleDiscoveryContract.decodeTokenPayload(
-                        scanRecord?.serviceData?.get(ParcelUuid(BleDiscoveryContract.TOKEN_SERVICE_UUID))
-                    )
-                } else {
-                    null
-                }
+                val bearerTokenBytes = BleDiscoveryContract.decodeTokenPayload(
+                    scanRecord?.serviceData?.get(ParcelUuid(BleDiscoveryContract.TOKEN_SERVICE_UUID))
+                )
                 Log.d(
                     TAG,
                     "advertisement: ip=${payload.ipv4.hostAddress} port=${payload.port} " +
                         "quality=${payload.modelQuality} backend=${payload.llmBackendOrdinal} " +
-                        "rssi=${result.rssi} auth=${decoded.authCapable}"
+                        "rssi=${result.rssi}"
                 )
                 listener.onAdvertisement(
                     ipv4 = payload.ipv4,
@@ -196,7 +182,6 @@ class PhoneBleScanner @Inject constructor(
                     modelQuality = payload.modelQuality,
                     llmBackendOrdinal = payload.llmBackendOrdinal,
                     rssi = result.rssi,
-                    authCapable = decoded.authCapable,
                     bearerTokenBytes = bearerTokenBytes,
                 )
             }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/discovery/PhoneDiscoveryManager.kt
@@ -159,10 +159,8 @@ class PhoneDiscoveryManager(
          */
         val rssi: Int? = null,
         val lastSuccessfulCheck: Long = System.currentTimeMillis(),
-        /** Base64url-encoded bearer token received via BLE scan response. Null for schema-v1 phones. */
+        /** Base64url-encoded bearer token received via BLE scan response. */
         val bearerToken: String? = null,
-        /** True when the phone emitted a schema-v2 advertisement (bearer auth capable). */
-        val authCapable: Boolean = false,
     )
 
     fun startDiscovery() {
@@ -543,7 +541,6 @@ class PhoneDiscoveryManager(
         modelQuality: Int,
         llmBackendOrdinal: Int,
         rssi: Int,
-        authCapable: Boolean = false,
         bearerTokenBytes: ByteArray? = null,
     ) {
         val hostAddress = ipv4.hostAddress ?: return
@@ -560,7 +557,6 @@ class PhoneDiscoveryManager(
                     it.copy(
                         rssi = rssi,
                         bearerToken = bearerToken ?: it.bearerToken,
-                        authCapable = authCapable || it.authCapable,
                     )
                 } else {
                     it
@@ -576,9 +572,9 @@ class PhoneDiscoveryManager(
             llmBackend = runCatching { LlmBackend.entries[llmBackendOrdinal] }
                 .getOrDefault(LlmBackend.NONE),
         )
-        Log.i(TAG, "BLE advertisement → resolving phone at $baseUrl (rssi=$rssi dBm auth=$authCapable)")
+        Log.i(TAG, "BLE advertisement → resolving phone at $baseUrl (rssi=$rssi dBm)")
         heartbeatScope.launch {
-            fetchCapabilityAndAdd(serviceName, txtRecord, baseUrl, rssi, authCapable, bearerToken)
+            fetchCapabilityAndAdd(serviceName, txtRecord, baseUrl, rssi, bearerToken)
         }
     }
 
@@ -598,7 +594,6 @@ class PhoneDiscoveryManager(
         txtRecord: PhoneTxtRecord,
         baseUrl: String,
         rssi: Int,
-        authCapable: Boolean = false,
         bearerToken: String? = null,
     ) {
         when (val result = fetchCapability(baseUrl)) {
@@ -607,7 +602,7 @@ class PhoneDiscoveryManager(
                 addOrUpdatePhone(
                     DiscoveredPhone(
                         serviceName, txtRecord, result.capability, score, baseUrl,
-                        rssi = rssi, authCapable = authCapable, bearerToken = bearerToken,
+                        rssi = rssi, bearerToken = bearerToken,
                     )
                 )
             }
@@ -628,7 +623,7 @@ class PhoneDiscoveryManager(
                 addOrUpdatePhone(
                     DiscoveredPhone(
                         serviceName, txtRecord, null, score, baseUrl,
-                        rssi = rssi, authCapable = authCapable, bearerToken = bearerToken,
+                        rssi = rssi, bearerToken = bearerToken,
                     )
                 )
             }
@@ -637,8 +632,8 @@ class PhoneDiscoveryManager(
 
     private fun startBleScan() {
         val started = bleScanner.start(
-            listener = { ipv4, port, quality, backend, rssi, authCapable, tokenBytes ->
-                onBleAdvertisement(ipv4, port, quality, backend, rssi, authCapable, tokenBytes)
+            listener = { ipv4, port, quality, backend, rssi, tokenBytes ->
+                onBleAdvertisement(ipv4, port, quality, backend, rssi, tokenBytes)
             },
             onFailure = { errorCode ->
                 _bleScanState.value = BleScanState.FAILED

--- a/core/src/main/java/com/justb81/watchbuddy/core/discovery/BleDiscoveryContract.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/discovery/BleDiscoveryContract.kt
@@ -17,7 +17,7 @@ import java.util.UUID
  *
  *   | offset | bytes | field                                              |
  *   |--------|-------|----------------------------------------------------|
- *   | 0      | 1     | schema version (1 = legacy, 2 = auth-capable)      |
+ *   | 0      | 1     | schema version (2 = current, bearer-auth capable)  |
  *   | 1..4   | 4     | IPv4 address (network byte order)                  |
  *   | 5..6   | 2     | TCP port (big-endian, unsigned)                    |
  *   | 7      | 1     | modelQuality (0..255 clamped; semantic range 0..150) |
@@ -25,9 +25,9 @@ import java.util.UUID
  *
  * ## Scan response (service data attached to [TOKEN_SERVICE_UUID]): 13 bytes.
  *
- * Schema-v2 phones also emit a BLE scan response carrying a 13-byte bearer
- * token for HTTP authentication. Token bytes are raw random material;
- * callers encode to Base64url for use in `Authorization: Bearer` headers.
+ * Phones emit a BLE scan response carrying a 13-byte bearer token for HTTP
+ * authentication. Token bytes are raw random material; callers encode to
+ * Base64url for use in `Authorization: Bearer` headers.
  *
  *   | offset | bytes | field               |
  *   |--------|-------|---------------------|
@@ -52,7 +52,7 @@ import java.util.UUID
  * `(ip, port)` pair.
  *
  * Schema evolution: additive changes must bump [PAYLOAD_SCHEMA_VERSION];
- * unknown versions beyond the recognised set are rejected.
+ * unknown versions are rejected.
  */
 object BleDiscoveryContract {
 
@@ -67,9 +67,6 @@ object BleDiscoveryContract {
      * Separate from [SERVICE_UUID] to avoid collision in Android's merged ScanRecord map.
      */
     val TOKEN_SERVICE_UUID: UUID = UUID.fromString("7a2c1f8b-3e5d-4c9a-b0e7-8d4f2a6c0b3e")
-
-    /** Legacy schema emitted by phone builds before bearer-token auth was introduced. */
-    const val PAYLOAD_SCHEMA_VERSION_LEGACY: Byte = 1
 
     /** Current schema — phone emits scan response with [TOKEN_SERVICE_UUID] bearer token. */
     const val PAYLOAD_SCHEMA_VERSION: Byte = 2
@@ -89,15 +86,10 @@ object BleDiscoveryContract {
 
     /** Typed result returned by [decode] so callers can distinguish failure modes. */
     sealed class DecodeResult {
-        /**
-         * Successfully decoded payload.
-         *
-         * [authCapable] is true for schema v2 phones that also emit a bearer-token
-         * scan response; false for legacy v1 phones with no token.
-         */
-        data class Ok(val payload: Payload, val authCapable: Boolean) : DecodeResult()
+        /** Successfully decoded payload. */
+        data class Ok(val payload: Payload) : DecodeResult()
 
-        /** Schema version is not 1 or 2 — unknown future schema or garbled advert. */
+        /** Schema version is not 2 — unknown schema or garbled advert. */
         data class WrongVersion(val found: Byte, val expected: Byte) : DecodeResult()
 
         /** Payload is null or shorter than [PAYLOAD_SIZE_BYTES]. */
@@ -137,20 +129,16 @@ object BleDiscoveryContract {
     /**
      * Reads a payload emitted by [encode]. Returns a [DecodeResult] that distinguishes
      * the failure mode so callers can log unexpected cases separately from expected
-     * schema-version mismatches (old client on the same network).
+     * schema-version mismatches (other apps using adjacent UUID space, radio corruption).
      *
-     * Accepts both schema v1 (legacy, [authCapable]=false) and v2 ([authCapable]=true).
-     * Never throws — this runs on every scan callback and bad data is a normal
-     * network condition (other apps using adjacent UUID space, radio corruption,
-     * schema drift from a newer phone build).
+     * Only accepts [PAYLOAD_SCHEMA_VERSION] (v2). Never throws — this runs on every
+     * scan callback and bad data is a normal network condition.
      */
     fun decode(bytes: ByteArray?): DecodeResult {
         if (bytes == null || bytes.size < PAYLOAD_SIZE_BYTES) return DecodeResult.Truncated
         val version = bytes[0]
-        val authCapable = when (version) {
-            PAYLOAD_SCHEMA_VERSION_LEGACY -> false
-            PAYLOAD_SCHEMA_VERSION -> true
-            else -> return DecodeResult.WrongVersion(found = version, expected = PAYLOAD_SCHEMA_VERSION)
+        if (version != PAYLOAD_SCHEMA_VERSION) {
+            return DecodeResult.WrongVersion(found = version, expected = PAYLOAD_SCHEMA_VERSION)
         }
         val ipv4 = runCatching {
             InetAddress.getByAddress(bytes.copyOfRange(1, 5)) as? Inet4Address
@@ -165,7 +153,6 @@ object BleDiscoveryContract {
                 modelQuality = modelQuality,
                 llmBackendOrdinal = llmBackendOrdinal,
             ),
-            authCapable = authCapable,
         )
     }
 

--- a/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/model/Models.kt
@@ -148,8 +148,7 @@ data class DeviceCapability(
     /**
      * Session key of the most recently resolved ambiguous prompt, or null when no prompt
      * has been resolved since service start. The TV reads this to stop re-dispatching the
-     * same ambiguous prompt (#474). Null-safe: old phone builds without this field default
-     * it to null via WatchBuddyJson's lenient decoding.
+     * same ambiguous prompt (#474).
      */
     val lastResolvedSessionKey: String? = null,
     /**
@@ -163,7 +162,6 @@ data class DeviceCapability(
      * when the phone's locale has no country component. The TV uses this for watch-provider
      * and JustWatch lookups so that region-specific services (e.g. Joyn in DE/AT) appear
      * correctly even when the TV's own UI locale returns an empty country string.
-     * Nullable for backward compatibility with older phone builds that don't include this field.
      */
     val countryCode: String? = null,
 )
@@ -227,11 +225,6 @@ data class ScrobbleCandidate(
  * in priority order by [com.justb81.watchbuddy.core.scrobbler.MediaSnapshotBuilder].
  * For the MediaSession-only case the tag prefix is `mediaSession.*`. Additional
  * enrichers (#471, #472) append their own prefixed lines without changing the schema.
- *
- * Wire-format note: [text] defaults to an empty string so that a TV client built
- * against the old schema (which sent 8 named fields instead of [text]) is
- * deserialized gracefully by a new phone — [WatchBuddyJson] ignores unknown keys,
- * and an empty [text] naturally yields confidence 0 from the extraction cascade.
  *
  * [sources] records which enrichers contributed; used for diagnostics only.
  */

--- a/core/src/test/java/com/justb81/watchbuddy/core/discovery/BleDiscoveryContractTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/discovery/BleDiscoveryContractTest.kt
@@ -2,7 +2,6 @@ package com.justb81.watchbuddy.core.discovery
 
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
@@ -37,25 +36,13 @@ class BleDiscoveryContractTest {
     }
 
     @Test
-    fun `decode v2 sets authCapable true`() {
+    fun `decode v2 returns Ok`() {
         val bytes = BleDiscoveryContract.encode(
             BleDiscoveryContract.Payload(ipv4("10.0.0.1"), 8765, 0, 0)
         )
         assertEquals(BleDiscoveryContract.PAYLOAD_SCHEMA_VERSION, bytes[0])
         val result = BleDiscoveryContract.decode(bytes)
         assertTrue(result is BleDiscoveryContract.DecodeResult.Ok)
-        assertTrue((result as BleDiscoveryContract.DecodeResult.Ok).authCapable)
-    }
-
-    @Test
-    fun `decode v1 legacy sets authCapable false`() {
-        val bytes = BleDiscoveryContract.encode(
-            BleDiscoveryContract.Payload(ipv4("10.0.0.1"), 8765, 0, 0)
-        ).copyOf()
-        bytes[0] = BleDiscoveryContract.PAYLOAD_SCHEMA_VERSION_LEGACY
-        val result = BleDiscoveryContract.decode(bytes)
-        assertTrue(result is BleDiscoveryContract.DecodeResult.Ok)
-        assertFalse((result as BleDiscoveryContract.DecodeResult.Ok).authCapable)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Remove BLE schema v1 (legacy) backward compatibility: drop `PAYLOAD_SCHEMA_VERSION_LEGACY`, v1 scan filter in `PhoneBleScanner`, and `authCapable` field from `DiscoveredPhone` / `DecodeResult.Ok` (it was always `true`).
- Remove legacy ciphertext migration (key-name AAD format) from `TokenRepository`; drop `migrateLegacyStoreIfPresent()` and `LEGACY_PREFS_FILE`.
- Remove version downgrade guard in phone-side `ProviderCatalogRepository` that rejected catalog versions lower than cached.
- Remove old-format client guard in `CompanionHttpServer /scrobble/extract` (blank snapshot text returning confidence=0).
- Remove backward-compat field comments from `DeviceCapability` and `MediaMetadataSnapshot` in `Models.kt`.
- Add "Active Early Development — No Cross-Component Fallbacks" convention section to `CLAUDE.md`.

## Test plan

- [ ] Build compiles without errors (`./gradlew assembleDebug`)
- [ ] All unit tests pass (`./gradlew test`)
- [ ] No new detekt findings (`./gradlew detektAll`)
- [ ] Phone and TV BLE discovery still works end-to-end (only v2 schema advertised/scanned)
- [ ] Token storage and retrieval works correctly (v1 format only)

> Note: Gradle scope skipped locally (no Android SDK in this environment); CI is the gate.

Closes #686

https://claude.ai/code/session_01K646NB5WPMhdUrXM2jwQRX

---
_Generated by [Claude Code](https://claude.ai/code/session_01K646NB5WPMhdUrXM2jwQRX)_