### PR TITLE
chore: ignore agent worktree directory in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ Thumbs.db
 /.claude/settings.local.json
 /hs_err_*.log
 /replay_*.log
+
+# Git worktrees created by agents
+/wt/


### PR DESCRIPTION
## Summary
- Adds `/wt/` to `.gitignore` so agent-created git worktrees inside the repo root are not tracked as untracked files

## Background
Claude Code agents create worktrees under `wt/` (e.g. `wt/issue-731-show-list-refresh/`) when working on issues in parallel. Without this entry the stop hook reports untracked files on every session end.

https://claude.ai/code/session_01WUCvcuVc9dw1Yx1Y8DdssQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUCvcuVc9dw1Yx1Y8DdssQ)_