### PR TITLE
feat: move episode list to dedicated All Episodes screen on TV

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ watchbuddy/
 │           ├── diagnostics/ TvDiagnosticsScreen, TvDiagnosticsViewModel (discovery / BLE / discovered-phones health — view-only, no Share)
 │           ├── scrobble/   ScrobbleOverlay, ScrobbleViewModel
 │           ├── settings/   TvSettingsScreen + TvSettingsViewModel (settings hub — discovery, autostart, show-non-installed toggle, diagnostics)
-│           ├── showdetail/ ShowDetailScreen, ShowDetailViewModel (next-episode still + TMDB watch providers + installed-app filter + last-used ranking + JustWatch deep links; `NextEpisodeUiState`, `ProviderListUiState`, `DeepLinkState` flows; one-tap "Mark as watched" button — `MarkWatchedState` sealed interface, `markCurrentEpisodeWatched` fan-out to all phones via `POST /watched`, `advancedEntry` optimistic-advance flow with `AnimatedContent` slide transition)
+│           ├── showdetail/ ShowDetailScreen, AllEpisodesScreen, ShowDetailViewModel (next-episode still + TMDB watch providers + installed-app filter + last-used ranking + JustWatch deep links; `NextEpisodeUiState`, `ProviderListUiState`, `DeepLinkState` flows; one-tap "Mark as watched" button — `MarkWatchedState` sealed interface, `markCurrentEpisodeWatched` fan-out to all phones via `POST /watched`, `advancedEntry` optimistic-advance flow with `AnimatedContent` slide transition; "All Episodes" button navigates to AllEpisodesScreen — full-screen D-pad-navigable episode list with per-episode watched toggle)
 │           └── theme/      TV Material theme
 ├── build-logic/        Gradle convention plugins (included build)
 │   └── convention/

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvNavGraph.kt
@@ -14,13 +14,14 @@ import com.justb81.watchbuddy.tv.ui.recap.RecapScreen
 import com.justb81.watchbuddy.tv.ui.scrobble.ScrobbleOverlay
 import com.justb81.watchbuddy.tv.ui.scrobble.ScrobbleViewModel
 import com.justb81.watchbuddy.tv.ui.settings.TvSettingsScreen
