### PR TITLE
refactor(core): extract pure episode extraction/resolution logic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ watchbuddy/
 │       ├── model/      Data models (Kotlin Serialization)
 │       ├── network/    NetworkModule (Hilt, OkHttp, Retrofit), SharedJson (WatchBuddyJson shared instance)
 │       ├── progress/   ShowProgressCalculator
-│       ├── scrobbler/  MediaSessionScrobbler, ScrobbleContracts
+│       ├── scrobbler/  MediaSessionScrobbler, ScrobbleContracts, EpisodeMarkerExtractor (pure marker extraction), EpisodeResolution (pure episode resolution — `resolveEpisodeFromMetadata`, `EpisodeResolutionResult`, `ResolveSource`)
 │       ├── tmdb/       TmdbApiService (+ `getWatchProviders` endpoint + `TmdbImageHelper.logo`)
 │       └── trakt/      TraktApiService, TokenProxyService
 ├── backend/            Node.js token proxy (Docker)

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/EpisodeMarkerExtractor.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/EpisodeMarkerExtractor.kt
@@ -1,0 +1,56 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+/**
+ * Pure functions for building episode-marker pattern lists and extracting
+ * `(season, episode)` pairs from text strings.
+ *
+ * No external dependencies — no caches, no logging, no coroutines. Callers
+ * are responsible for logging any diagnostics at the call site.
+ */
+object EpisodeMarkerExtractor {
+
+    /**
+     * A resolved `(season, episode)` pair extracted from a text field.
+     */
+    data class Marker(val season: Int, val episode: Int)
+
+    /**
+     * Tries every pattern in [profile.markerRegexes] (if any), then the
+     * generic `S##E##` fallback, and returns the first [Marker] found in
+     * [text]. Returns null when no pattern matches.
+     */
+    fun extractFromText(text: String, profile: AppProfile?): Marker? {
+        val patterns = buildPatterns(profile)
+        for (pattern in patterns) {
+            val match = pattern.find(text) ?: continue
+            val season = match.groupValues.getOrNull(1)?.toIntOrNull() ?: continue
+            val episode = match.groupValues.getOrNull(2)?.toIntOrNull() ?: continue
+            return Marker(season, episode)
+        }
+        return null
+    }
+
+    /**
+     * Strips an `S##E##`-style marker suffix (using the profile's patterns plus
+     * the generic fallback) and any trailing colon or whitespace from [field],
+     * returning the remaining show-title portion.
+     *
+     * Example: `"Breaking Bad S03E07"` → `"Breaking Bad"`
+     * Example: `"The Crown:"` → `"The Crown"`
+     */
+    fun normalizeTitle(field: String, profile: AppProfile?): String {
+        val patterns = buildPatterns(profile)
+        val match = patterns.firstNotNullOfOrNull { it.find(field) }
+        val withoutMarker = if (match != null) field.substringBefore(match.value) else field
+        return withoutMarker.trimEnd(':', ' ', '\t')
+    }
+
+    /**
+     * Returns profile-specific marker regexes followed by the generic `S##E##`
+     * pattern. Callers should iterate this list and stop at the first match.
+     */
+    internal fun buildPatterns(profile: AppProfile?): List<Regex> = buildList {
+        profile?.markerRegexes?.let { addAll(it) }
+        add(Regex("""(?i)S(\d{1,2})E(\d{1,2})"""))
+    }
+}

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/EpisodeMarkerExtractor.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/EpisodeMarkerExtractor.kt
@@ -19,16 +19,16 @@ object EpisodeMarkerExtractor {
      * generic `S##E##` fallback, and returns the first [Marker] found in
      * [text]. Returns null when no pattern matches.
      */
-    fun extractFromText(text: String, profile: AppProfile?): Marker? {
-        val patterns = buildPatterns(profile)
-        for (pattern in patterns) {
-            val match = pattern.find(text) ?: continue
-            val season = match.groupValues.getOrNull(1)?.toIntOrNull() ?: continue
-            val episode = match.groupValues.getOrNull(2)?.toIntOrNull() ?: continue
-            return Marker(season, episode)
-        }
-        return null
-    }
+    fun extractFromText(text: String, profile: AppProfile?): Marker? =
+        buildPatterns(profile)
+            .asSequence()
+            .mapNotNull { it.find(text) }
+            .mapNotNull { match ->
+                val season = match.groupValues.getOrNull(1)?.toIntOrNull()
+                val episode = match.groupValues.getOrNull(2)?.toIntOrNull()
+                if (season != null && episode != null) Marker(season, episode) else null
+            }
+            .firstOrNull()
 
     /**
      * Strips an `S##E##`-style marker suffix (using the profile's patterns plus

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/EpisodeResolution.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/EpisodeResolution.kt
@@ -1,0 +1,100 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import com.justb81.watchbuddy.core.model.TmdbProgressHint
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.progress.ShowProgressCalculator
+
+/**
+ * Result of attempting to resolve a `(season, episode)` pair from scrobble
+ * metadata. Pure sealed type — no side effects, no I/O.
+ */
+sealed interface EpisodeResolutionResult {
+    /**
+     * A definitive `(season, episode)` pair was resolved.
+     * [source] indicates which evidence path produced the result.
+     */
+    data class Resolved(
+        val season: Int,
+        val episode: Int,
+        val source: ResolveSource,
+    ) : EpisodeResolutionResult
+
+    /**
+     * An explicit marker and a high-confidence progress hint disagree.
+     * The caller should surface a confirmation prompt rather than
+     * auto-scrobbling.
+     */
+    data object Ambiguous : EpisodeResolutionResult
+
+    /**
+     * No episode could be resolved: either the explicit marker was absent
+     * and confidence was too low to trust the progress hint, or the
+     * progress hint itself was unavailable.
+     */
+    data object Unresolved : EpisodeResolutionResult
+}
+
+/** Which evidence path produced a [EpisodeResolutionResult.Resolved] result. */
+enum class ResolveSource {
+    /** An explicit `S##E##` (or profile-specific) marker was found in the metadata. */
+    EXPLICIT_MARKER,
+
+    /** No explicit marker; episode was inferred from the show's progress hint. */
+    PROGRESS_HINT,
+
+    /** Reserved for future use — not emitted by the current implementation. */
+    FALLBACK,
+}
+
+/**
+ * Pure function that resolves a `(season, episode)` pair from scrobble metadata.
+ *
+ * Decision rules (in order):
+ * 1. If [explicit] is present, use it ([ResolveSource.EXPLICIT_MARKER]).
+ *    When a high-confidence [hint]-derived episode also exists and disagrees,
+ *    return [EpisodeResolutionResult.Ambiguous] so the caller can prompt the user.
+ * 2. If [confidence] ≥ [tuning.autoScrobbleThreshold] and [hint] yields an episode
+ *    via [ShowProgressCalculator.nextEpisodeNumbers], return that episode
+ *    ([ResolveSource.PROGRESS_HINT]).
+ * 3. Otherwise return [EpisodeResolutionResult.Unresolved].
+ *
+ * The caller is responsible for fetching [hint] and for logging any diagnostics
+ * at the call boundary.
+ */
+fun resolveEpisodeFromMetadata(
+    explicit: EpisodeMarkerExtractor.Marker?,
+    hint: TmdbProgressHint?,
+    confidence: Float,
+    tuning: ScrobbleTuning,
+    cacheEntry: TraktWatchedEntry,
+): EpisodeResolutionResult {
+    val hintEpisode: Pair<Int, Int>? =
+        if (confidence >= tuning.autoScrobbleThreshold) {
+            ShowProgressCalculator.nextEpisodeNumbers(cacheEntry, hint)
+        } else {
+            null
+        }
+
+    if (explicit != null) {
+        if (hintEpisode != null &&
+            (hintEpisode.first != explicit.season || hintEpisode.second != explicit.episode)
+        ) {
+            return EpisodeResolutionResult.Ambiguous
+        }
+        return EpisodeResolutionResult.Resolved(
+            season = explicit.season,
+            episode = explicit.episode,
+            source = ResolveSource.EXPLICIT_MARKER,
+        )
+    }
+
+    if (hintEpisode != null) {
+        return EpisodeResolutionResult.Resolved(
+            season = hintEpisode.first,
+            episode = hintEpisode.second,
+            source = ResolveSource.PROGRESS_HINT,
+        )
+    }
+
+    return EpisodeResolutionResult.Unresolved
+}

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/EpisodeResolution.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/EpisodeResolution.kt
@@ -20,16 +20,20 @@ sealed interface EpisodeResolutionResult {
     ) : EpisodeResolutionResult
 
     /**
-     * An explicit marker and a high-confidence progress hint disagree.
-     * The caller should surface a confirmation prompt rather than
-     * auto-scrobbling.
+     * Both an explicit marker and a progress hint were provided and they
+     * disagree. The caller should surface a confirmation prompt rather than
+     * auto-scrobbling. This result is only reachable when the caller passes
+     * a non-null [hint] together with a non-null [explicit] to
+     * [resolveEpisodeFromMetadata] — [MediaSessionScrobbler] never does this
+     * (it passes `hint = null` when [explicit] is non-null), so [Ambiguous]
+     * is reserved for callers that deliberately provide both.
      */
     data object Ambiguous : EpisodeResolutionResult
 
     /**
-     * No episode could be resolved: either the explicit marker was absent
-     * and confidence was too low to trust the progress hint, or the
-     * progress hint itself was unavailable.
+     * No episode could be resolved: either the explicit marker was absent,
+     * the progress hint was null or yielded no episode, or confidence was
+     * too low to trust the hint.
      */
     data object Unresolved : EpisodeResolutionResult
 }
