### PR TITLE
fix: correct Joyn scrobbler profile package name to current TV app

### DIFF
--- a/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/AppProfiles.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/scrobbler/AppProfiles.kt
@@ -97,7 +97,7 @@ object AppProfiles {
         ),
         // Joyn (German free streaming, ProSiebenSat.1) — episode marker uses "Staffel Y, Folge X"
         AppProfile(
-            packageName = "de.prosiebensat1digital.seventv",
+            packageName = "de.prosiebensat1.joyn.tv",
             preferredSourceTags = listOf("watchNext.contentId", "watchNext.episodeNumber", "mediaSession.subtitle"),
             markerRegexes = listOf(
                 // "Staffel 2, Folge 3" or "Staffel 2 Folge 3"

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/AppProfilesTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/AppProfilesTest.kt
@@ -369,19 +369,19 @@ class AppProfilesTest {
     // ── Joyn fixture ─────────────────────────────────────────────────────────
 
     @Nested
-    @DisplayName("Joyn (de.prosiebensat1digital.seventv)")
+    @DisplayName("Joyn (de.prosiebensat1.joyn.tv)")
     inner class JoynFixture {
 
         @Test
         fun `forPackage returns profile for joyn`() {
-            val profile = AppProfiles.forPackage("de.prosiebensat1digital.seventv")
+            val profile = AppProfiles.forPackage("de.prosiebensat1.joyn.tv")
             assertNotNull(profile)
-            assertEquals("de.prosiebensat1digital.seventv", profile!!.packageName)
+            assertEquals("de.prosiebensat1.joyn.tv", profile!!.packageName)
         }
 
         @Test
         fun `Staffel Y Folge X marker regex extracts season and episode`() {
-            val profile = AppProfiles.forPackage("de.prosiebensat1digital.seventv")!!
+            val profile = AppProfiles.forPackage("de.prosiebensat1.joyn.tv")!!
             val regex = profile.markerRegexes.first()
 
             val match1 = regex.find("Staffel 2, Folge 3")
@@ -397,7 +397,7 @@ class AppProfilesTest {
 
         @Test
         fun `Staffel Folge marker regex is case-insensitive`() {
-            val profile = AppProfiles.forPackage("de.prosiebensat1digital.seventv")!!
+            val profile = AppProfiles.forPackage("de.prosiebensat1.joyn.tv")!!
             val regex = profile.markerRegexes.first()
             val match = regex.find("staffel 3, folge 5")
             assertNotNull(match)
@@ -407,7 +407,7 @@ class AppProfilesTest {
 
         @Test
         fun `joyn profile has llmHint`() {
-            val profile = AppProfiles.forPackage("de.prosiebensat1digital.seventv")!!
+            val profile = AppProfiles.forPackage("de.prosiebensat1.joyn.tv")!!
             assertNotNull(profile.llmHint)
         }
     }

--- a/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/EpisodeMarkerExtractorTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/scrobbler/EpisodeMarkerExtractorTest.kt
@@ -26,7 +26,7 @@ class EpisodeMarkerExtractorTest {
             // Standard S##E## pattern still matches "S01E02" embedded with a dot separator
             // via profile-specific Joyn regex: "Staffel 1, Folge 2"
             val joynProfile = AppProfile(
-                packageName = "de.prosiebensat1digital.seventv",
+                packageName = "de.prosiebensat1.joyn.tv",
                 markerRegexes = listOf(
                     Regex("""Staffel\s*(\d+)[,\s]+Folge\s*(\d+)""", RegexOption.IGNORE_CASE),
                 ),


### PR DESCRIPTION
## Summary

- Fix the `AppProfiles` entry for Joyn: the scrobbler profile still referenced the old 7TV package (`de.prosiebensat1digital.seventv`) instead of the current Joyn TV app package (`de.prosiebensat1.joyn.tv`)
- When watching Joyn, the scrobbler was unable to find a matching `AppProfile`, so German episode-marker extraction ("Staffel N, Folge M") and the Joyn-specific LLM hint fell back to defaults
- Update `AppProfilesTest` and a stale test fixture in `EpisodeMarkerExtractorTest` to use the current package name

**Note:** Provider detection (`InstalledAppsProbe` + `ProviderCatalogRegistry` + manifest `<queries>`) was already correct — `de.prosiebensat1.joyn.tv` was added in a prior fix (#685). This PR completes that fix by aligning the scrobbler profile.

## Test plan

- [ ] Verify `AppProfiles.forPackage("de.prosiebensat1.joyn.tv")` returns the Joyn profile (covered by `AppProfilesTest`)
- [ ] Verify German episode-marker extraction ("Staffel N, Folge M") works for the Joyn profile (covered by `AppProfilesTest`)
- [ ] Verify `AppProfiles.forPackage("de.prosiebensat1digital.seventv")` returns `null` (old package is gone)
- [ ] Verify Joyn appears in the provider list on the TV show detail screen when installed
- [ ] Verify scrobble detection works when watching Joyn

> Note: Gradle scope skipped locally (no Android SDK in this environment); CI is the gate.

Closes #715

https://claude.ai/code/session_01QkSDrZo9TzgP1z5Y4FrhsY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkSDrZo9TzgP1z5Y4FrhsY)_