+import com.justb81.watchbuddy.tv.ui.showdetail.AllEpisodesScreen
 import com.justb81.watchbuddy.tv.ui.showdetail.ShowDetailScreen
 
 @Composable
 fun TvNavGraph() {
     val navController = rememberNavController()
 
-    // Shared state: currently selected show (passed between Home → Detail → Recap)
+    // Shared state: currently selected show (passed between Home → Detail → Recap → AllEpisodes)
     var selectedEntry by remember { mutableStateOf<EnrichedShowEntry?>(null) }
 
     NavHost(
@@ -52,9 +53,20 @@ fun TvNavGraph() {
             val enriched = selectedEntry
             if (enriched != null) {
                 ShowDetailScreen(
-                    enriched     = enriched,
-                    onRecapClick = { navController.navigate(TvRoute.Recap.route) },
-                    onBack       = { navController.popBackStack() }
+                    enriched          = enriched,
+                    onRecapClick      = { navController.navigate(TvRoute.Recap.route) },
+                    onAllEpisodesClick = { navController.navigate(TvRoute.AllEpisodes.route) },
+                    onBack            = { navController.popBackStack() }
+                )
+            }
+        }
+
+        composable(TvRoute.AllEpisodes.route) {
+            val enriched = selectedEntry
+            if (enriched != null) {
+                AllEpisodesScreen(
+                    enriched = enriched,
+                    onBack   = { navController.popBackStack() }
                 )
             }
         }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvRoute.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/navigation/TvRoute.kt
@@ -3,6 +3,7 @@ package com.justb81.watchbuddy.tv.ui.navigation
 sealed class TvRoute(val route: String) {
     object Home : TvRoute("tv_home")
     object ShowDetail : TvRoute("tv_show_detail")
+    object AllEpisodes : TvRoute("tv_all_episodes")
     object Recap : TvRoute("tv_recap")
     object Settings : TvRoute("tv_settings")
     object Diagnostics : TvRoute("tv_diagnostics")

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/AllEpisodesScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/AllEpisodesScreen.kt
@@ -31,11 +31,13 @@ import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.model.EnrichedShowEntry
+import com.justb81.watchbuddy.core.model.TraktIds
 import com.justb81.watchbuddy.tv.ui.components.SeasonEpisodeListPicker
 import com.justb81.watchbuddy.tv.ui.components.UserScopePickerDialog
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
+@Suppress("LongMethod")
 fun AllEpisodesScreen(
     enriched: EnrichedShowEntry,
     onBack: () -> Unit,
@@ -79,65 +81,14 @@ fun AllEpisodesScreen(
                 .fillMaxSize()
                 .padding(horizontal = 64.dp, vertical = 48.dp)
         ) {
-            Text(
-                text = entry.show.title,
-                fontSize = 28.sp,
-                fontWeight = FontWeight.Bold,
-                color = Color.White,
-            )
-            Spacer(Modifier.height(4.dp))
-            Text(
-                text = stringResource(R.string.tv_all_episodes),
-                fontSize = 16.sp,
-                color = Color.White.copy(alpha = 0.5f),
-            )
+            AllEpisodesHeader(showTitle = entry.show.title)
             Spacer(Modifier.height(24.dp))
-
-            when (episodeListState) {
-                is EpisodeListUiState.Idle, is EpisodeListUiState.Loading -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        CircularProgressIndicator(color = Color.White)
-                    }
-                }
-
-                is EpisodeListUiState.Error -> {
-                    Box(
-                        modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = stringResource(R.string.tv_error_phone_unreachable),
-                            color = Color.White.copy(alpha = 0.6f),
-                        )
-                    }
-                }
-
-                is EpisodeListUiState.Success -> {
-                    SeasonEpisodeListPicker(
-                        seasons = episodeListState.seasons,
-                        watchedSet = episodeListState.watchedSet,
-                        highlightSeason = null,
-                        onToggle = { season, episode, currentlyWatched ->
-                            if (viewModel.skipScopePickerThisSession) {
-                                val allIds = viewModel.connectedUsers().map { it.id }.toSet()
-                                viewModel.toggleEpisodeWatched(
-                                    showIds = entry.show.ids,
-                                    season = season,
-                                    episode = episode,
-                                    markAsWatched = !currentlyWatched,
-                                    selectedUserIds = allIds,
-                                )
-                            } else {
-                                pendingToggle = Triple(season, episode, !currentlyWatched)
-                            }
-                        },
-                        modifier = Modifier.weight(1f),
-                    )
-                }
-            }
+            AllEpisodesBody(
+                state = episodeListState,
+                showIds = entry.show.ids,
+                viewModel = viewModel,
+                onToggleRequest = { pendingToggle = it },
+            )
         }
 
         OutlinedButton(
@@ -158,22 +109,113 @@ fun AllEpisodesScreen(
     }
 
     pendingToggle?.let { (season, episode, markAsWatched) ->
-        val users = viewModel.connectedUsers()
-        UserScopePickerDialog(
-            connectedUsers = users,
-            initialSelection = users.map { it.id }.toSet(),
-            onConfirm = { selectedIds, dontAskAgain ->
-                if (dontAskAgain) viewModel.onDontAskAgainSet()
-                viewModel.toggleEpisodeWatched(
-                    showIds = entry.show.ids,
-                    season = season,
-                    episode = episode,
-                    markAsWatched = markAsWatched,
-                    selectedUserIds = selectedIds,
-                )
-                pendingToggle = null
-            },
+        AllEpisodesScopePicker(
+            viewModel = viewModel,
+            showIds = entry.show.ids,
+            season = season,
+            episode = episode,
+            markAsWatched = markAsWatched,
             onDismiss = { pendingToggle = null },
         )
     }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun AllEpisodesHeader(showTitle: String) {
+    Text(
+        text = showTitle,
+        fontSize = 28.sp,
+        fontWeight = FontWeight.Bold,
+        color = Color.White,
+    )
+    Spacer(Modifier.height(4.dp))
+    Text(
+        text = stringResource(R.string.tv_all_episodes),
+        fontSize = 16.sp,
+        color = Color.White.copy(alpha = 0.5f),
+    )
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun AllEpisodesBody(
+    state: EpisodeListUiState,
+    showIds: TraktIds,
+    viewModel: ShowDetailViewModel,
+    onToggleRequest: (Triple<Int, Int, Boolean>) -> Unit,
+) {
+    when (state) {
+        is EpisodeListUiState.Idle, is EpisodeListUiState.Loading -> {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(color = Color.White)
+            }
+        }
+
+        is EpisodeListUiState.Error -> {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(
+                    text = stringResource(R.string.tv_error_phone_unreachable),
+                    color = Color.White.copy(alpha = 0.6f),
+                )
+            }
+        }
+
+        is EpisodeListUiState.Success -> {
+            SeasonEpisodeListPicker(
+                seasons = state.seasons,
+                watchedSet = state.watchedSet,
+                highlightSeason = null,
+                onToggle = { season, episode, currentlyWatched ->
+                    if (viewModel.skipScopePickerThisSession) {
+                        val allIds = viewModel.connectedUsers().map { it.id }.toSet()
+                        viewModel.toggleEpisodeWatched(
+                            showIds = showIds,
+                            season = season,
+                            episode = episode,
+                            markAsWatched = !currentlyWatched,
+                            selectedUserIds = allIds,
+                        )
+                    } else {
+                        onToggleRequest(Triple(season, episode, !currentlyWatched))
+                    }
+                },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun AllEpisodesScopePicker(
+    viewModel: ShowDetailViewModel,
+    showIds: TraktIds,
+    season: Int,
+    episode: Int,
+    markAsWatched: Boolean,
+    onDismiss: () -> Unit,
+) {
+    val users = viewModel.connectedUsers()
+    UserScopePickerDialog(
+        connectedUsers = users,
+        initialSelection = users.map { it.id }.toSet(),
+        onConfirm = { selectedIds, dontAskAgain ->
+            if (dontAskAgain) viewModel.onDontAskAgainSet()
+            viewModel.toggleEpisodeWatched(
+                showIds = showIds,
+                season = season,
+                episode = episode,
+                markAsWatched = markAsWatched,
+                selectedUserIds = selectedIds,
+            )
+            onDismiss()
+        },
+        onDismiss = onDismiss,
+    )
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/AllEpisodesScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/AllEpisodesScreen.kt
@@ -31,13 +31,12 @@ import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.model.EnrichedShowEntry
-import com.justb81.watchbuddy.core.model.TraktIds
+import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.tv.ui.components.SeasonEpisodeListPicker
 import com.justb81.watchbuddy.tv.ui.components.UserScopePickerDialog
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-@Suppress("LongMethod")
 fun AllEpisodesScreen(
     enriched: EnrichedShowEntry,
     onBack: () -> Unit,
@@ -76,20 +75,13 @@ fun AllEpisodesScreen(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 64.dp, vertical = 48.dp)
-        ) {
-            AllEpisodesHeader(showTitle = entry.show.title)
-            Spacer(Modifier.height(24.dp))
-            AllEpisodesBody(
-                state = episodeListState,
-                showIds = entry.show.ids,
-                viewModel = viewModel,
-                onToggleRequest = { pendingToggle = it },
-            )
-        }
+        AllEpisodesContent(
+            title = entry.show.title,
+            episodeListState = episodeListState,
+            entry = entry,
+            viewModel = viewModel,
+            onPendingToggle = { pendingToggle = it },
+        )
 
         OutlinedButton(
             onClick = onBack,
@@ -109,12 +101,21 @@ fun AllEpisodesScreen(
     }
 
     pendingToggle?.let { (season, episode, markAsWatched) ->
-        AllEpisodesScopePicker(
-            viewModel = viewModel,
-            showIds = entry.show.ids,
-            season = season,
-            episode = episode,
-            markAsWatched = markAsWatched,
+        val users = viewModel.connectedUsers()
+        UserScopePickerDialog(
+            connectedUsers = users,
+            initialSelection = users.map { it.id }.toSet(),
+            onConfirm = { selectedIds, dontAskAgain ->
+                if (dontAskAgain) viewModel.onDontAskAgainSet()
+                viewModel.toggleEpisodeWatched(
+                    showIds = entry.show.ids,
+                    season = season,
+                    episode = episode,
+                    markAsWatched = markAsWatched,
+                    selectedUserIds = selectedIds,
+                )
+                pendingToggle = null
+            },
             onDismiss = { pendingToggle = null },
         )
     }
@@ -122,100 +123,76 @@ fun AllEpisodesScreen(
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
-private fun AllEpisodesHeader(showTitle: String) {
-    Text(
-        text = showTitle,
-        fontSize = 28.sp,
-        fontWeight = FontWeight.Bold,
-        color = Color.White,
-    )
-    Spacer(Modifier.height(4.dp))
-    Text(
-        text = stringResource(R.string.tv_all_episodes),
-        fontSize = 16.sp,
-        color = Color.White.copy(alpha = 0.5f),
-    )
-}
-
-@OptIn(ExperimentalTvMaterial3Api::class)
-@Composable
-private fun AllEpisodesBody(
-    state: EpisodeListUiState,
-    showIds: TraktIds,
+private fun AllEpisodesContent(
+    title: String,
+    episodeListState: EpisodeListUiState,
+    entry: TraktWatchedEntry,
     viewModel: ShowDetailViewModel,
-    onToggleRequest: (Triple<Int, Int, Boolean>) -> Unit,
+    onPendingToggle: (Triple<Int, Int, Boolean>) -> Unit,
 ) {
-    when (state) {
-        is EpisodeListUiState.Idle, is EpisodeListUiState.Loading -> {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                CircularProgressIndicator(color = Color.White)
-            }
-        }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 64.dp, vertical = 48.dp)
+    ) {
+        Text(
+            text = title,
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text = stringResource(R.string.tv_all_episodes),
+            fontSize = 16.sp,
+            color = Color.White.copy(alpha = 0.5f),
+        )
+        Spacer(Modifier.height(24.dp))
 
-        is EpisodeListUiState.Error -> {
-            Box(
-                modifier = Modifier.fillMaxSize(),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = stringResource(R.string.tv_error_phone_unreachable),
-                    color = Color.White.copy(alpha = 0.6f),
+        when (episodeListState) {
+            is EpisodeListUiState.Idle, is EpisodeListUiState.Loading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(color = Color.White)
+                }
+            }
+
+            is EpisodeListUiState.Error -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = stringResource(R.string.tv_error_phone_unreachable),
+                        color = Color.White.copy(alpha = 0.6f),
+                    )
+                }
+            }
+
+            is EpisodeListUiState.Success -> {
+                SeasonEpisodeListPicker(
+                    seasons = episodeListState.seasons,
+                    watchedSet = episodeListState.watchedSet,
+                    highlightSeason = null,
+                    onToggle = { season, episode, currentlyWatched ->
+                        if (viewModel.skipScopePickerThisSession) {
+                            val allIds = viewModel.connectedUsers().map { it.id }.toSet()
+                            viewModel.toggleEpisodeWatched(
+                                showIds = entry.show.ids,
+                                season = season,
+                                episode = episode,
+                                markAsWatched = !currentlyWatched,
+                                selectedUserIds = allIds,
+                            )
+                        } else {
+                            onPendingToggle(Triple(season, episode, !currentlyWatched))
+                        }
+                    },
+                    modifier = Modifier.weight(1f),
                 )
             }
         }
-
-        is EpisodeListUiState.Success -> {
-            SeasonEpisodeListPicker(
-                seasons = state.seasons,
-                watchedSet = state.watchedSet,
-                highlightSeason = null,
-                onToggle = { season, episode, currentlyWatched ->
-                    if (viewModel.skipScopePickerThisSession) {
-                        val allIds = viewModel.connectedUsers().map { it.id }.toSet()
-                        viewModel.toggleEpisodeWatched(
-                            showIds = showIds,
-                            season = season,
-                            episode = episode,
-                            markAsWatched = !currentlyWatched,
-                            selectedUserIds = allIds,
-                        )
-                    } else {
-                        onToggleRequest(Triple(season, episode, !currentlyWatched))
-                    }
-                },
-                modifier = Modifier.fillMaxSize(),
-            )
-        }
     }
-}
-
-@Composable
-private fun AllEpisodesScopePicker(
-    viewModel: ShowDetailViewModel,
-    showIds: TraktIds,
-    season: Int,
-    episode: Int,
-    markAsWatched: Boolean,
-    onDismiss: () -> Unit,
-) {
-    val users = viewModel.connectedUsers()
-    UserScopePickerDialog(
-        connectedUsers = users,
-        initialSelection = users.map { it.id }.toSet(),
-        onConfirm = { selectedIds, dontAskAgain ->
-            if (dontAskAgain) viewModel.onDontAskAgainSet()
-            viewModel.toggleEpisodeWatched(
-                showIds = showIds,
-                season = season,
-                episode = episode,
-                markAsWatched = markAsWatched,
-                selectedUserIds = selectedIds,
-            )
-            onDismiss()
-        },
-        onDismiss = onDismiss,
-    )
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/AllEpisodesScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/AllEpisodesScreen.kt
@@ -1,0 +1,179 @@
+package com.justb81.watchbuddy.tv.ui.showdetail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.OutlinedButton
+import androidx.tv.material3.Text
+import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.core.model.EnrichedShowEntry
+import com.justb81.watchbuddy.tv.ui.components.SeasonEpisodeListPicker
+import com.justb81.watchbuddy.tv.ui.components.UserScopePickerDialog
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+fun AllEpisodesScreen(
+    enriched: EnrichedShowEntry,
+    onBack: () -> Unit,
+    viewModel: ShowDetailViewModel = hiltViewModel(),
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    val ready = uiState as? ShowDetailUiState.Ready
+    val episodeListState = ready?.episodeList ?: EpisodeListUiState.Idle
+    val entry = enriched.entry
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    var pendingToggle by remember { mutableStateOf<Triple<Int, Int, Boolean>?>(null) }
+
+    val allFailedMsg = stringResource(R.string.tv_detail_toggle_failed_all)
+    val partialFailedMsg = stringResource(R.string.tv_detail_toggle_failed_partial)
+
+    LaunchedEffect(entry.show.ids.trakt) {
+        viewModel.loadEpisodeList(enriched)
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.episodeToggleEvents.collect { event ->
+            when (event) {
+                is EpisodeToggleEvent.AllFailed ->
+                    snackbarHostState.showSnackbar(allFailedMsg)
+                is EpisodeToggleEvent.PartialFailed ->
+                    snackbarHostState.showSnackbar(
+                        partialFailedMsg.format(event.failedUserNames.joinToString(", "))
+                    )
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 64.dp, vertical = 48.dp)
+        ) {
+            Text(
+                text = entry.show.title,
+                fontSize = 28.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.tv_all_episodes),
+                fontSize = 16.sp,
+                color = Color.White.copy(alpha = 0.5f),
+            )
+            Spacer(Modifier.height(24.dp))
+
+            when (episodeListState) {
+                is EpisodeListUiState.Idle, is EpisodeListUiState.Loading -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        CircularProgressIndicator(color = Color.White)
+                    }
+                }
+
+                is EpisodeListUiState.Error -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.tv_error_phone_unreachable),
+                            color = Color.White.copy(alpha = 0.6f),
+                        )
+                    }
+                }
+
+                is EpisodeListUiState.Success -> {
+                    SeasonEpisodeListPicker(
+                        seasons = episodeListState.seasons,
+                        watchedSet = episodeListState.watchedSet,
+                        highlightSeason = null,
+                        onToggle = { season, episode, currentlyWatched ->
+                            if (viewModel.skipScopePickerThisSession) {
+                                val allIds = viewModel.connectedUsers().map { it.id }.toSet()
+                                viewModel.toggleEpisodeWatched(
+                                    showIds = entry.show.ids,
+                                    season = season,
+                                    episode = episode,
+                                    markAsWatched = !currentlyWatched,
+                                    selectedUserIds = allIds,
+                                )
+                            } else {
+                                pendingToggle = Triple(season, episode, !currentlyWatched)
+                            }
+                        },
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+        }
+
+        OutlinedButton(
+            onClick = onBack,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(32.dp),
+        ) {
+            Text(stringResource(R.string.tv_back_arrow))
+        }
+
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(16.dp),
+        )
+    }
+
+    pendingToggle?.let { (season, episode, markAsWatched) ->
+        val users = viewModel.connectedUsers()
+        UserScopePickerDialog(
+            connectedUsers = users,
+            initialSelection = users.map { it.id }.toSet(),
+            onConfirm = { selectedIds, dontAskAgain ->
+                if (dontAskAgain) viewModel.onDontAskAgainSet()
+                viewModel.toggleEpisodeWatched(
+                    showIds = entry.show.ids,
+                    season = season,
+                    episode = episode,
+                    markAsWatched = markAsWatched,
+                    selectedUserIds = selectedIds,
+                )
+                pendingToggle = null
+            },
+            onDismiss = { pendingToggle = null },
+        )
+    }
+}

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -44,8 +44,6 @@ import com.justb81.watchbuddy.core.deeplink.ProviderDeepLinkRewriter
 import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.ResolvedProvider
 import com.justb81.watchbuddy.core.tmdb.TmdbImageHelper
-import com.justb81.watchbuddy.tv.ui.components.SeasonEpisodeListPicker
-import com.justb81.watchbuddy.tv.ui.components.UserScopePickerDialog
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -58,10 +56,8 @@ private data class ShowDetailActions(
     val onRetryProviders: () -> Unit,
     val onRecapClick: () -> Unit,
     val onMarkWatched: () -> Unit,
-    val onEpisodeToggle: (season: Int, episode: Int, currentlyWatched: Boolean) -> Unit,
+    val onAllEpisodesClick: () -> Unit,
 )
-
-private const val EPISODE_LIST_MAX_HEIGHT_DP = 320
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -69,6 +65,7 @@ private const val EPISODE_LIST_MAX_HEIGHT_DP = 320
 fun ShowDetailScreen(
     enriched: EnrichedShowEntry,
     onRecapClick: () -> Unit,
+    onAllEpisodesClick: () -> Unit,
     onBack: () -> Unit,
     viewModel: ShowDetailViewModel = hiltViewModel()
 ) {
@@ -83,18 +80,12 @@ fun ShowDetailScreen(
     val providerState = ready?.providers ?: ProviderListUiState.Loading
     val deepLinks = ready?.deepLinks ?: emptyMap()
     val watchNowState = ready?.watchNow ?: WatchNowState.Loading
-    val episodeListState = ready?.episodeList ?: EpisodeListUiState.Idle
     val markState = ready?.markWatched ?: MarkWatchedState.Idle
 
     val scope = rememberCoroutineScope()
     val watchNowFocus = remember { FocusRequester() }
     val snackbarHostState = remember { SnackbarHostState() }
 
-    // (season, episode, markAsWatched) waiting for the scope picker
-    var pendingToggle by remember { mutableStateOf<Triple<Int, Int, Boolean>?>(null) }
-
-    val allFailedMsg = stringResource(R.string.tv_detail_toggle_failed_all)
-    val partialFailedMsg = stringResource(R.string.tv_detail_toggle_failed_partial)
     val markWatchedNoPhonesMsg = stringResource(R.string.tv_mark_watched_no_phones)
     val markWatchedErrorMsg = stringResource(R.string.tv_mark_watched_error)
     val openFailedMsg = stringResource(R.string.tv_provider_open_failed)
@@ -105,8 +96,6 @@ fun ShowDetailScreen(
         providerState = providerState,
         watchNowFocus = watchNowFocus,
         snackbarHostState = snackbarHostState,
-        allFailedMsg = allFailedMsg,
-        partialFailedMsg = partialFailedMsg,
     )
 
     // One-shot toast for mark-watched feedback, then acknowledge to reset to Idle.
@@ -132,7 +121,6 @@ fun ShowDetailScreen(
             providerState = providerState,
             deepLinks = deepLinks,
             watchNowState = watchNowState,
-            episodeListState = episodeListState,
             markState = markState,
             watchNowFocus = watchNowFocus,
             actions = ShowDetailActions(
@@ -154,20 +142,7 @@ fun ShowDetailScreen(
                 onRetryProviders = { viewModel.loadProviders(effectiveEntry) },
                 onRecapClick = onRecapClick,
                 onMarkWatched = { viewModel.markCurrentEpisodeWatched(effectiveEntry) },
-                onEpisodeToggle = { season, episode, currentlyWatched ->
-                    if (viewModel.skipScopePickerThisSession) {
-                        val allIds = viewModel.connectedUsers().map { it.id }.toSet()
-                        viewModel.toggleEpisodeWatched(
-                            showIds = entry.show.ids,
-                            season = season,
-                            episode = episode,
-                            markAsWatched = !currentlyWatched,
-                            selectedUserIds = allIds,
-                        )
-                    } else {
-                        pendingToggle = Triple(season, episode, !currentlyWatched)
-                    }
-                },
+                onAllEpisodesClick = onAllEpisodesClick,
             ),
             modifier = Modifier.align(Alignment.CenterEnd),
         )
@@ -182,13 +157,6 @@ fun ShowDetailScreen(
             modifier = Modifier.align(Alignment.BottomCenter).padding(16.dp)
         )
     }
-
-    ShowDetailScopePicker(
-        viewModel = viewModel,
-        enriched = effectiveEntry,
-        pendingToggle = pendingToggle,
-        onDismiss = { pendingToggle = null },
-    )
 }
 
 /**
@@ -325,7 +293,6 @@ private fun ShowDetailContent(
     providerState: ProviderListUiState,
     deepLinks: Map<Int, DeepLinkState>,
     watchNowState: WatchNowState,
-    episodeListState: EpisodeListUiState,
     markState: MarkWatchedState,
     watchNowFocus: FocusRequester,
     actions: ShowDetailActions,
@@ -394,6 +361,9 @@ private fun ShowDetailContent(
                 onClick = actions.onMarkWatched,
             )
             OutlinedButton(onClick = actions.onRecapClick) { Text(stringResource(R.string.tv_recap)) }
+            OutlinedButton(onClick = actions.onAllEpisodesClick) {
+                Text(stringResource(R.string.tv_all_episodes))
+            }
         }
 
         AvailableOnSection(
@@ -401,11 +371,6 @@ private fun ShowDetailContent(
             deepLinks = deepLinks,
             onProviderClick = actions.onProviderClick,
             onRetry = actions.onRetryProviders,
-        )
-
-        EpisodeListSection(
-            state = episodeListState,
-            onToggle = actions.onEpisodeToggle,
         )
     }
 }
@@ -678,37 +643,6 @@ private fun JustWatchAttributionBadge() {
 }
 
 @Composable
-private fun EpisodeListSection(
-    state: EpisodeListUiState,
-    onToggle: (season: Int, episode: Int, currentlyWatched: Boolean) -> Unit,
-) {
-    when (state) {
-        is EpisodeListUiState.Idle, is EpisodeListUiState.Loading -> {
-            // Show nothing while loading to keep the layout clean
-        }
-        is EpisodeListUiState.Error -> {
-            // Silently swallow — the user doesn't need a dedicated error for episode list
-        }
-        is EpisodeListUiState.Success -> {
-            Text(
-                text = stringResource(R.string.tv_detail_episodes),
-                fontSize = 12.sp,
-                color = Color.White.copy(alpha = 0.4f),
-            )
-            SeasonEpisodeListPicker(
-                seasons = state.seasons,
-                watchedSet = state.watchedSet,
-                highlightSeason = null,
-                onToggle = onToggle,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(max = EPISODE_LIST_MAX_HEIGHT_DP.dp),
-            )
-        }
-    }
-}
-
-@Composable
 private fun MetaChip(text: String, color: Color = MaterialTheme.colorScheme.surfaceVariant) {
     Box(
         modifier = Modifier
@@ -731,58 +665,15 @@ private fun ShowDetailEffects(
     providerState: ProviderListUiState,
     watchNowFocus: FocusRequester,
     snackbarHostState: SnackbarHostState,
-    allFailedMsg: String,
-    partialFailedMsg: String,
 ) {
     LaunchedEffect(enriched.entry.show.ids.trakt) {
         viewModel.loadNextEpisode(enriched)
         viewModel.loadProviders(enriched)
-        viewModel.loadEpisodeList(enriched)
         watchNowFocus.requestFocus()
     }
     LaunchedEffect(providerState) {
         if (providerState is ProviderListUiState.Success) {
             viewModel.loadDeepLinks(enriched)
         }
-    }
-    LaunchedEffect(Unit) {
-        viewModel.episodeToggleEvents.collect { event ->
-            when (event) {
-                is EpisodeToggleEvent.AllFailed ->
-                    snackbarHostState.showSnackbar(allFailedMsg)
-                is EpisodeToggleEvent.PartialFailed ->
-                    snackbarHostState.showSnackbar(
-                        partialFailedMsg.format(event.failedUserNames.joinToString(", "))
-                    )
-            }
-        }
-    }
-}
-
-@Composable
-private fun ShowDetailScopePicker(
-    viewModel: ShowDetailViewModel,
-    enriched: EnrichedShowEntry,
-    pendingToggle: Triple<Int, Int, Boolean>?,
-    onDismiss: () -> Unit,
-) {
-    pendingToggle?.let { (season, episode, markAsWatched) ->
-        val users = viewModel.connectedUsers()
-        UserScopePickerDialog(
-            connectedUsers = users,
-            initialSelection = users.map { it.id }.toSet(),
-            onConfirm = { selectedIds, dontAskAgain ->
-                if (dontAskAgain) viewModel.onDontAskAgainSet()
-                viewModel.toggleEpisodeWatched(
-                    showIds = enriched.entry.show.ids,
-                    season = season,
-                    episode = episode,
-                    markAsWatched = markAsWatched,
-                    selectedUserIds = selectedIds,
-                )
-                onDismiss()
-            },
-            onDismiss = onDismiss,
-        )
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -95,7 +95,6 @@ fun ShowDetailScreen(
         enriched = enriched,
         providerState = providerState,
         watchNowFocus = watchNowFocus,
-        snackbarHostState = snackbarHostState,
     )
 
     // One-shot toast for mark-watched feedback, then acknowledge to reset to Idle.
@@ -664,7 +663,6 @@ private fun ShowDetailEffects(
     enriched: EnrichedShowEntry,
     providerState: ProviderListUiState,
     watchNowFocus: FocusRequester,
-    snackbarHostState: SnackbarHostState,
 ) {
     LaunchedEffect(enriched.entry.show.ids.trakt) {
         viewModel.loadNextEpisode(enriched)

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -62,6 +62,9 @@
     <string name="tv_mark_watched_no_phones">Kein verbundenes Telefon — bitte ein Telefon verbinden, um Folgen zu markieren.</string>
     <string name="tv_mark_watched_error">Folge konnte nicht als gesehen markiert werden.</string>
 
+    <!-- Show detail — All Episodes screen (#712) -->
+    <string name="tv_all_episodes">Alle Folgen</string>
+
     <!-- Show detail — manually mark episodes watched (#217) -->
     <string name="tv_detail_episodes">Folgen</string>
     <string name="tv_detail_season_header">Staffel %1$d</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -65,6 +65,9 @@
     <string name="tv_mark_watched_no_phones">Ningún teléfono conectado — conecta un teléfono para marcar episodios.</string>
     <string name="tv_mark_watched_error">No se pudo marcar el episodio como visto.</string>
 
+    <!-- Show detail — All Episodes screen (#712) -->
+    <string name="tv_all_episodes">Todos los episodios</string>
+
     <!-- Show detail — manually mark episodes watched (#217) -->
     <string name="tv_detail_episodes">Episodios</string>
     <string name="tv_detail_season_header">Temporada %1$d</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -65,6 +65,9 @@
     <string name="tv_mark_watched_no_phones">Aucun téléphone connecté — connectez un téléphone pour marquer les épisodes.</string>
     <string name="tv_mark_watched_error">Impossible de marquer l\'episode comme vu.</string>
 
+    <!-- Show detail — All Episodes screen (#712) -->
+    <string name="tv_all_episodes">Tous les épisodes</string>
+
     <!-- Show detail — manually mark episodes watched (#217) -->
     <string name="tv_detail_episodes">Épisodes</string>
     <string name="tv_detail_season_header">Saison %1$d</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -62,6 +62,9 @@
     <string name="tv_mark_watched_no_phones">No connected phone — connect a phone to mark episodes.</string>
     <string name="tv_mark_watched_error">Could not mark episode as watched.</string>
 
+    <!-- Show detail — All Episodes screen (#712) -->
+    <string name="tv_all_episodes">All Episodes</string>
+
     <!-- Show detail — manually mark episodes watched (#217) -->
     <string name="tv_detail_episodes">Episodes</string>
     <string name="tv_detail_season_header">Season %1$d</string>


### PR DESCRIPTION
## Summary
- Removes the inline episode list from `TvShowDetailScreen` to reduce visual clutter on the TV
- Adds an **"All Episodes"** button to the TV show detail view
- Introduces a new full-screen, D-pad-navigable `AllEpisodesScreen` under `app-tv/.../showdetail/`
- Wires `TvRoute.AllEpisodes` and the new composable destination into `TvNavGraph`
- Navigation back from the All Episodes screen returns to the show detail view

## Test plan
- [ ] Open a show on the TV app; verify no inline episode list is shown on the detail screen
- [ ] Verify the **"All Episodes"** button is visible in the action row next to Recap
- [ ] Tap "All Episodes"; verify navigation to the new full-screen episode list
- [ ] Verify all seasons and episodes are listed with correct watched indicators
- [ ] Navigate the episode list with the D-pad; verify focus moves correctly
- [ ] Tap an episode row to toggle watched/unwatched; verify the state updates optimistically
- [ ] Verify scope picker dialog appears for multi-user setups
- [ ] Verify snackbar appears on toggle failure (AllFailed / PartialFailed)
- [ ] Tap the back button; verify return to show detail
- [ ] Verify no regression in watched state, deep links, or other show detail behaviour

Closes #712

> Note: Gradle scope skipped locally (no Android SDK in this environment); CI is the gate for Kotlin/Android changes.

https://claude.ai/code/session_013PNZkpfbQfqXhidTsziQak

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4KBJP34Tzm7f59LJn2uKR)_