### PR TITLE
feat: show notification when phone is actively connected to TV

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionService.kt
@@ -150,6 +150,7 @@ class CompanionService : Service() {
             stateManager.setServiceRunning(true)
             registerNetworkCallback()
             startPresenceMonitor()
+            observeConnectionState()
             ensureScrobblePromptChannel()
             observeAmbiguousPrompts()
             // Pre-load the on-device LLM so the user's first recap hits a warm
@@ -197,7 +198,6 @@ class CompanionService : Service() {
     private fun startPresenceMonitor() {
         // Reset the timestamp so the first check doesn't immediately time out
         stateManager.onCapabilityChecked()
-        var lastNotifiedConnected = false
         presenceJob = serviceScope.launch {
             while (true) {
                 delay(PRESENCE_CHECK_INTERVAL_MS)
@@ -208,12 +208,29 @@ class CompanionService : Service() {
                     stopSelf()
                     break
                 }
-                val connected = elapsed < TV_CONNECTED_WINDOW_MS
-                if (connected != lastNotifiedConnected) {
-                    lastNotifiedConnected = connected
-                    val nm = getSystemService(NotificationManager::class.java)
-                    nm.notify(NOTIFICATION_ID, buildNotification(connected))
+                // Clear the connected flag once the TV's polling window has expired.
+                // The flag is set immediately in onCapabilityChecked(), so this is
+                // the only place it needs to be cleared.
+                if (elapsed >= TV_CONNECTED_WINDOW_MS) {
+                    stateManager.setConnectedToTv(false)
                 }
+            }
+        }
+    }
+
+    // ── Connection state → notification ──────────────────────────────────────
+
+    /**
+     * Observes [CompanionStateManager.isConnectedToTv] and updates the foreground
+     * service notification immediately whenever the connection state changes.
+     * This ensures the "TV connected" message appears as soon as the TV polls
+     * `/capability`, without waiting for the 60-second presence-monitor tick.
+     */
+    private fun observeConnectionState() {
+        serviceScope.launch {
+            stateManager.isConnectedToTv.collect { connected ->
+                val nm = getSystemService(NotificationManager::class.java)
+                nm.notify(NOTIFICATION_ID, buildNotification(connected))
             }
         }
     }

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionStateManager.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionStateManager.kt
@@ -23,6 +23,16 @@ class CompanionStateManager @Inject constructor() {
     /** Epoch millis of the most recent `/capability` request from a TV. */
     val lastCapabilityCheck: StateFlow<Long> = _lastCapabilityCheck.asStateFlow()
 
+    private val _isConnectedToTv = MutableStateFlow(false)
+    /**
+     * True while at least one TV client has polled `/capability` within the
+     * [CompanionService.TV_CONNECTED_WINDOW_MS] window.  Updated immediately on
+     * each capability check and cleared by the presence monitor when the window
+     * expires, so the status-bar notification reflects the live connection state
+     * without the 60-second polling delay.
+     */
+    val isConnectedToTv: StateFlow<Boolean> = _isConnectedToTv.asStateFlow()
+
     private val _lastScrobbleEvent = MutableStateFlow<ScrobbleDisplayEvent?>(null)
     /** Most recent scrobble event received via the companion HTTP server. */
     val lastScrobbleEvent: StateFlow<ScrobbleDisplayEvent?> = _lastScrobbleEvent.asStateFlow()
@@ -65,11 +75,18 @@ class CompanionStateManager @Inject constructor() {
 
     fun onCapabilityChecked() {
         _lastCapabilityCheck.value = System.currentTimeMillis()
+        _isConnectedToTv.value = true
     }
 
     /** Test-only overload — production always goes through [onCapabilityChecked]. */
     internal fun onCapabilityCheckedAt(now: Long) {
         _lastCapabilityCheck.value = now
+        _isConnectedToTv.value = true
+    }
+
+    /** Marks the TV as disconnected. Called by the presence monitor when the connection window expires. */
+    internal fun setConnectedToTv(connected: Boolean) {
+        _isConnectedToTv.value = connected
     }
 
     fun onScrobbleEvent(event: ScrobbleDisplayEvent) {
@@ -102,6 +119,7 @@ class CompanionStateManager @Inject constructor() {
             _wifiIpv4.value = null
             _lastCapabilityCheck.value = 0L
             _pendingPrompt.value = null
+            _isConnectedToTv.value = false
         }
     }
 

--- a/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionStateManager.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/service/CompanionStateManager.kt
@@ -24,6 +24,7 @@ class CompanionStateManager @Inject constructor() {
     val lastCapabilityCheck: StateFlow<Long> = _lastCapabilityCheck.asStateFlow()
 
     private val _isConnectedToTv = MutableStateFlow(false)
+
     /**
      * True while at least one TV client has polled `/capability` within the
      * [CompanionService.TV_CONNECTED_WINDOW_MS] window.  Updated immediately on

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/service/CompanionStateManagerTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/service/CompanionStateManagerTest.kt
@@ -41,7 +41,26 @@ class CompanionStateManagerTest {
     }
 
     @Test
-    fun `setServiceRunning false resets transient state`() {
+    fun `onCapabilityChecked sets isConnectedToTv true immediately`() {
+        val mgr = CompanionStateManager()
+        assertFalse(mgr.isConnectedToTv.value)
+
+        mgr.onCapabilityCheckedAt(1_000_000_000L)
+        assertTrue(mgr.isConnectedToTv.value)
+    }
+
+    @Test
+    fun `setConnectedToTv false clears isConnectedToTv`() {
+        val mgr = CompanionStateManager()
+        mgr.onCapabilityCheckedAt(1_000_000_000L)
+        assertTrue(mgr.isConnectedToTv.value)
+
+        mgr.setConnectedToTv(false)
+        assertFalse(mgr.isConnectedToTv.value)
+    }
+
+    @Test
+    fun `setServiceRunning false resets transient state including isConnectedToTv`() {
         val mgr = CompanionStateManager()
         val t0 = 1_000_000_000L
         mgr.setHttpServerBinding("0.0.0.0:8765")
@@ -53,6 +72,7 @@ class CompanionStateManagerTest {
         assertTrue(mgr.isServiceRunning.value)
         assertEquals("0.0.0.0:8765", mgr.httpServerBinding.value)
         assertEquals(CompanionStateManager.BleAdvertiseState.ADVERTISING, mgr.bleAdvertiseState.value)
+        assertTrue(mgr.isConnectedToTv.value)
 
         mgr.setServiceRunning(false)
 
@@ -61,5 +81,6 @@ class CompanionStateManagerTest {
         assertEquals(CompanionStateManager.BleAdvertiseState.IDLE, mgr.bleAdvertiseState.value)
         assertNull(mgr.wifiIpv4.value)
         assertEquals(0L, mgr.lastCapabilityCheck.value)
+        assertFalse(mgr.isConnectedToTv.value)
     }
 }


### PR DESCRIPTION
## Summary
- Adds `isConnectedToTv: StateFlow<Boolean>` to `CompanionStateManager` that is set to `true` immediately when a TV polls `/capability` and cleared by the presence monitor when the 90-second polling window expires
- Replaces the 60-second polling-based notification update in `startPresenceMonitor()` with a reactive `observeConnectionState()` coroutine that updates the foreground notification as soon as the TV connection state changes
- All notification strings already localised in EN, DE, FR, ES (`companion_notification_text_connected`)

## Test plan
- [ ] Connect TV app to phone; verify the foreground notification updates to "TV connected" promptly (within seconds, not minutes) in the notification shade
- [ ] Disconnect TV / wait 90+ seconds without a `/capability` poll; verify notification reverts to "Ready for TV connection"
- [ ] Tap the notification; verify it opens the WatchBuddy phone app (`MainActivity`)
- [ ] Check all four locales (EN, DE, FR, ES) render the connected text correctly

Closes #721

> Note: Gradle scope skipped locally (no Android SDK in this runner); CI is the real gate for Kotlin/Android checks.

https://claude.ai/code/session_013PNZkpfbQfqXhidTsziQak

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4KBJP34Tzm7f59LJn2uKR)_