### PR TITLE
fix(tv): fall back to launch intent when streaming app is present

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -44,6 +44,7 @@ import com.justb81.watchbuddy.core.tmdb.TmdbImageHelper
 import com.justb81.watchbuddy.tv.ui.components.SeasonEpisodeListPicker
 import com.justb81.watchbuddy.tv.ui.components.UserScopePickerDialog
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 private const val TMDB_POSTER_WIDTH = 500
 private const val MARK_WATCHED_TOAST_DELAY_MS = 3_000L
@@ -82,6 +83,7 @@ fun ShowDetailScreen(
     val episodeListState = ready?.episodeList ?: EpisodeListUiState.Idle
     val markState = ready?.markWatched ?: MarkWatchedState.Idle
 
+    val scope = rememberCoroutineScope()
     val watchNowFocus = remember { FocusRequester() }
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -92,6 +94,7 @@ fun ShowDetailScreen(
     val partialFailedMsg = stringResource(R.string.tv_detail_toggle_failed_partial)
     val markWatchedNoPhonesMsg = stringResource(R.string.tv_mark_watched_no_phones)
     val markWatchedErrorMsg = stringResource(R.string.tv_mark_watched_error)
+    val openFailedMsg = stringResource(R.string.tv_provider_open_failed)
 
     ShowDetailEffects(
         viewModel = viewModel,
@@ -134,12 +137,16 @@ fun ShowDetailScreen(
                     if (watchNowState is WatchNowState.Available) {
                         val firstProvider = (providerState as? ProviderListUiState.Success)
                             ?.providers?.firstOrNull()
-                        launchProvider(context, firstProvider, watchNowState.url)
+                        launchProvider(context, firstProvider, watchNowState.url) {
+                            scope.launch { snackbarHostState.showSnackbar(openFailedMsg) }
+                        }
                     }
                 },
                 onProviderClick = { provider ->
                     val link = viewModel.onProviderSelected(provider, effectiveEntry)
-                    launchProvider(context, provider, link)
+                    launchProvider(context, provider, link) {
+                        scope.launch { snackbarHostState.showSnackbar(openFailedMsg) }
+                    }
                 },
                 onRetryProviders = { viewModel.loadProviders(effectiveEntry) },
                 onRecapClick = onRecapClick,
@@ -182,13 +189,29 @@ fun ShowDetailScreen(
 }
 
 /**
- * Three-stage launch cascade for a streaming provider:
- *   1. Deep-link intent (with [ResolvedProvider.packageName] targeted when known).
- *   2. If the provider is detected as installed, fall through to the app's main
- *      activity via [android.content.pm.PackageManager.getLaunchIntentForPackage].
- *   3. Otherwise open [ResolvedProvider.tmdbPageUrl] in the system browser.
+ * Four-stage launch cascade for a streaming provider.
+ *
+ * Stages are tried in order; the function returns as soon as one succeeds:
+ *   1. Targeted [Intent.ACTION_VIEW] with the JustWatch deep-link URL pinned to
+ *      [ResolvedProvider.packageName] (when known).
+ *   2. Untargeted [Intent.ACTION_VIEW] with the same URL (lets the OS route to any
+ *      app that handles the scheme, e.g. a regional variant of the streaming app).
+ *   3. [android.content.pm.PackageManager.getLaunchIntentForPackage] for
+ *      [ResolvedProvider.packageName] — tried unconditionally, regardless of
+ *      [ResolvedProvider.isInstalled], because the catalog entry may carry a stale or
+ *      mismatched package name while the real app is present on the device.
+ *   4. Open [ResolvedProvider.tmdbPageUrl] in the system browser.
+ *
+ * If every stage fails (no activity resolves) [onFailure] is invoked so the caller can
+ * show a user-facing error message. The function never lets the system "you don't have
+ * an app for that" dialog surface to the user.
  */
-private fun launchProvider(context: Context, provider: ResolvedProvider?, deepLink: String?) {
+internal fun launchProvider(
+    context: Context,
+    provider: ResolvedProvider?,
+    deepLink: String?,
+    onFailure: () -> Unit = {},
+) {
     val pm = context.packageManager
 
     if (deepLink != null && deepLink.isNotBlank()) {
@@ -210,9 +233,12 @@ private fun launchProvider(context: Context, provider: ResolvedProvider?, deepLi
         }
     }
 
-    val installedPackage = provider?.takeIf { it.isInstalled }?.packageName
-    if (installedPackage != null) {
-        pm.getLaunchIntentForPackage(installedPackage)?.let { launchIntent ->
+    // Stage 3: try getLaunchIntentForPackage regardless of isInstalled — the catalog
+    // entry may be stale or carry a region-variant package name, but the app may still
+    // be present. getLaunchIntentForPackage returns null when the package is absent, so
+    // there is no risk of surfacing a system "no app" dialog here.
+    provider?.packageName?.let { pkg ->
+        pm.getLaunchIntentForPackage(pkg)?.let { launchIntent ->
             context.startActivity(launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
             return
         }
@@ -223,8 +249,11 @@ private fun launchProvider(context: Context, provider: ResolvedProvider?, deepLi
             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         if (fallback.resolveActivity(pm) != null) {
             context.startActivity(fallback)
+            return
         }
     }
+
+    onFailure()
 }
 
 @Composable

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -219,14 +219,16 @@ internal fun launchProvider(
         val targetedIntent = Intent(Intent.ACTION_VIEW, uri)
             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         provider?.packageName?.let { targetedIntent.setPackage(it) }
-        if (targetedIntent.resolveActivity(pm) != null) {
+        @Suppress("DEPRECATION")
+        if (pm.resolveActivity(targetedIntent, 0) != null) {
             context.startActivity(targetedIntent)
             return
         }
         if (provider?.packageName != null) {
             val untargetedIntent = Intent(Intent.ACTION_VIEW, uri)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            if (untargetedIntent.resolveActivity(pm) != null) {
+            @Suppress("DEPRECATION")
+            if (pm.resolveActivity(untargetedIntent, 0) != null) {
                 context.startActivity(untargetedIntent)
                 return
             }
@@ -247,7 +249,8 @@ internal fun launchProvider(
     provider?.tmdbPageUrl?.let { pageUrl ->
         val fallback = Intent(Intent.ACTION_VIEW, pageUrl.toUri())
             .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        if (fallback.resolveActivity(pm) != null) {
+        @Suppress("DEPRECATION")
+        if (pm.resolveActivity(fallback, 0) != null) {
             context.startActivity(fallback)
             return
         }

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -84,6 +84,7 @@
     <!-- JustWatch deep links (#476) -->
     <string name="tv_provider_no_deep_link">Kein Deep Link</string>
     <string name="tv_provider_open_app">App öffnen</string>
+    <string name="tv_provider_open_failed">Diese Streaming-App konnte nicht geöffnet werden.</string>
     <string name="tv_watch_now_unavailable">Deep Link nicht verfügbar</string>
     <string name="tv_watch_now_no_provider">Kein Anbieter verfügbar</string>
     <string name="tv_justwatch_attribution">Streaming-Daten von JustWatch</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -87,6 +87,7 @@
     <!-- JustWatch deep links (#476) -->
     <string name="tv_provider_no_deep_link">Sin enlace directo</string>
     <string name="tv_provider_open_app">Abrir app</string>
+    <string name="tv_provider_open_failed">No se pudo abrir esta aplicación de streaming.</string>
     <string name="tv_watch_now_unavailable">Enlace directo no disponible</string>
     <string name="tv_watch_now_no_provider">Ningún proveedor disponible</string>
     <string name="tv_justwatch_attribution">Datos de streaming por JustWatch</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -87,6 +87,7 @@
     <!-- JustWatch deep links (#476) -->
     <string name="tv_provider_no_deep_link">Pas de lien direct</string>
     <string name="tv_provider_open_app">Ouvrir l\'app</string>
+    <string name="tv_provider_open_failed">Impossible d\'ouvrir cette application de streaming.</string>
     <string name="tv_watch_now_unavailable">Lien direct indisponible</string>
     <string name="tv_watch_now_no_provider">Aucun fournisseur disponible</string>
     <string name="tv_justwatch_attribution">Données streaming par JustWatch</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -85,6 +85,8 @@
     <string name="tv_provider_no_deep_link">No deep link</string>
     <!-- Shown on a provider chip when JustWatch has no deep link but the app is installed (#620) -->
     <string name="tv_provider_open_app">Open app</string>
+    <!-- Snackbar shown when all launch steps fail and no app can be opened (#720) -->
+    <string name="tv_provider_open_failed">Could not open this streaming app.</string>
     <string name="tv_watch_now_unavailable">Deep link unavailable</string>
     <string name="tv_watch_now_no_provider">No provider available</string>
     <string name="tv_justwatch_attribution">Streaming data by JustWatch</string>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/LaunchProviderTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/LaunchProviderTest.kt
@@ -6,8 +6,11 @@ import android.content.pm.PackageManager
 import com.justb81.watchbuddy.core.model.ResolvedProvider
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.slot
+import io.mockk.unmockkConstructor
 import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -19,15 +22,16 @@ import org.junit.jupiter.api.Test
  * Unit tests for [launchProvider] — the four-stage provider launch cascade in
  * [ShowDetailScreen].
  *
- * Test strategy: mock [Context] and [PackageManager] with MockK; stub
- * [PackageManager.resolveActivity] and [PackageManager.getLaunchIntentForPackage]
- * to control which stage fires. Verify that [Context.startActivity] is called the
- * expected number of times, or not at all when every stage fails. Also verifies
- * the [onFailure] callback fires only when the entire cascade is exhausted.
- *
- * Note: Intent property accessors (`.package`, `.action`) are Android SDK stubs and
- * throw NullPointerException on the pure JVM. Tests use [any()] and call-count
- * assertions instead.
+ * Test strategy:
+ * - Mock [Context] and [PackageManager] with MockK.
+ * - Use [mockkConstructor] to intercept `Intent(action, uri)` construction so that
+ *   `addFlags` / `setPackage` return the same mock instead of null (Android stubs return
+ *   null for object-returning methods when `isReturnDefaultValues = true`).
+ * - Stub [PackageManager.resolveActivity] and [PackageManager.getLaunchIntentForPackage]
+ *   to control which stage fires.
+ * - Verify that [Context.startActivity] is called the expected number of times, or not at
+ *   all when every stage fails. Also verifies the [onFailure] callback fires only when the
+ *   entire cascade is exhausted.
  */
 @DisplayName("launchProvider — four-stage launch cascade (#720)")
 class LaunchProviderTest {
@@ -38,6 +42,12 @@ class LaunchProviderTest {
 
     @BeforeEach
     fun setUp() {
+        mockkConstructor(Intent::class)
+        // Make every constructed Intent return itself from chainable methods so that
+        // `Intent(...).addFlags(...).setPackage(...)` does not NPE.
+        every { anyConstructed<Intent>().addFlags(any()) } answers { self as Intent }
+        every { anyConstructed<Intent>().setPackage(any()) } answers { self as Intent }
+
         every { context.packageManager } returns pm
         val intentSlot = slot<Intent>()
         every { context.startActivity(capture(intentSlot)) } answers {
@@ -47,6 +57,12 @@ class LaunchProviderTest {
         every { pm.resolveActivity(any(), any<Int>()) } returns null
         // Default: getLaunchIntentForPackage returns null (package not present)
         every { pm.getLaunchIntentForPackage(any()) } returns null
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkConstructor(Intent::class)
+        startedIntents.clear()
     }
 
     private fun makeProvider(
@@ -88,7 +104,7 @@ class LaunchProviderTest {
 
             launchProvider(context, makeProvider(), deepLink)
 
-            // Exactly one startActivity call from stage 3, not from a deep-link intent.
+            // Exactly one startActivity call from stage 3 (via getLaunchIntentForPackage).
             verify(exactly = 1) { context.startActivity(any()) }
             verify(exactly = 1) { pm.getLaunchIntentForPackage("com.amazon.avod.thirdpartyclient") }
         }
@@ -110,15 +126,12 @@ class LaunchProviderTest {
 
         @Test
         fun `does not attempt untargeted intent when provider has no package name`() {
-            // Without a package name there is no targeted attempt, so stage 2 is skipped
-            // entirely. resolveActivity should be called at most once (for stage 1 targeted,
-            // which becomes untargeted when packageName is null), then cascade moves to stage 3.
+            // Without a package name, stage 2 is skipped entirely and stage 3 is also
+            // skipped (no packageName to pass to getLaunchIntentForPackage).
             every { pm.resolveActivity(any(), any<Int>()) } returns null
-            every { pm.getLaunchIntentForPackage(any()) } returns null
 
             launchProvider(context, makeProvider(packageName = null), deepLink)
 
-            // No stage 3 call when packageName is null.
             verify(exactly = 0) { pm.getLaunchIntentForPackage(any()) }
         }
     }
@@ -174,7 +187,7 @@ class LaunchProviderTest {
 
         @Test
         fun `opens TMDB page when all other stages fail`() {
-            // resolveActivity returns null for deep-link intents and non-null for the TMDB URL.
+            // resolveActivity returns null for deep-link intents and non-null for TMDB URL.
             every { pm.resolveActivity(any(), any<Int>()) } returnsMany listOf(null, null, mockk())
             every { pm.getLaunchIntentForPackage(any()) } returns null
 

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/LaunchProviderTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/LaunchProviderTest.kt
@@ -1,0 +1,234 @@
+package com.justb81.watchbuddy.tv.ui.showdetail
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import com.justb81.watchbuddy.core.model.ResolvedProvider
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * Unit tests for [launchProvider] — the four-stage provider launch cascade in
+ * [ShowDetailScreen].
+ *
+ * Test strategy: mock [Context] and [PackageManager] with MockK; stub
+ * [PackageManager.resolveActivity] and [PackageManager.getLaunchIntentForPackage]
+ * to control which stage fires. Verify that [Context.startActivity] is called with
+ * the expected intent, or not called at all when every stage fails. Also verifies
+ * the [onFailure] callback fires only when the entire cascade is exhausted.
+ */
+@DisplayName("launchProvider — four-stage launch cascade (#720)")
+class LaunchProviderTest {
+
+    private val pm: PackageManager = mockk(relaxed = true)
+    private val context: Context = mockk(relaxed = true)
+    private val startedIntents = mutableListOf<Intent>()
+
+    @BeforeEach
+    fun setUp() {
+        every { context.packageManager } returns pm
+        val intentSlot = slot<Intent>()
+        justRun { context.startActivity(capture(intentSlot)) }
+        every { context.startActivity(capture(intentSlot)) } answers {
+            startedIntents.add(intentSlot.captured)
+        }
+        // Default: resolveActivity returns null (nothing handles any intent)
+        every { pm.resolveActivity(any(), any<Int>()) } returns null
+        // Default: getLaunchIntentForPackage returns null (package not present)
+        every { pm.getLaunchIntentForPackage(any()) } returns null
+    }
+
+    private fun makeProvider(
+        packageName: String? = "com.amazon.avod.thirdpartyclient",
+        isInstalled: Boolean = true,
+        tmdbPageUrl: String? = "https://www.themoviedb.org/tv/1399",
+    ) = ResolvedProvider(
+        providerId = 9,
+        name = "Prime Video",
+        logoPath = null,
+        packageName = packageName,
+        isInstalled = isInstalled,
+        isLastUsed = false,
+        tmdbPageUrl = tmdbPageUrl,
+    )
+
+    private val deepLink = "https://www.amazon.com/gp/video/detail/B00VSTHUGG"
+    private val launchIntent = mockk<Intent>(relaxed = true)
+
+    @Nested
+    @DisplayName("Stage 1 — targeted deep-link intent")
+    inner class Stage1Tests {
+
+        @Test
+        fun `fires targeted intent when resolveActivity returns non-null`() {
+            every { pm.resolveActivity(match { it.`package` != null }, any<Int>()) } returns mockk()
+
+            launchProvider(context, makeProvider(), deepLink)
+
+            verify(exactly = 1) { context.startActivity(any()) }
+        }
+
+        @Test
+        fun `skips to next stage when targeted resolveActivity returns null`() {
+            every { pm.resolveActivity(match { it.`package` != null }, any<Int>()) } returns null
+            every { pm.resolveActivity(match { it.`package` == null }, any<Int>()) } returns null
+
+            launchProvider(context, makeProvider(), deepLink)
+
+            // No startActivity for deep-link intents; falls through to launch-intent stage
+            verify(exactly = 0) { context.startActivity(match { it.action == Intent.ACTION_VIEW && it.`package` != null }) }
+        }
+    }
+
+    @Nested
+    @DisplayName("Stage 2 — untargeted deep-link intent")
+    inner class Stage2Tests {
+
+        @Test
+        fun `fires untargeted intent when targeted fails but untargeted resolves`() {
+            every { pm.resolveActivity(match { it.`package` != null }, any<Int>()) } returns null
+            every { pm.resolveActivity(match { it.`package` == null }, any<Int>()) } returns mockk()
+
+            launchProvider(context, makeProvider(), deepLink)
+
+            verify(exactly = 1) { context.startActivity(any()) }
+        }
+
+        @Test
+        fun `does not fire untargeted intent when provider has no package name`() {
+            every { pm.resolveActivity(any(), any<Int>()) } returns null
+
+            launchProvider(context, makeProvider(packageName = null), deepLink)
+
+            verify(exactly = 0) { context.startActivity(match { it.action == Intent.ACTION_VIEW }) }
+        }
+    }
+
+    @Nested
+    @DisplayName("Stage 3 — getLaunchIntentForPackage fallback")
+    inner class Stage3Tests {
+
+        @Test
+        fun `falls back to getLaunchIntentForPackage when deep-link stages fail`() {
+            every { pm.resolveActivity(any(), any<Int>()) } returns null
+            every { pm.getLaunchIntentForPackage("com.amazon.avod.thirdpartyclient") } returns launchIntent
+
+            launchProvider(context, makeProvider(isInstalled = true), deepLink)
+
+            verify(exactly = 1) { context.startActivity(any()) }
+        }
+
+        @Test
+        fun `uses getLaunchIntentForPackage even when isInstalled is false`() {
+            every { pm.resolveActivity(any(), any<Int>()) } returns null
+            every { pm.getLaunchIntentForPackage("com.amazon.avod.thirdpartyclient") } returns launchIntent
+
+            launchProvider(context, makeProvider(isInstalled = false), deepLink)
+
+            verify(exactly = 1) { context.startActivity(any()) }
+        }
+
+        @Test
+        fun `uses getLaunchIntentForPackage even when deepLink is null`() {
+            every { pm.getLaunchIntentForPackage("com.amazon.avod.thirdpartyclient") } returns launchIntent
+
+            launchProvider(context, makeProvider(isInstalled = false), deepLink = null)
+
+            verify(exactly = 1) { context.startActivity(any()) }
+        }
+
+        @Test
+        fun `skips stage 3 when provider has no package name`() {
+            every { pm.resolveActivity(any(), any<Int>()) } returns null
+
+            launchProvider(context, makeProvider(packageName = null), deepLink)
+
+            verify(exactly = 0) { pm.getLaunchIntentForPackage(any()) }
+        }
+    }
+
+    @Nested
+    @DisplayName("Stage 4 — TMDB page URL browser fallback")
+    inner class Stage4Tests {
+
+        @Test
+        fun `opens TMDB page when all other stages fail`() {
+            every { pm.resolveActivity(any(), any<Int>()) } returnsMany listOf(null, null, mockk())
+            every { pm.getLaunchIntentForPackage(any()) } returns null
+
+            launchProvider(context, makeProvider(), deepLink)
+
+            verify(exactly = 1) { context.startActivity(any()) }
+        }
+
+        @Test
+        fun `onFailure fires when TMDB page URL is null and all other stages fail`() {
+            every { pm.resolveActivity(any(), any<Int>()) } returns null
+            every { pm.getLaunchIntentForPackage(any()) } returns null
+
+            var failed = false
+            launchProvider(context, makeProvider(tmdbPageUrl = null), deepLink) { failed = true }
+
+            verify(exactly = 0) { context.startActivity(any()) }
+            assertTrue(failed)
+        }
+
+        @Test
+        fun `onFailure fires when provider is null and deepLink is null`() {
+            var failed = false
+            launchProvider(context, provider = null, deepLink = null) { failed = true }
+
+            verify(exactly = 0) { context.startActivity(any()) }
+            assertTrue(failed)
+        }
+
+        @Test
+        fun `onFailure is not called when stage 4 succeeds`() {
+            every { pm.resolveActivity(any(), any<Int>()) } returnsMany listOf(null, null, mockk())
+            every { pm.getLaunchIntentForPackage(any()) } returns null
+
+            var failed = false
+            launchProvider(context, makeProvider(), deepLink) { failed = true }
+
+            verify(exactly = 1) { context.startActivity(any()) }
+            assertFalse(failed)
+        }
+    }
+
+    @Nested
+    @DisplayName("fallback priority order")
+    inner class FallbackOrderTests {
+
+        @Test
+        fun `stage 3 is preferred over stage 4 when getLaunchIntentForPackage succeeds`() {
+            every { pm.resolveActivity(any(), any<Int>()) } returns null
+            every { pm.getLaunchIntentForPackage("com.amazon.avod.thirdpartyclient") } returns launchIntent
+
+            launchProvider(context, makeProvider(isInstalled = false), deepLink)
+
+            // Only one startActivity call — from stage 3, not stage 4
+            verify(exactly = 1) { context.startActivity(any()) }
+        }
+
+        @Test
+        fun `isInstalled=false no longer blocks stage 3 fallback`() {
+            every { pm.resolveActivity(any(), any<Int>()) } returns null
+            every { pm.getLaunchIntentForPackage("com.amazon.avod.thirdpartyclient") } returns launchIntent
+
+            launchProvider(context, makeProvider(isInstalled = false), deepLink)
+
+            verify { pm.getLaunchIntentForPackage("com.amazon.avod.thirdpartyclient") }
+            verify(exactly = 1) { context.startActivity(any()) }
+        }
+    }
+}

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/LaunchProviderTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/LaunchProviderTest.kt
@@ -5,17 +5,15 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import com.justb81.watchbuddy.core.model.ResolvedProvider
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertTrue
 
 /**
  * Unit tests for [launchProvider] — the four-stage provider launch cascade in
@@ -23,9 +21,13 @@ import org.junit.jupiter.api.Assertions.assertTrue
  *
  * Test strategy: mock [Context] and [PackageManager] with MockK; stub
  * [PackageManager.resolveActivity] and [PackageManager.getLaunchIntentForPackage]
- * to control which stage fires. Verify that [Context.startActivity] is called with
- * the expected intent, or not called at all when every stage fails. Also verifies
+ * to control which stage fires. Verify that [Context.startActivity] is called the
+ * expected number of times, or not at all when every stage fails. Also verifies
  * the [onFailure] callback fires only when the entire cascade is exhausted.
+ *
+ * Note: Intent property accessors (`.package`, `.action`) are Android SDK stubs and
+ * throw NullPointerException on the pure JVM. Tests use [any()] and call-count
+ * assertions instead.
  */
 @DisplayName("launchProvider — four-stage launch cascade (#720)")
 class LaunchProviderTest {
@@ -38,7 +40,6 @@ class LaunchProviderTest {
     fun setUp() {
         every { context.packageManager } returns pm
         val intentSlot = slot<Intent>()
-        justRun { context.startActivity(capture(intentSlot)) }
         every { context.startActivity(capture(intentSlot)) } answers {
             startedIntents.add(intentSlot.captured)
         }
@@ -71,7 +72,8 @@ class LaunchProviderTest {
 
         @Test
         fun `fires targeted intent when resolveActivity returns non-null`() {
-            every { pm.resolveActivity(match { it.`package` != null }, any<Int>()) } returns mockk()
+            // First resolveActivity call (targeted) returns a result → stage 1 fires.
+            every { pm.resolveActivity(any(), any<Int>()) } returns mockk()
 
             launchProvider(context, makeProvider(), deepLink)
 
@@ -80,13 +82,15 @@ class LaunchProviderTest {
 
         @Test
         fun `skips to next stage when targeted resolveActivity returns null`() {
-            every { pm.resolveActivity(match { it.`package` != null }, any<Int>()) } returns null
-            every { pm.resolveActivity(match { it.`package` == null }, any<Int>()) } returns null
+            // Both deep-link calls return null → cascade continues to stage 3.
+            every { pm.resolveActivity(any(), any<Int>()) } returns null
+            every { pm.getLaunchIntentForPackage(any()) } returns launchIntent
 
             launchProvider(context, makeProvider(), deepLink)
 
-            // No startActivity for deep-link intents; falls through to launch-intent stage
-            verify(exactly = 0) { context.startActivity(match { it.action == Intent.ACTION_VIEW && it.`package` != null }) }
+            // Exactly one startActivity call from stage 3, not from a deep-link intent.
+            verify(exactly = 1) { context.startActivity(any()) }
+            verify(exactly = 1) { pm.getLaunchIntentForPackage("com.amazon.avod.thirdpartyclient") }
         }
     }
 
@@ -96,8 +100,8 @@ class LaunchProviderTest {
 
         @Test
         fun `fires untargeted intent when targeted fails but untargeted resolves`() {
-            every { pm.resolveActivity(match { it.`package` != null }, any<Int>()) } returns null
-            every { pm.resolveActivity(match { it.`package` == null }, any<Int>()) } returns mockk()
+            // First call (targeted) returns null; second call (untargeted) resolves.
+            every { pm.resolveActivity(any(), any<Int>()) } returnsMany listOf(null, mockk())
 
             launchProvider(context, makeProvider(), deepLink)
 
@@ -105,12 +109,17 @@ class LaunchProviderTest {
         }
 
         @Test
-        fun `does not fire untargeted intent when provider has no package name`() {
+        fun `does not attempt untargeted intent when provider has no package name`() {
+            // Without a package name there is no targeted attempt, so stage 2 is skipped
+            // entirely. resolveActivity should be called at most once (for stage 1 targeted,
+            // which becomes untargeted when packageName is null), then cascade moves to stage 3.
             every { pm.resolveActivity(any(), any<Int>()) } returns null
+            every { pm.getLaunchIntentForPackage(any()) } returns null
 
             launchProvider(context, makeProvider(packageName = null), deepLink)
 
-            verify(exactly = 0) { context.startActivity(match { it.action == Intent.ACTION_VIEW }) }
+            // No stage 3 call when packageName is null.
+            verify(exactly = 0) { pm.getLaunchIntentForPackage(any()) }
         }
     }
 
@@ -130,11 +139,13 @@ class LaunchProviderTest {
 
         @Test
         fun `uses getLaunchIntentForPackage even when isInstalled is false`() {
+            // PRIMARY REGRESSION TEST FOR #720 — isInstalled=false must not block stage 3.
             every { pm.resolveActivity(any(), any<Int>()) } returns null
             every { pm.getLaunchIntentForPackage("com.amazon.avod.thirdpartyclient") } returns launchIntent
 
             launchProvider(context, makeProvider(isInstalled = false), deepLink)
 
+            verify { pm.getLaunchIntentForPackage("com.amazon.avod.thirdpartyclient") }
             verify(exactly = 1) { context.startActivity(any()) }
         }
 
@@ -163,6 +174,7 @@ class LaunchProviderTest {
 
         @Test
         fun `opens TMDB page when all other stages fail`() {
+            // resolveActivity returns null for deep-link intents and non-null for the TMDB URL.
             every { pm.resolveActivity(any(), any<Int>()) } returnsMany listOf(null, null, mockk())
             every { pm.getLaunchIntentForPackage(any()) } returns null
 
@@ -216,7 +228,7 @@ class LaunchProviderTest {
 
             launchProvider(context, makeProvider(isInstalled = false), deepLink)
 
-            // Only one startActivity call — from stage 3, not stage 4
+            // Exactly one startActivity call — from stage 3, not from stage 4.
             verify(exactly = 1) { context.startActivity(any()) }
         }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -325,6 +325,8 @@ The available-provider list for each show is fetched from TMDB `/tv/{id}/watch/p
 
 **ViewModel integration:** `ShowDetailViewModel.loadDeepLinks()` is triggered once `ProviderListUiState.Success` arrives. Each provider gets a `viewModelScope.async` backed by `JustWatchDeepLinkRepository`; in-flight dedup at the ViewModel level prevents duplicate `Deferred` jobs per key. State is `deepLinks: StateFlow<Map<Int, DeepLinkState>>` with `DeepLinkState = Loading | Available(url) | Unavailable`. The UI shows a spinner overlay on loading chips, disables unavailable chips, and displays a JustWatch attribution badge when any link is `Available`.
 
+**Launch cascade (`launchProvider` in `ShowDetailScreen.kt`):** When the user taps a provider chip or the "Watch Now" button, a four-stage cascade fires in order: (1) targeted `ACTION_VIEW` with the JustWatch deep-link URL pinned to the provider's package; (2) untargeted `ACTION_VIEW` with the same URL; (3) `PackageManager.getLaunchIntentForPackage` — attempted whenever the package is actually present on the device, regardless of whether `ResolvedProvider.isInstalled` is true (guards against stale `InstalledAppsProbe` caches and region-variant APK package names not in `ProviderCatalogRegistry`); (4) open `ResolvedProvider.tmdbPageUrl` in the system browser. If every stage fails the caller's `onFailure` callback fires and a WatchBuddy snackbar is shown; the system "no app for that" dialog is never surfaced.
+
 **Diagnostics:** `TvDiagnosticsScreen` shows a "Streaming Links" section with cached URL count, negative entry count, last-fetch timestamp, and a "Clear cache" button.
 
 ### Provider ordering on ShowDetail


### PR DESCRIPTION
## Summary
- Fix #720: stage 3 of the `launchProvider` cascade now calls `PackageManager.getLaunchIntentForPackage` unconditionally, regardless of the cached `ResolvedProvider.isInstalled` flag — guarding against stale `InstalledAppsProbe` results and region-variant APK package names not listed in `ProviderCatalogRegistry`
- Add `onFailure: () -> Unit` callback to `launchProvider` so the screen can show a WatchBuddy snackbar (`tv_provider_open_failed`) instead of the bare system "no app for that" dialog when every launch step is exhausted
- Add `tv_provider_open_failed` string resource in EN / DE / FR / ES
- Add `LaunchProviderTest` (JVM, MockK + JUnit5) covering all five cascade branches, including the primary regression test with `isInstalled = false` but package present on device
- Update `docs/architecture.md` with the launch cascade documentation

## Test plan
- [ ] Tap "Prime Video" (or any installed streaming provider) on the show detail screen — app opens
- [ ] With `isInstalled=false` still in cache, tap provider chip — app still opens (stage 3 fallback)
- [ ] Provider not installed: TMDB page opens in browser; no system "no app" dialog
- [ ] Provider not installed + no TMDB URL: WatchBuddy snackbar "Could not open this streaming app." appears; no system dialog
- [ ] `./gradlew :app-tv:test` passes (CI gate — Gradle scope skipped locally, no Android SDK in runner)

Closes #720

> Note: Gradle scope skipped locally (no Android SDK in CI runner); CI is the gate.

https://claude.ai/code/session_013PNZkpfbQfqXhidTsziQak

---
_Generated by [Claude Code](https://claude.ai/code/session_011mYRxTYbV3QmRLxyKN6Ach)_