### PR TITLE
fix: detect ARD and ZDF Mediathek as installed on TV

### DIFF
--- a/app-tv/src/main/AndroidManifest.xml
+++ b/app-tv/src/main/AndroidManifest.xml
@@ -93,6 +93,7 @@
         <package android:name="de.exaring.waipu" />
         <package android:name="de.prosiebensat1.joyn.tv" />
         <package android:name="de.swr.avp.ard.tv" />
+        <package android:name="de.swr.avp.ard" />
         <package android:name="com.zdf.android.mediathek" />
         <package android:name="com.google.android.youtube.tv" />
         <package android:name="tv.wuaki.apptv" />

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/InstalledAppsProbeTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/discovery/InstalledAppsProbeTest.kt
@@ -95,6 +95,42 @@ class InstalledAppsProbeTest {
         fun `returns false for a package not in ProviderCatalogRegistry`() {
             assertFalse(probe.isInstalled("com.unknown.app"))
         }
+
+        @Test
+        fun `returns true for ARD dedicated TV package when installed`() {
+            every { packageManager.getPackageInfo(eq("de.swr.avp.ard.tv"), 0) } returns mockk()
+
+            assertTrue(probe.isInstalled("de.swr.avp.ard.tv"))
+        }
+
+        @Test
+        fun `returns true for ARD universal package when installed on TV`() {
+            every { packageManager.getPackageInfo(eq("de.swr.avp.ard"), 0) } returns mockk()
+
+            assertTrue(probe.isInstalled("de.swr.avp.ard"))
+        }
+
+        @Test
+        fun `returns true for ZDF Mediathek when installed`() {
+            every { packageManager.getPackageInfo(eq("com.zdf.android.mediathek"), 0) } returns mockk()
+
+            assertTrue(probe.isInstalled("com.zdf.android.mediathek"))
+        }
+
+        @Test
+        fun `returns false for ARD dedicated TV package when not installed`() {
+            assertFalse(probe.isInstalled("de.swr.avp.ard.tv"))
+        }
+
+        @Test
+        fun `returns false for ARD universal package when not installed`() {
+            assertFalse(probe.isInstalled("de.swr.avp.ard"))
+        }
+
+        @Test
+        fun `returns false for ZDF Mediathek when not installed`() {
+            assertFalse(probe.isInstalled("com.zdf.android.mediathek"))
+        }
     }
 
     @Nested

--- a/backend/src/data/provider-catalog.json
+++ b/backend/src/data/provider-catalog.json
@@ -87,8 +87,8 @@
       "name": "ARD Mediathek",
       "regions": ["DE", "AT", "CH"],
       "androidPackages": {
-        "tv": ["de.swr.avp.ard.tv"],
-        "phone": ["de.swr.avp.ard.tv"]
+        "tv": ["de.swr.avp.ard.tv", "de.swr.avp.ard"],
+        "phone": ["de.swr.avp.ard"]
       },
       "justWatchTechnicalNames": ["daserstemediathek", "ardplus"]
     },

--- a/core/src/main/java/com/justb81/watchbuddy/core/deeplink/ProviderCatalogRegistry.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/deeplink/ProviderCatalogRegistry.kt
@@ -179,7 +179,7 @@ object ProviderCatalogRegistry {
                 name = "ARD Mediathek",
                 regions = listOf("DE", "AT", "CH"),
                 androidPackages = CatalogAndroidPackages(
-                    tv = listOf("de.swr.avp.ard.tv"),
+                    tv = listOf("de.swr.avp.ard.tv", "de.swr.avp.ard"),
                     phone = listOf("de.swr.avp.ard"),
                 ),
                 justWatchTechnicalNames = listOf("daserstemediathek", "ardplus"),

--- a/core/src/test/java/com/justb81/watchbuddy/core/deeplink/ProviderCatalogRegistryTest.kt
+++ b/core/src/test/java/com/justb81/watchbuddy/core/deeplink/ProviderCatalogRegistryTest.kt
@@ -117,6 +117,39 @@ class ProviderCatalogRegistryTest {
     }
 
     @Test
+    fun `bundled snapshot includes both ARD TV package names`() {
+        val packages = ProviderCatalogRegistry.packagesByProviderId(195)
+        assertTrue(
+            "de.swr.avp.ard.tv" in packages,
+            "de.swr.avp.ard.tv must be a known TV package for ARD Mediathek",
+        )
+        assertTrue(
+            "de.swr.avp.ard" in packages,
+            "de.swr.avp.ard must be a known TV package for ARD Mediathek (universal app)",
+        )
+    }
+
+    @Test
+    fun `bundled snapshot lists both ARD packages in knownPackageNames`() {
+        val knownPackages = ProviderCatalogRegistry.knownPackageNames
+        assertTrue("de.swr.avp.ard.tv" in knownPackages)
+        assertTrue("de.swr.avp.ard" in knownPackages)
+    }
+
+    @Test
+    fun `bundled snapshot resolves ZDF Mediathek package name and provider id`() {
+        val entry = ProviderCatalogRegistry.entryById(231)
+        assertNotNull(entry)
+        assertEquals("com.zdf.android.mediathek", entry!!.packageName)
+        assertEquals(231, entry.providerId)
+    }
+
+    @Test
+    fun `bundled snapshot lists ZDF Mediathek package in knownPackageNames`() {
+        assertTrue("com.zdf.android.mediathek" in ProviderCatalogRegistry.knownPackageNames)
+    }
+
+    @Test
     fun `entries returns one ProviderEntry per providerId-packageName pair`() {
         val snapshot = makeSnapshot(
             makeEntry(ids = listOf(119, 9), tvPkg = "com.amazon.amazonvideo.livingroom"),


### PR DESCRIPTION
## Summary

- Add `de.swr.avp.ard` (ARD universal app) to the TV packages list in `ProviderCatalogRegistry` bundled snapshot and `backend/src/data/provider-catalog.json` — ARD publishes both a dedicated TV app (`de.swr.avp.ard.tv`) and a universal app (`de.swr.avp.ard`) that supports Android TV; only the dedicated app was previously registered
- Correct the ARD phone package in `provider-catalog.json` from `de.swr.avp.ard.tv` (incorrect after a prior partial edit) back to `de.swr.avp.ard`
- Add `de.swr.avp.ard` to the `<queries>` block in `app-tv/src/main/AndroidManifest.xml` so `PackageManager` can see it on Android 11+
- ZDF Mediathek (`com.zdf.android.mediathek`) is verified correct — no change needed
- Add unit tests in `InstalledAppsProbeTest` and `ProviderCatalogRegistryTest` covering both ARD package variants and ZDF detection

## Test plan

- [ ] `InstalledAppsProbe.isInstalled("de.swr.avp.ard.tv")` returns `true` when ARD dedicated TV app is installed
- [ ] `InstalledAppsProbe.isInstalled("de.swr.avp.ard")` returns `true` when ARD universal app is installed on TV
- [ ] `InstalledAppsProbe.isInstalled("com.zdf.android.mediathek")` returns `true` when ZDF is installed
- [ ] Both ARD packages appear in `ProviderCatalogRegistry.knownPackageNames`
- [ ] Unit tests pass for all new test cases in `InstalledAppsProbeTest` and `ProviderCatalogRegistryTest`
- [ ] ARD and ZDF appear in the provider list on the show detail screen (and are tappable) when installed

> Note: Gradle scope skipped locally (no Android SDK); CI is the gate for Kotlin/Android checks.

Closes #718

https://claude.ai/code/session_01QkSDrZo9TzgP1z5Y4FrhsY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QkSDrZo9TzgP1z5Y4FrhsY)_