@@ -50,13 +54,25 @@ enum class ResolveSource {
  * Pure function that resolves a `(season, episode)` pair from scrobble metadata.
  *
  * Decision rules (in order):
- * 1. If [explicit] is present, use it ([ResolveSource.EXPLICIT_MARKER]).
- *    When a high-confidence [hint]-derived episode also exists and disagrees,
- *    return [EpisodeResolutionResult.Ambiguous] so the caller can prompt the user.
- * 2. If [confidence] ≥ [tuning.autoScrobbleThreshold] and [hint] yields an episode
- *    via [ShowProgressCalculator.nextEpisodeNumbers], return that episode
- *    ([ResolveSource.PROGRESS_HINT]).
+ * 1. If [explicit] is present:
+ *    - When [hint] is also non-null and `nextEpisodeNumbers` disagrees with
+ *      [explicit], return [EpisodeResolutionResult.Ambiguous].
+ *    - Otherwise return [EpisodeResolutionResult.Resolved] with
+ *      [ResolveSource.EXPLICIT_MARKER].
+ * 2. If [confidence] ≥ [tuning.autoScrobbleThreshold] and [hint] is non-null and
+ *    yields an episode via [ShowProgressCalculator.nextEpisodeNumbers], return that
+ *    episode ([ResolveSource.PROGRESS_HINT]).
  * 3. Otherwise return [EpisodeResolutionResult.Unresolved].
+ *
+ * When [hint] is `null`, the progress-hint path is skipped and the function
+ * returns [EpisodeResolutionResult.Unresolved] unless [explicit] is present.
+ * This preserves the original [MediaSessionScrobbler] contract where a null
+ * hint from [WatchedShowSource.getShowHint] causes a dropped scrobble.
+ *
+ * **Note on [MediaSessionScrobbler] usage:** the scrobbler passes `hint = null`
+ * whenever [explicit] is non-null, so [EpisodeResolutionResult.Ambiguous] is never
+ * returned from the scrobbler's call path. The Ambiguous branch is exposed for
+ * callers that deliberately provide both pieces of evidence.
  *
  * The caller is responsible for fetching [hint] and for logging any diagnostics
  * at the call boundary.
@@ -68,18 +84,14 @@ fun resolveEpisodeFromMetadata(
     tuning: ScrobbleTuning,
     cacheEntry: TraktWatchedEntry,
 ): EpisodeResolutionResult {
-    val hintEpisode: Pair<Int, Int>? =
-        if (confidence >= tuning.autoScrobbleThreshold) {
-            ShowProgressCalculator.nextEpisodeNumbers(cacheEntry, hint)
-        } else {
-            null
-        }
-
     if (explicit != null) {
-        if (hintEpisode != null &&
-            (hintEpisode.first != explicit.season || hintEpisode.second != explicit.episode)
-        ) {
-            return EpisodeResolutionResult.Ambiguous
+        if (hint != null) {
+            val hintEpisode = ShowProgressCalculator.nextEpisodeNumbers(cacheEntry, hint)
+            if (hintEpisode != null &&
+                (hintEpisode.first != explicit.season || hintEpisode.second != explicit.episode)
+            ) {
+                return EpisodeResolutionResult.Ambiguous
+            }
         }
         return EpisodeResolutionResult.Resolved(
             season = explicit.season,
@@ -88,12 +100,15 @@ fun resolveEpisodeFromMetadata(
         )
     }
 
-    if (hintEpisode != null) {
-        return EpisodeResolutionResult.Resolved(
-            season = hintEpisode.first,
-            episode = hintEpisode.second,
-            source = ResolveSource.PROGRESS_HINT,
-        )
+    if (hint != null && confidence >= tuning.autoScrobbleThreshold) {
+        val hintEpisode = ShowProgressCalculator.nextEpisodeNumbers(cacheEntry, hint)
+        if (hintEpisode != null) {
+            return EpisodeResolutionResult.Resolved(
+                season = hintEpisode.first,
+                episode = hintEpisode.second,
+                source = ResolveSource.PROGRESS_HINT,
+            )
+        }
     }
 
     return EpisodeResolutionResult.Unresolved

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -17,7 +17,6 @@ import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
-import com.justb81.watchbuddy.core.progress.ShowProgressCalculator
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.*
@@ -593,18 +592,14 @@ class MediaSessionScrobbler @Inject constructor(
         tick: PlaybackTick,
         fallthroughIntent: PlaybackIntent? = null,
     ): List<AmbiguousCandidate> {
-        val patterns = buildList {
-            profile?.markerRegexes?.let { addAll(it) }
-            add(Regex("""(?i)S(\d{1,2})E(\d{1,2})"""))
-        }
         // Best score per Trakt ID across all candidate strings.
         val bestByTraktId = mutableMapOf<Int, ScoredEntry>()
         for (field in candidates) {
-            val marker = patterns.firstNotNullOfOrNull { it.find(field) }
-            val showTitle = if (marker != null) field.substringBefore(marker.value).trim() else field.trim()
+            val extracted = EpisodeMarkerExtractor.extractFromText(field, profile)
+            val showTitle = EpisodeMarkerExtractor.normalizeTitle(field, profile).trim()
             if (showTitle.isBlank()) continue
-            val season = marker?.groupValues?.getOrNull(1)?.toIntOrNull()
-            val episode = marker?.groupValues?.getOrNull(2)?.toIntOrNull()
+            val season = extracted?.season
+            val episode = extracted?.episode
             cachedShows.forEach { entry ->
                 val base = fuzzyScore(entry.show.title, showTitle)
                 val weighted = (base * runtimeAffinity(tick.durationMs, entry.show.runtime))
@@ -735,13 +730,8 @@ class MediaSessionScrobbler @Inject constructor(
         title: String,
         profile: AppProfile? = null,
     ): Float {
-        val patterns = buildList {
-            profile?.markerRegexes?.let { addAll(it) }
-            add(Regex("""(?i)S(\d{1,2})E(\d{1,2})"""))
-        }
         return candidates.maxOfOrNull { field ->
-            val m = patterns.firstNotNullOfOrNull { it.find(field) }
-            val showTitle = if (m != null) field.substringBefore(m.value).trim() else field.trim()
+            val showTitle = EpisodeMarkerExtractor.normalizeTitle(field, profile).trim()
             if (showTitle.isBlank()) 0f else fuzzyScore(showTitle, title)
         } ?: 0f
     }
@@ -944,17 +934,9 @@ class MediaSessionScrobbler @Inject constructor(
         candidates: List<String>,
         profile: AppProfile? = null,
     ): Pair<Int?, Int?> {
-        val patterns = buildList {
-            profile?.markerRegexes?.let { addAll(it) }
-            add(Regex("""(?i)S(\d{1,2})E(\d{1,2})"""))
-        }
-        for (pattern in patterns) {
-            val match = candidates.firstNotNullOfOrNull { pattern.find(it) }
-            if (match != null) {
-                val season = match.groupValues.getOrNull(1)?.toIntOrNull()
-                val episode = match.groupValues.getOrNull(2)?.toIntOrNull()
-                if (season != null && episode != null) return season to episode
-            }
+        for (candidate in candidates) {
+            val marker = EpisodeMarkerExtractor.extractFromText(candidate, profile) ?: continue
+            return marker.season to marker.episode
         }
         return null to null
     }
@@ -1045,14 +1027,10 @@ class MediaSessionScrobbler @Inject constructor(
         profile: AppProfile? = null,
         tick: PlaybackTick = PlaybackTick.UNKNOWN,
     ): CheapMatch {
-        val patterns = buildList {
-            profile?.markerRegexes?.let { addAll(it) }
-            add(Regex("""(?i)S(\d{1,2})E(\d{1,2})"""))
-        }
-        val match = patterns.firstNotNullOfOrNull { it.find(field) }
-        val showTitle = if (match != null) field.substringBefore(match.value).trim() else field.trim()
-        val season = match?.groupValues?.getOrNull(1)?.toIntOrNull()
-        val episode = match?.groupValues?.getOrNull(2)?.toIntOrNull()
+        val marker = EpisodeMarkerExtractor.extractFromText(field, profile)
+        val showTitle = EpisodeMarkerExtractor.normalizeTitle(field, profile).trim()
+        val season = marker?.season
+        val episode = marker?.episode
         if (showTitle.isBlank() || cachedShows.isEmpty()) {
             return CheapMatch(field, showTitle, season, episode, 0f, null)
         }
@@ -1109,12 +1087,16 @@ class MediaSessionScrobbler @Inject constructor(
     }
 
     /**
-     * Resolve the episode tuple for a cache-matched show. Prefers the explicit `S##E##`
-     * pair parsed from MediaMetadata when available; otherwise falls back to the progress
-     * hint so scrobbles from Netflix / Prime / Disney+ (which ship only the episode title
-     * in `METADATA_KEY_TITLE`) aren't silently dropped (issue #401). The fallback only
-     * activates when show-match confidence clears [ScrobbleTuning.autoScrobbleThreshold] — below that
-     * the overlay path still asks the user to confirm.
+     * Resolve the episode tuple for a cache-matched show. Delegates to the pure
+     * [resolveEpisodeFromMetadata] function after fetching the progress hint from
+     * [WatchedShowSource]. Logs diagnostics at the call boundary.
+     *
+     * Prefers the explicit `S##E##` pair parsed from MediaMetadata when available;
+     * otherwise falls back to the progress hint so scrobbles from Netflix / Prime /
+     * Disney+ (which ship only the episode title in `METADATA_KEY_TITLE`) aren't
+     * silently dropped (issue #401). The fallback only activates when show-match
+     * confidence clears [ScrobbleTuning.autoScrobbleThreshold] — below that the
+     * overlay path still asks the user to confirm.
      */
     private suspend fun resolveEpisode(
         explicitSeason: Int?,
@@ -1122,20 +1104,33 @@ class MediaSessionScrobbler @Inject constructor(
         cacheEntry: TraktWatchedEntry,
         confidence: Float
     ): TraktEpisode? {
-        if (explicitSeason != null && explicitEpisode != null) {
-            return TraktEpisode(season = explicitSeason, number = explicitEpisode)
+        val explicit = if (explicitSeason != null && explicitEpisode != null) {
+            EpisodeMarkerExtractor.Marker(explicitSeason, explicitEpisode)
+        } else {
+            null
         }
-        if (confidence < tuning.autoScrobbleThreshold) return null
-        val hint = watchedShowSource.getShowHint(cacheEntry.show.ids)
-        if (hint == null) {
-            DiagnosticLog.warn(
-                TAG,
-                "scrobble dropped — no episode in title and no progress hint for '${cacheEntry.show.title}'"
-            )
-            return null
+        val hint = if (confidence >= tuning.autoScrobbleThreshold) {
+            watchedShowSource.getShowHint(cacheEntry.show.ids)
+        } else {
+            null
         }
-        return ShowProgressCalculator.nextEpisodeNumbers(cacheEntry, hint)
-            ?.let { TraktEpisode(season = it.first, number = it.second) }
+        return when (
+            val result = resolveEpisodeFromMetadata(explicit, hint, confidence, tuning, cacheEntry)
+        ) {
+            is EpisodeResolutionResult.Resolved ->
+                TraktEpisode(season = result.season, number = result.episode)
+            EpisodeResolutionResult.Ambiguous ->
+                TraktEpisode(season = explicit!!.season, number = explicit.episode)
+            EpisodeResolutionResult.Unresolved -> {
+                if (explicit == null && confidence >= tuning.autoScrobbleThreshold) {
+                    DiagnosticLog.warn(
+                        TAG,
+                        "scrobble dropped — no episode in title and no progress hint for '${cacheEntry.show.title}'"
+                    )
+                }
+                null
+            }
+        }
     }
 
     internal fun normalize(title: String): String {

--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/MediaSessionScrobbler.kt
@@ -706,7 +706,7 @@ class MediaSessionScrobbler @Inject constructor(
         return (positionMs * 100f / durationMs).coerceIn(0f, 100f)
     }
 
-    // ── Fuzzy Matching ────────────────────────────────────────────────────────
+    // ── Fuzzy Matching ──────────────────────────────────────────────────
 
     /**
      * Convenience adaptor preserved so vanish/stop paths and existing tests can
@@ -1109,7 +1109,7 @@ class MediaSessionScrobbler @Inject constructor(
         } else {
             null
         }
-        val hint = if (confidence >= tuning.autoScrobbleThreshold) {
+        val hint = if (explicit == null && confidence >= tuning.autoScrobbleThreshold) {
             watchedShowSource.getShowHint(cacheEntry.show.ids)
         } else {
             null
@@ -1166,7 +1166,7 @@ class MediaSessionScrobbler @Inject constructor(
         return dp[a.length][b.length]
     }
 
-    // ── Scrobble API ──────────────────────────────────────────────────────────
+    // ── Scrobble API ─────────────────────────────────────────────────────
 
     suspend fun autoScrobble(
         candidate: ScrobbleCandidate,

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/EpisodeMarkerExtractorTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/EpisodeMarkerExtractorTest.kt
@@ -1,0 +1,119 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("EpisodeMarkerExtractor")
+class EpisodeMarkerExtractorTest {
+
+    // ── extractFromText ───────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("extractFromText()")
+    inner class ExtractFromTextTest {
+
+        @Test
+        fun `extracts S01E02 from canonical English title`() {
+            val result = EpisodeMarkerExtractor.extractFromText("Breaking Bad S01E02", profile = null)
+            assertEquals(EpisodeMarkerExtractor.Marker(season = 1, episode = 2), result)
+        }
+
+        @Test
+        fun `extracts S01 dot E02 from Joyn-style dot delimiter`() {
+            // Standard S##E## pattern still matches "S01E02" embedded with a dot separator
+            // via profile-specific Joyn regex: "Staffel 1, Folge 2"
+            val joynProfile = AppProfile(
+                packageName = "de.prosiebensat1digital.seventv",
+                markerRegexes = listOf(
+                    Regex("""Staffel\s*(\d+)[,\s]+Folge\s*(\d+)""", RegexOption.IGNORE_CASE),
+                ),
+            )
+            val result = EpisodeMarkerExtractor.extractFromText(
+                "Staffel 1, Folge 2 — Some Episode Title",
+                profile = joynProfile,
+            )
+            assertEquals(EpisodeMarkerExtractor.Marker(season = 1, episode = 2), result)
+        }
+
+        @Test
+        fun `extracts Folge 7 from Disney plus German title`() {
+            // Disney+ uses T##E## marker; simulate a profile with that regex
+            val disneyProfile = AppProfile(
+                packageName = "com.disney.disneyplus",
+                markerRegexes = listOf(Regex("""T(\d+)\s*E(\d+)""", RegexOption.IGNORE_CASE)),
+            )
+            val result = EpisodeMarkerExtractor.extractFromText(
+                "The Mandalorian T1 E7",
+                profile = disneyProfile,
+            )
+            assertEquals(EpisodeMarkerExtractor.Marker(season = 1, episode = 7), result)
+        }
+
+        @Test
+        fun `returns null when text contains no marker`() {
+            val result = EpisodeMarkerExtractor.extractFromText("Just a plain show title", profile = null)
+            assertNull(result)
+        }
+
+        @Test
+        fun `prefers profile-specific regex over generic S##E## fallback`() {
+            // Profile uses T##E##; input contains T2 E3 which should win over any S##E## match
+            val profile = AppProfile(
+                packageName = "com.disney.disneyplus",
+                markerRegexes = listOf(Regex("""T(\d+)\s*E(\d+)""", RegexOption.IGNORE_CASE)),
+            )
+            val result = EpisodeMarkerExtractor.extractFromText("Loki T2 E3", profile = profile)
+            assertEquals(EpisodeMarkerExtractor.Marker(season = 2, episode = 3), result)
+        }
+
+        @Test
+        fun `generic S##E## matches when no profile is supplied`() {
+            val result = EpisodeMarkerExtractor.extractFromText("Dark S03E08", profile = null)
+            assertEquals(EpisodeMarkerExtractor.Marker(season = 3, episode = 8), result)
+        }
+
+        @Test
+        fun `extraction is case-insensitive for generic pattern`() {
+            val result = EpisodeMarkerExtractor.extractFromText("Show s02e05 Title", profile = null)
+            assertEquals(EpisodeMarkerExtractor.Marker(season = 2, episode = 5), result)
+        }
+    }
+
+    // ── normalizeTitle ────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("normalizeTitle()")
+    inner class NormalizeTitleTest {
+
+        @Test
+        fun `normalizeTitle strips trailing colon and SxxEyy suffix`() {
+            val result = EpisodeMarkerExtractor.normalizeTitle("Breaking Bad S03E07", profile = null)
+            assertEquals("Breaking Bad", result)
+        }
+
+        @Test
+        fun `normalizeTitle strips trailing colon without marker`() {
+            val result = EpisodeMarkerExtractor.normalizeTitle("The Crown:", profile = null)
+            assertEquals("The Crown", result)
+        }
+
+        @Test
+        fun `normalizeTitle returns trimmed field when no marker or colon`() {
+            val result = EpisodeMarkerExtractor.normalizeTitle("Stranger Things", profile = null)
+            assertEquals("Stranger Things", result)
+        }
+
+        @Test
+        fun `normalizeTitle strips profile-specific marker`() {
+            val profile = AppProfile(
+                packageName = "com.disney.disneyplus",
+                markerRegexes = listOf(Regex("""T(\d+)\s*E(\d+)""", RegexOption.IGNORE_CASE)),
+            )
+            val result = EpisodeMarkerExtractor.normalizeTitle("The Mandalorian T1 E1", profile = profile)
+            assertEquals("The Mandalorian", result)
+        }
+    }
+}

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/EpisodeResolutionTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/EpisodeResolutionTest.kt
@@ -38,14 +38,11 @@ class EpisodeResolutionTest {
     inner class ExplicitMarkerTest {
 
         @Test
-        fun `explicit marker wins over progress hint`() {
+        fun `explicit marker wins when no hint provided`() {
             val marker = EpisodeMarkerExtractor.Marker(season = 2, episode = 5)
-            val hint = TmdbProgressHint(
-                nextAired = TmdbEpisodeSummary(season_number = 3, episode_number = 1),
-            )
             val result = resolveEpisodeFromMetadata(
                 explicit = marker,
-                hint = hint,
+                hint = null,
                 confidence = 0.98f,
                 tuning = defaultTuning,
                 cacheEntry = watchedEntry(),
@@ -61,13 +58,12 @@ class EpisodeResolutionTest {
         }
 
         @Test
-        fun `ambiguous when explicit marker disagrees with high-confidence hint`() {
+        fun `ambiguous when explicit marker disagrees with non-null hint`() {
             // Explicit says S2E5; nextEpisodeNumbers from hint says S3E1 — they disagree.
             val marker = EpisodeMarkerExtractor.Marker(season = 2, episode = 5)
             val hint = TmdbProgressHint(
                 nextAired = TmdbEpisodeSummary(season_number = 3, episode_number = 1),
             )
-            // confidence >= autoScrobbleThreshold so hint is computed
             val result = resolveEpisodeFromMetadata(
                 explicit = marker,
                 hint = hint,
@@ -97,6 +93,30 @@ class EpisodeResolutionTest {
                 result,
             )
         }
+
+        @Test
+        fun `explicit marker resolves when hint agrees`() {
+            // Explicit says S3E1; hint also points to S3E1 — no ambiguity.
+            val marker = EpisodeMarkerExtractor.Marker(season = 3, episode = 1)
+            val hint = TmdbProgressHint(
+                nextAired = TmdbEpisodeSummary(season_number = 3, episode_number = 1),
+            )
+            val result = resolveEpisodeFromMetadata(
+                explicit = marker,
+                hint = hint,
+                confidence = defaultTuning.autoScrobbleThreshold,
+                tuning = defaultTuning,
+                cacheEntry = watchedEntry(),
+            )
+            assertEquals(
+                EpisodeResolutionResult.Resolved(
+                    season = 3,
+                    episode = 1,
+                    source = ResolveSource.EXPLICIT_MARKER,
+                ),
+                result,
+            )
+        }
     }
 
     // ── progress hint path ────────────────────────────────────────────────────
@@ -107,14 +127,16 @@ class EpisodeResolutionTest {
 
         @Test
         fun `progress hint used when no explicit marker and confidence at threshold`() {
-            // nextEpisodeNumbers will compute S1E4 (latest watched S1E3 + 1)
-            val entry = watchedEntry(season = 1, episode = 3)
+            // hint carries nextAired = S1E4; nextEpisodeNumbers returns S1E4
+            val hint = TmdbProgressHint(
+                nextAired = TmdbEpisodeSummary(season_number = 1, episode_number = 4),
+            )
             val result = resolveEpisodeFromMetadata(
                 explicit = null,
-                hint = null,
+                hint = hint,
                 confidence = defaultTuning.autoScrobbleThreshold,
                 tuning = defaultTuning,
-                cacheEntry = entry,
+                cacheEntry = watchedEntry(),
             )
             assertEquals(
                 EpisodeResolutionResult.Resolved(
@@ -127,10 +149,25 @@ class EpisodeResolutionTest {
         }
 
         @Test
-        fun `unresolved when confidence below hintThreshold and no explicit marker`() {
+        fun `unresolved when hint is null and no explicit marker`() {
             val result = resolveEpisodeFromMetadata(
                 explicit = null,
                 hint = null,
+                confidence = defaultTuning.autoScrobbleThreshold,
+                tuning = defaultTuning,
+                cacheEntry = watchedEntry(),
+            )
+            assertEquals(EpisodeResolutionResult.Unresolved, result)
+        }
+
+        @Test
+        fun `unresolved when confidence below threshold and no explicit marker`() {
+            val hint = TmdbProgressHint(
+                nextAired = TmdbEpisodeSummary(season_number = 1, episode_number = 4),
+            )
+            val result = resolveEpisodeFromMetadata(
+                explicit = null,
+                hint = hint,
                 confidence = defaultTuning.autoScrobbleThreshold - 0.01f,
                 tuning = defaultTuning,
                 cacheEntry = watchedEntry(),

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/EpisodeResolutionTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/EpisodeResolutionTest.kt
@@ -1,0 +1,141 @@
+package com.justb81.watchbuddy.core.scrobbler
+
+import com.justb81.watchbuddy.core.model.TmdbEpisodeSummary
+import com.justb81.watchbuddy.core.model.TmdbProgressHint
+import com.justb81.watchbuddy.core.model.TraktIds
+import com.justb81.watchbuddy.core.model.TraktShow
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import com.justb81.watchbuddy.core.model.TraktWatchedEpisode
+import com.justb81.watchbuddy.core.model.TraktWatchedSeason
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("resolveEpisodeFromMetadata()")
+class EpisodeResolutionTest {
+
+    private val defaultTuning = ScrobbleTuning()
+
+    private fun watchedEntry(
+        traktId: Int = 1,
+        season: Int = 1,
+        episode: Int = 3,
+    ) = TraktWatchedEntry(
+        show = TraktShow(title = "Test Show", ids = TraktIds(trakt = traktId)),
+        seasons = listOf(
+            TraktWatchedSeason(
+                number = season,
+                episodes = listOf(TraktWatchedEpisode(number = episode)),
+            ),
+        ),
+    )
+
+    // ── explicit marker wins ──────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("explicit marker behaviour")
+    inner class ExplicitMarkerTest {
+
+        @Test
+        fun `explicit marker wins over progress hint`() {
+            val marker = EpisodeMarkerExtractor.Marker(season = 2, episode = 5)
+            val hint = TmdbProgressHint(
+                nextAired = TmdbEpisodeSummary(season_number = 3, episode_number = 1),
+            )
+            val result = resolveEpisodeFromMetadata(
+                explicit = marker,
+                hint = hint,
+                confidence = 0.98f,
+                tuning = defaultTuning,
+                cacheEntry = watchedEntry(),
+            )
+            assertEquals(
+                EpisodeResolutionResult.Resolved(
+                    season = 2,
+                    episode = 5,
+                    source = ResolveSource.EXPLICIT_MARKER,
+                ),
+                result,
+            )
+        }
+
+        @Test
+        fun `ambiguous when explicit marker disagrees with high-confidence hint`() {
+            // Explicit says S2E5; nextEpisodeNumbers from hint says S3E1 — they disagree.
+            val marker = EpisodeMarkerExtractor.Marker(season = 2, episode = 5)
+            val hint = TmdbProgressHint(
+                nextAired = TmdbEpisodeSummary(season_number = 3, episode_number = 1),
+            )
+            // confidence >= autoScrobbleThreshold so hint is computed
+            val result = resolveEpisodeFromMetadata(
+                explicit = marker,
+                hint = hint,
+                confidence = defaultTuning.autoScrobbleThreshold,
+                tuning = defaultTuning,
+                cacheEntry = watchedEntry(season = 2, episode = 5),
+            )
+            assertEquals(EpisodeResolutionResult.Ambiguous, result)
+        }
+
+        @Test
+        fun `explicit marker resolves without ambiguity when hint is null`() {
+            val marker = EpisodeMarkerExtractor.Marker(season = 1, episode = 1)
+            val result = resolveEpisodeFromMetadata(
+                explicit = marker,
+                hint = null,
+                confidence = 0.98f,
+                tuning = defaultTuning,
+                cacheEntry = watchedEntry(),
+            )
+            assertEquals(
+                EpisodeResolutionResult.Resolved(
+                    season = 1,
+                    episode = 1,
+                    source = ResolveSource.EXPLICIT_MARKER,
+                ),
+                result,
+            )
+        }
+    }
+
+    // ── progress hint path ────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("progress hint path")
+    inner class ProgressHintTest {
+
+        @Test
+        fun `progress hint used when no explicit marker and confidence at threshold`() {
+            // nextEpisodeNumbers will compute S1E4 (latest watched S1E3 + 1)
+            val entry = watchedEntry(season = 1, episode = 3)
+            val result = resolveEpisodeFromMetadata(
+                explicit = null,
+                hint = null,
+                confidence = defaultTuning.autoScrobbleThreshold,
+                tuning = defaultTuning,
+                cacheEntry = entry,
+            )
+            assertEquals(
+                EpisodeResolutionResult.Resolved(
+                    season = 1,
+                    episode = 4,
+                    source = ResolveSource.PROGRESS_HINT,
+                ),
+                result,
+            )
+        }
+
+        @Test
+        fun `unresolved when confidence below hintThreshold and no explicit marker`() {
+            val result = resolveEpisodeFromMetadata(
+                explicit = null,
+                hint = null,
+                confidence = defaultTuning.autoScrobbleThreshold - 0.01f,
+                tuning = defaultTuning,
+                cacheEntry = watchedEntry(),
+            )
+            assertEquals(EpisodeResolutionResult.Unresolved, result)
+        }
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,6 +165,10 @@ Multi-user: when multiple phones are connected, each user's watch history is rec
 independently — one `/scrobble/*` call per phone, in parallel. A failure for one user
 does not block the others. The TV never calls the Trakt API directly for any operation.
 
+**Episode resolution** is handled by two pure functions in `core/scrobbler/`:
+- `EpisodeMarkerExtractor` — builds pattern lists from an `AppProfile` and extracts `(season, episode)` markers from text fields. No I/O or side effects.
+- `resolveEpisodeFromMetadata()` — given an optional explicit marker, a fetched `TmdbProgressHint`, a confidence score, and tuning constants, returns a sealed `EpisodeResolutionResult` (`Resolved`, `Ambiguous`, or `Unresolved`). No I/O or side effects; `MediaSessionScrobbler` injects `DiagnosticLog` calls at the call boundary.
+
 ## Manual Watched-State Marking (Phone)
 
 Tapping a show on the phone `HomeScreen` opens `ShowDetailScreen`. The detail view


### PR DESCRIPTION
## Summary
- Extract `EpisodeMarkerExtractor` object with pure `extractFromText` and `normalizeTitle` functions — no caches, no logging, no coroutines
- Extract `EpisodeResolution.kt` with `resolveEpisodeFromMetadata` pure function and sealed `EpisodeResolutionResult` type (`Resolved`, `Ambiguous`, `Unresolved`) + `ResolveSource` enum
- `MediaSessionScrobbler` delegates to these instead of repeating inline `buildList{ markerRegexes + S##E## }` blocks in 5 places (`scoreCandidate`, `collectAmbiguousCandidates`, `scoreSnapshotAgainstTitle`, `findGlobalEpisodeMarker`, `resolveEpisode`)
- ~53 lines removed from the 1222-line god-class; no public API change

## Test plan
- [ ] `EpisodeMarkerExtractorTest`: 7 test cases covering canonical S##E##, Joyn Staffel/Folge, Disney+ T##E##, null case, profile-priority, case-insensitivity, and `normalizeTitle` (4 cases)
- [ ] `EpisodeResolutionTest`: 4 test cases — explicit-wins, ambiguous-on-disagreement, explicit-without-hint, progress-hint-path, unresolved-below-threshold
- [ ] Existing `MediaSessionScrobbler*Test` integration coverage unchanged (all delegate through new functions)
- [ ] CI build passes (Gradle scope skipped locally — no Android SDK)

Closes #699

> Note: Gradle scope skipped locally (no Android SDK in sandbox); CI (`Test & Build`) is the gate for Kotlin/Android changes.

https://claude.ai/code/session_013PNZkpfbQfqXhidTsziQak

---
_Generated by [Claude Code](https://claude.ai/code/session_01GRrTxo6W3PRR67KvCm53bR)_