### PR TITLE
fix: remove redundant TV connection badge below connection toggle

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/ui/home/HomeScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -289,9 +288,6 @@ private fun HomeContent(
                 onToggle = onToggleWatchingTv
             )
         }
-        if (state.isWatchingTv) {
-            item { TvConnectionChip(connected = state.isTvConnected) }
-        }
         when {
             state.latestScrobbleEvent != null ->
                 item { NowWatchingCard(event = state.latestScrobbleEvent) }
@@ -537,32 +533,6 @@ private fun WatchingTvToggle(
             )
         }
     }
-}
-
-@Composable
-private fun TvConnectionChip(connected: Boolean) {
-    val label = stringResource(if (connected) R.string.home_tv_connected else R.string.home_tv_waiting)
-    AssistChip(
-        onClick = {},
-        label = { Text(label) },
-        leadingIcon = {
-            Icon(
-                painter = painterResource(R.drawable.ic_tv),
-                contentDescription = null,
-                modifier = Modifier.size(AssistChipDefaults.IconSize)
-            )
-        },
-        border = if (connected) null else AssistChipDefaults.assistChipBorder(enabled = true),
-        colors = if (connected) {
-            AssistChipDefaults.assistChipColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                labelColor = MaterialTheme.colorScheme.onPrimaryContainer,
-                leadingIconContentColor = MaterialTheme.colorScheme.onPrimaryContainer,
-            )
-        } else {
-            AssistChipDefaults.assistChipColors()
-        },
-    )
 }
 
 @Composable

--- a/app-phone/src/main/res/values-de/strings.xml
+++ b/app-phone/src/main/res/values-de/strings.xml
@@ -62,9 +62,6 @@
     <string name="home_watching_tv_description">Mit deinem TV verbinden für Scrobbling</string>
     <string name="home_watching_tv_disabled_reason">Verbinde dich zuerst mit Trakt und konfiguriere TMDB</string>
     <string name="home_watching_tv_disabled_reason_no_wifi">Verbinde dich mit einem WLAN-Netzwerk, um mit deinem TV zu schauen</string>
-    <string name="home_tv_connected">TV verbunden</string>
-    <string name="home_tv_waiting">Warte auf TV…</string>
-
     <!-- Settings -->
     <string name="settings_title">Einstellungen</string>
     <string name="settings_account">Konto</string>

--- a/app-phone/src/main/res/values-es/strings.xml
+++ b/app-phone/src/main/res/values-es/strings.xml
@@ -63,9 +63,6 @@
     <string name="home_watching_tv_description">Conectar con tu TV para scrobbling</string>
     <string name="home_watching_tv_disabled_reason">Conéctate primero a Trakt y configura TMDB</string>
     <string name="home_watching_tv_disabled_reason_no_wifi">Conéctate a una red Wi-Fi para ver con tu TV</string>
-    <string name="home_tv_connected">TV conectada</string>
-    <string name="home_tv_waiting">Esperando TV…</string>
-
     <!-- Settings -->
     <string name="settings_title">Ajustes</string>
     <string name="settings_account">Cuenta</string>

--- a/app-phone/src/main/res/values-fr/strings.xml
+++ b/app-phone/src/main/res/values-fr/strings.xml
@@ -63,9 +63,6 @@
     <string name="home_watching_tv_description">Se connecter au téléviseur pour le scrobbling</string>
     <string name="home_watching_tv_disabled_reason">Connectez-vous d\'abord à Trakt et configurez TMDB</string>
     <string name="home_watching_tv_disabled_reason_no_wifi">Connectez-vous à un réseau Wi-Fi pour regarder avec votre TV</string>
-    <string name="home_tv_connected">TV connectée</string>
-    <string name="home_tv_waiting">En attente du TV…</string>
-
     <!-- Settings -->
     <string name="settings_title">Paramètres</string>
     <string name="settings_account">Compte</string>

--- a/app-phone/src/main/res/values/strings.xml
+++ b/app-phone/src/main/res/values/strings.xml
@@ -70,9 +70,6 @@
     <string name="home_watching_tv_description">Connect with your TV for scrobbling</string>
     <string name="home_watching_tv_disabled_reason">Connect to Trakt and configure TMDB first</string>
     <string name="home_watching_tv_disabled_reason_no_wifi">Connect to a Wi-Fi network to watch with your TV</string>
-    <string name="home_tv_connected">TV connected</string>
-    <string name="home_tv_waiting">Waiting for TV…</string>
-
     <!-- Settings -->
     <string name="settings_title">Settings</string>
     <string name="settings_account">Account</string>


### PR DESCRIPTION
## Summary
- Remove the `TvConnectionChip` composable and its call site from the phone home screen
- The `WatchingTvToggle` card already turns green (`primaryContainer`) when a TV is connected, making the chip below it redundant
- Remove unused string resources (`home_tv_connected` / `home_tv_waiting`) from all four locale files (EN, DE, FR, ES)

## Test plan
- [ ] TV connected: toggle turns green, no badge/box visible below it
- [ ] TV disconnected: toggle reverts to default state, no leftover badge
- [ ] No visual regression on the toggle in disconnected state

Closes #740

> Note: Gradle scope skipped locally (no Android SDK in this environment); CI is the real gate for Kotlin/Android changes.

https://claude.ai/code/session_013PNZkpfbQfqXhidTsziQak

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXta1iYPcaBn2Z4aMpW6qd)_