### PR TITLE
fix: resolve build warnings across phone, TV app, and tests

### DIFF
--- a/app-phone/src/main/AndroidManifest.xml
+++ b/app-phone/src/main/AndroidManifest.xml
@@ -63,7 +63,12 @@
             </intent-filter>
         </activity>
 
-        <!-- Disable default WorkManager initializer (custom HiltWorkerFactory) -->
+        <!-- Disable the default WorkManager auto-initializer so Hilt can inject
+             HiltWorkerFactory before WorkManager starts. The meta-data entry
+             being removed is declared by the androidx.work:work-runtime-ktx
+             library manifest (via androidx.startup) and merged here at build
+             time; the tools:node="remove" directive prevents the startup
+             library from auto-starting WorkManager with the default factory. -->
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenAeadModule.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenAeadModule.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.phone.auth
 import android.content.Context
 import com.google.crypto.tink.Aead
 import com.google.crypto.tink.KeyTemplates
+import com.google.crypto.tink.RegistryConfiguration
 import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.integration.android.AndroidKeysetManager
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
@@ -49,7 +50,7 @@ object TokenAeadModule {
                 .withMasterKeyUri(KEYSTORE_URI)
                 .build()
                 .keysetHandle
-                .getPrimitive(Aead::class.java)
+                .getPrimitive(RegistryConfiguration.get(), Aead::class.java)
         } catch (e: Exception) {
             DiagnosticLog.error(TAG, "Keystore AEAD init failed — auth storage unavailable", e)
             BrokenAead(AuthUnavailableException("Keystore unavailable: ${e.message}", e))

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/data/ProviderCatalogRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/data/ProviderCatalogRepository.kt
@@ -106,7 +106,7 @@ class ProviderCatalogRepository @Inject constructor(
                     true
                 }
                 response.isSuccessful -> {
-                    val body = response.body?.string() ?: return false
+                    val body = response.body.string()
                     val etag = response.header("ETag")
                     val parsed = parseCatalog(body) ?: return false
                     persist(body, parsed.version, etag)

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeViewModel.kt
@@ -22,6 +22,7 @@ import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import com.justb81.watchbuddy.service.CompanionService
 import com.justb81.watchbuddy.service.CompanionStateManager
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -249,6 +250,7 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     private fun observeTvConnected() {
         viewModelScope.launch {
             companionStateManager.lastCapabilityCheck

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/settings/SettingsScreen.kt
@@ -644,7 +644,7 @@ private fun CountryOverrideDropdown(selected: String, onSelect: (String) -> Unit
             },
             modifier          = Modifier
                 .fillMaxWidth()
-                .menuAnchor(MenuAnchorType.PrimaryNotEditable)
+                .menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable)
         )
         ExposedDropdownMenu(
             expanded         = expanded,

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/CompanionHttpServerTest.kt
@@ -247,7 +247,7 @@ class CompanionHttpServerTest {
             val response = client.get("/avatar")
 
             assertEquals(HttpStatusCode.OK, response.status)
-            assertArrayEquals(avatarBytes, response.readBytes())
+            assertArrayEquals(avatarBytes, response.readRawBytes())
         }
 
         @Test
@@ -291,7 +291,7 @@ class CompanionHttpServerTest {
             val response = client.get("/avatar")
 
             assertEquals(HttpStatusCode.OK, response.status)
-            assertArrayEquals(content, response.readBytes())
+            assertArrayEquals(content, response.readRawBytes())
         }
     }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/TvProviderCatalogRepository.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/data/TvProviderCatalogRepository.kt
@@ -145,9 +145,9 @@ class TvProviderCatalogRepository @Inject constructor(
                     DiagnosticLog.event(TAG, "catalog up to date (304)")
                 }
                 response.isSuccessful -> {
-                    val body = response.body?.string()
-                    val parsed = if (body != null) parseCatalog(body) else null
-                    if (body == null || parsed == null) return
+                    val body = response.body.string()
+                    val parsed = parseCatalog(body)
+                    if (parsed == null) return
                     val currentVersion = cached?.version ?: 0
                     if (parsed.version < currentVersion) {
                         DiagnosticLog.warn(TAG, "phone version ${parsed.version} < cached $currentVersion, ignoring")


### PR DESCRIPTION
## Summary
- Document `WorkManagerInitializer` `tools:node="remove"` in phone manifest with a comment confirming which transitive dependency (`androidx.work:work-runtime-ktx`) declares the initializer and why the directive is necessary for Hilt's `HiltWorkerFactory`
- Replace deprecated `KeysetHandle.getPrimitive(Class)` with `getPrimitive(RegistryConfiguration.get(), Aead::class.java)` in `TokenAeadModule`
- Remove unnecessary `?.` safe calls on non-null `ResponseBody` in `ProviderCatalogRepository` (phone) and `TvProviderCatalogRepository` (TV)
- Add `@OptIn(ExperimentalCoroutinesApi::class)` to `HomeViewModel.observeTvConnected()` which uses `flatMapLatest`
- Replace deprecated `MenuAnchorType` with `ExposedDropdownMenuAnchorType` in `SettingsScreen`
- Replace deprecated `HttpResponse.readBytes()` with `readRawBytes()` at both call sites in `CompanionHttpServerTest`

## Test plan
- [ ] All 6 acceptance criteria items resolved
- [ ] CI build passes with no new warnings in affected files (`build-android.yml`)

> Note: Gradle scope skipped locally — no Android SDK in this environment; CI (`build-android.yml`) is the real gate for Kotlin/Android changes.

Closes #683

https://claude.ai/code/session_01GRrTxo6W3PRR67KvCm53bR

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRrTxo6W3PRR67KvCm53bR)_