### PR TITLE
fix: show added via search appears in list immediately

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
@@ -16,6 +16,7 @@ import com.justb81.watchbuddy.core.trakt.SyncWatchlistBody
 import com.justb81.watchbuddy.core.trakt.SyncWatchlistShowItem
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.core.trakt.TraktSearchResult
+import com.justb81.watchbuddy.core.trakt.TraktWatchlistEntry
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import kotlinx.coroutines.async
@@ -90,15 +91,39 @@ class ShowRepository @Inject constructor(
             bearer,
             SyncWatchlistBody(shows = listOf(SyncWatchlistShowItem(ids = show.ids)))
         )
-        // Invalidate the cache so the next getShows() fetch picks up the new show.
+        val traktId = show.ids.trakt
+        if (traktId != null) {
+            _shows.update { current ->
+                if (current.any { it.entry.show.ids.trakt == traktId }) {
+                    current
+                } else {
+                    (current + EnrichedShowEntry(entry = TraktWatchedEntry(show = show)))
+                        .sortedWith(showComparator)
+                }
+            }
+        }
         cache.invalidate(Unit)
     }
 
     private suspend fun fetchFromTrakt(): List<EnrichedShowEntry> {
         val token = tokenRefreshManager.getValidAccessToken()
             ?: error("No access token available")
-        val trakt = traktApi.getWatchedShows("Bearer $token")
-        return enrich(trakt).sortedWith(showComparator)
+        val bearer = "Bearer $token"
+        return coroutineScope {
+            val watchedDeferred = async { traktApi.getWatchedShows(bearer) }
+            val watchlistDeferred = async {
+                runCatching { traktApi.getWatchlistShows(bearer) }
+                    .onFailure { Log.w(TAG, "watchlist fetch failed; continuing with watched only", it) }
+                    .getOrDefault(emptyList())
+            }
+            val watched = watchedDeferred.await()
+            val watchlist = watchlistDeferred.await()
+            val watchedIds = watched.mapNotNull { it.show.ids.trakt }.toSet()
+            val watchlistOnly = watchlist
+                .filter { it.show.ids.trakt == null || it.show.ids.trakt !in watchedIds }
+                .map { TraktWatchedEntry(show = it.show, seasons = emptyList()) }
+            enrich(watched + watchlistOnly).sortedWith(showComparator)
+        }
     }
 
     /**

--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/server/ShowRepository.kt
@@ -16,7 +16,6 @@ import com.justb81.watchbuddy.core.trakt.SyncWatchlistBody
 import com.justb81.watchbuddy.core.trakt.SyncWatchlistShowItem
 import com.justb81.watchbuddy.core.trakt.TraktApiService
 import com.justb81.watchbuddy.core.trakt.TraktSearchResult
-import com.justb81.watchbuddy.core.trakt.TraktWatchlistEntry
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import kotlinx.coroutines.async

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
@@ -8,10 +8,8 @@ import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.model.TraktWatchedEpisode
 import com.justb81.watchbuddy.core.model.TraktWatchedSeason
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
-import com.justb81.watchbuddy.core.trakt.SyncWatchlistCount
 import com.justb81.watchbuddy.core.trakt.SyncWatchlistResult
 import com.justb81.watchbuddy.core.trakt.TraktApiService
-import com.justb81.watchbuddy.core.trakt.TraktWatchlistEntry
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import io.mockk.*

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/server/ShowRepositoryTest.kt
@@ -8,7 +8,10 @@ import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.core.model.TraktWatchedEpisode
 import com.justb81.watchbuddy.core.model.TraktWatchedSeason
 import com.justb81.watchbuddy.core.tmdb.TmdbApiService
+import com.justb81.watchbuddy.core.trakt.SyncWatchlistCount
+import com.justb81.watchbuddy.core.trakt.SyncWatchlistResult
 import com.justb81.watchbuddy.core.trakt.TraktApiService
+import com.justb81.watchbuddy.core.trakt.TraktWatchlistEntry
 import com.justb81.watchbuddy.phone.auth.TokenRefreshManager
 import com.justb81.watchbuddy.phone.settings.SettingsRepository
 import io.mockk.*
@@ -39,6 +42,7 @@ class ShowRepositoryTest {
     @BeforeEach
     fun setUp() {
         every { settingsRepository.getTmdbApiKey() } returns flowOf("")
+        coEvery { traktApi.getWatchlistShows(any()) } returns emptyList()
         repository = ShowRepository(traktApi, tokenRefreshManager, tmdbApiService, settingsRepository)
     }
 
@@ -360,6 +364,73 @@ class ShowRepositoryTest {
             val seasons = state.first().entry.seasons
             val s1episodes = seasons.find { it.number == 1 }?.episodes ?: emptyList()
             assertEquals(10, s1episodes.size, "All 10 episodes must be toggled on")
+        }
+    }
+
+    @Nested
+    @DisplayName("addShowToWatchlist — shows StateFlow update (#731)")
+    inner class AddShowToWatchlistTest {
+
+        @Test
+        fun `addShowToWatchlist updates shows StateFlow immediately without waiting for next fetch`() = runTest {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+            coEvery { traktApi.getWatchedShows(any()) } returns testShows
+            coEvery { traktApi.addToWatchlist(any(), any()) } returns SyncWatchlistResult()
+            repository.getShows()
+
+            val newShow = TraktShow("New Show", 2025, TraktIds(trakt = 99, tmdb = 999))
+
+            repository.shows.test {
+                awaitItem() // consume the initial seeded emission
+
+                repository.addShowToWatchlist("Bearer test-token", newShow)
+
+                val afterAdd = awaitItem()
+                assertTrue(
+                    afterAdd.any { it.entry.show.ids.trakt == 99 },
+                    "New show must appear in the StateFlow immediately after addShowToWatchlist"
+                )
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+        @Test
+        fun `addShowToWatchlist does not add duplicate when show is already tracked`() = runTest {
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+            coEvery { traktApi.getWatchedShows(any()) } returns testShows
+            coEvery { traktApi.addToWatchlist(any(), any()) } returns SyncWatchlistResult()
+            repository.getShows()
+
+            val existingShow = testShows.first().show
+
+            repository.addShowToWatchlist("Bearer test-token", existingShow)
+
+            val shows = repository.shows.value
+            assertEquals(2, shows.size, "No duplicate must be added for an already-tracked show")
+        }
+
+        @Test
+        fun `addShowToWatchlist appended show appears at correct sort position`() = runTest {
+            val entries = listOf(
+                watchedEntry(trakt = 1, title = "Alpha", lastWatchedAt = "2026-04-15T10:00:00Z"),
+                watchedEntry(trakt = 2, title = "Beta", lastWatchedAt = "2026-04-10T10:00:00Z")
+            )
+            coEvery { tokenRefreshManager.getValidAccessToken() } returns "test-token"
+            coEvery { traktApi.getWatchedShows(any()) } returns entries
+            coEvery { traktApi.addToWatchlist(any(), any()) } returns SyncWatchlistResult()
+            repository.getShows()
+
+            val newShow = TraktShow("Zeta", 2025, TraktIds(trakt = 99, tmdb = 999))
+            repository.addShowToWatchlist("Bearer test-token", newShow)
+
+            val ids = repository.shows.value.map { it.entry.show.ids.trakt }
+            // The new show has no watch history so latestWatchedInstant == null,
+            // meaning it sorts last (after all shows with a last-watched timestamp).
+            assertEquals(
+                listOf(1, 2, 99),
+                ids,
+                "Unwatched newly added show must sort after shows with watch history"
+            )
         }
     }
 

--- a/core/src/main/java/com/justb81/watchbuddy/core/trakt/TraktApiService.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/trakt/TraktApiService.kt
@@ -73,6 +73,11 @@ interface TraktApiService {
         @Body body: SyncWatchlistBody
     ): SyncWatchlistResult
 
+    @GET("sync/watchlist/shows")
+    suspend fun getWatchlistShows(
+        @Header("Authorization") bearer: String
+    ): List<TraktWatchlistEntry>
+
     // ── Shows ─────────────────────────────────────────────────────────────────
 
     @GET("shows/{id}/seasons")
@@ -208,3 +213,10 @@ interface TraktApiService {
 )
 
 @Serializable data class SyncWatchlistCount(val shows: Int = 0)
+
+@Serializable data class TraktWatchlistEntry(
+    val rank: Int? = null,
+    val listed_at: String? = null,
+    val type: String? = null,
+    val show: TraktShow,
+)

--- a/core/src/main/java/com/justb81/watchbuddy/core/trakt/TraktApiService.kt
+++ b/core/src/main/java/com/justb81/watchbuddy/core/trakt/TraktApiService.kt
@@ -4,6 +4,7 @@ import com.justb81.watchbuddy.core.model.TraktEpisode
 import com.justb81.watchbuddy.core.model.TraktSeasonWithEpisodes
 import com.justb81.watchbuddy.core.model.TraktShow
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import retrofit2.http.*
 
@@ -216,7 +217,7 @@ interface TraktApiService {
 
 @Serializable data class TraktWatchlistEntry(
     val rank: Int? = null,
-    val listed_at: String? = null,
+    @SerialName("listed_at") val listedAt: String? = null,
     val type: String? = null,
     val show: TraktShow,
 )


### PR DESCRIPTION
## Summary

- Fix `ShowRepository.addShowToWatchlist` to immediately insert the new show into the `_shows` StateFlow via an optimistic `_shows.update { ... }` call before the cache is invalidated
- `HomeViewModel.observeShows()` and `SearchViewModel.observeTrackedShows()` both collect from `showRepository.shows`, so they now reflect the addition without a manual refresh or app restart
- Extend `fetchFromTrakt` to also fetch `sync/watchlist/shows` and merge watchlist-only entries (no watch history yet) into the shows list, so newly added shows persist across full refreshes
- Add `TraktWatchlistEntry` model and `getWatchlistShows` Retrofit endpoint to `TraktApiService`
- Add three unit tests in `ShowRepositoryTest` covering: (1) immediate StateFlow emission after `addShowToWatchlist`, (2) no duplicate added for an already-tracked show, (3) correct sort position for an unwatched newly added show

## Test plan

- [ ] Add a show via phone search and verify it appears in the list immediately without restarting the app
- [ ] Verify no duplicate appears when adding a show that is already tracked
- [ ] Verify newly added show appears at correct sort position (after shows with watch history, alphabetically among unwatched)
- [ ] Verify existing shows remain visible after adding a new one
- [ ] Check no regressions in show list loading, caching, or watched-state toggle behaviour

Closes #731

> Note: Gradle/Android SDK not present in this environment — Gradle scope skipped locally. CI (`build-android.yml`) is the gate for Kotlin/Android correctness.

https://claude.ai/code/session_013PNZkpfbQfqXhidTsziQak

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUCvcuVc9dw1Yx1Y8DdssQ)_