### PR TITLE
fix: show connected phone user on TV home screen immediately after discovery

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -90,14 +90,20 @@ fun TvHomeScreen(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
-                    if (uiState.activeViewers.isNotEmpty()) {
-                        ActiveViewersRow(viewers = uiState.activeViewers)
-                    } else {
-                        Text(
-                            text = stringResource(R.string.tv_no_phone),
-                            fontSize = 12.sp,
-                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f)
-                        )
+                    when {
+                        uiState.activeViewers.isNotEmpty() -> {
+                            ActiveViewersRow(viewers = uiState.activeViewers)
+                        }
+                        uiState.isDiscoveryPending -> {
+                            DiscoveryPendingIndicator()
+                        }
+                        else -> {
+                            Text(
+                                text = stringResource(R.string.tv_no_phone),
+                                fontSize = 12.sp,
+                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f)
+                            )
+                        }
                     }
 
                     OutlinedButton(
@@ -660,6 +666,30 @@ private fun relativeDate(context: android.content.Context, moment: Instant, now:
         else -> DateUtils.getRelativeTimeSpanString(
             moment.toEpochMilli(), now, DateUtils.DAY_IN_MILLIS, DateUtils.FORMAT_ABBREV_RELATIVE
         ).toString()
+    }
+}
+
+@Composable
+private fun DiscoveryPendingIndicator() {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = Modifier
+            .padding(4.dp)
+            .clip(RoundedCornerShape(20.dp))
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.5f))
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+    ) {
+        CircularProgressIndicator(
+            color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+            modifier = Modifier.size(14.dp),
+            strokeWidth = 2.dp
+        )
+        Text(
+            text = stringResource(R.string.tv_discovering_phone),
+            fontSize = 12.sp,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.6f)
+        )
     }
 }
 

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -71,48 +71,7 @@ fun TvHomeScreen(
             .background(MaterialTheme.colorScheme.background)
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 48.dp, vertical = 24.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                Text(
-                    text       = stringResource(R.string.tv_home_title),
-                    fontSize   = 32.sp,
-                    fontWeight = FontWeight.Bold,
-                    color      = MaterialTheme.colorScheme.primary
-                )
-
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(16.dp)
-                ) {
-                    when {
-                        uiState.activeViewers.isNotEmpty() -> {
-                            ActiveViewersRow(viewers = uiState.activeViewers)
-                        }
-                        uiState.isDiscoveryPending -> {
-                            DiscoveryPendingIndicator()
-                        }
-                        else -> {
-                            Text(
-                                text = stringResource(R.string.tv_no_phone),
-                                fontSize = 12.sp,
-                                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f)
-                            )
-                        }
-                    }
-
-                    OutlinedButton(
-                        onClick = onSettingsClick,
-                        scale = ButtonDefaults.scale(scale = 1f)
-                    ) { Text(stringResource(R.string.tv_settings_title)) }
-                }
-            }
-
+            TvHomeHeader(uiState = uiState, onSettingsClick = onSettingsClick)
             when {
                 uiState.isLoading -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
@@ -150,6 +109,43 @@ fun TvHomeScreen(
                     }
                 }
             }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun TvHomeHeader(uiState: TvHomeUiState, onSettingsClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 48.dp, vertical = 24.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text       = stringResource(R.string.tv_home_title),
+            fontSize   = 32.sp,
+            fontWeight = FontWeight.Bold,
+            color      = MaterialTheme.colorScheme.primary
+        )
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            when {
+                uiState.activeViewers.isNotEmpty() -> ActiveViewersRow(viewers = uiState.activeViewers)
+                uiState.isDiscoveryPending -> DiscoveryPendingIndicator()
+                else -> Text(
+                    text = stringResource(R.string.tv_no_phone),
+                    fontSize = 12.sp,
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.4f)
+                )
+            }
+            OutlinedButton(
+                onClick = onSettingsClick,
+                scale = ButtonDefaults.scale(scale = 1f)
+            ) { Text(stringResource(R.string.tv_settings_title)) }
         }
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModel.kt
@@ -56,6 +56,12 @@ data class TvHomeUiState(
     val canLoadMore: Boolean = false,
     /** True when the displayed show list comes from the on-device persistent cache while the phone is offline. */
     val isShowingStaleCache: Boolean = false,
+    /**
+     * True while BLE discovery is running but no phone has been found yet.
+     * The connected-user section shows a pending indicator instead of the
+     * "no phone connected" label so the user knows a refresh is coming.
+     */
+    val isDiscoveryPending: Boolean = false,
 )
 
 private sealed interface FailureReason {
@@ -95,7 +101,11 @@ class TvHomeViewModel @Inject constructor(
     init {
         observeDiscoveryPreference()
         observePhones()
+        observeDiscoveryActive()
         // Initial load — re-triggered whenever the best phone changes.
+        // If discovery is already active and no phone has been found, the
+        // pending indicator is shown immediately and the first real load is
+        // deferred to when observePhones detects the first phone.
         loadShows()
     }
 
@@ -124,16 +134,37 @@ class TvHomeViewModel @Inject constructor(
                 _uiState.update {
                     it.copy(
                         connectedPhones = phones.size,
-                        activeViewers = viewers
+                        activeViewers = viewers,
+                        // Clear the pending indicator as soon as a phone is found.
+                        isDiscoveryPending = it.isDiscoveryPending && phones.isEmpty(),
                     )
                 }
-                // When the best phone changes (new primary discovered or the
-                // previous one was evicted), refresh the show list from the
-                // new source so the TV never displays another user's shows.
+                // Refresh the show list whenever the best phone changes — this
+                // includes the transition from null → first phone (discovery
+                // finds a phone for the first time) so the stale-cache view is
+                // replaced promptly without waiting for the heartbeat.
                 if (bestDeviceId != previousBestDeviceId) {
                     previousBestDeviceId = bestDeviceId
                     loadedOffset = 0
                     doLoadShows(append = false)
+                }
+            }
+        }
+    }
+
+    /**
+     * Mirrors [PhoneDiscoveryManager.discoveryActive] into [TvHomeUiState.isDiscoveryPending].
+     * While discovery is running and no phone has been found yet we show a pending indicator
+     * rather than the "no phone connected" label so the user knows discovery is in progress.
+     * Once a phone is found [observePhones] clears the flag; once discovery stops without
+     * finding any phone the flag is cleared here so the permanent "no phone" state appears.
+     */
+    private fun observeDiscoveryActive() {
+        viewModelScope.launch {
+            phoneDiscovery.discoveryActive.collect { active ->
+                _uiState.update { state ->
+                    val hasPendingDiscovery = active && state.connectedPhones == 0
+                    state.copy(isDiscoveryPending = hasPendingDiscovery)
                 }
             }
         }
@@ -215,29 +246,34 @@ class TvHomeViewModel @Inject constructor(
         val cached = getFallbackCache()
         _uiState.update {
             when (reason) {
-                is FailureReason.NoPhone -> when {
-                    cached != null -> {
-                        val (cw, others) = partitionShows(cached)
-                        it.copy(
+                is FailureReason.NoPhone -> {
+                    // If discovery is still running we defer the "no phone" state — the
+                    // pending indicator already signals that a phone may appear soon.
+                    val discoveryStillPending = it.isDiscoveryPending
+                    when {
+                        cached != null -> {
+                            val (cw, others) = partitionShows(cached)
+                            it.copy(
+                                isLoading = false,
+                                isLoadingMore = false,
+                                shows = cached,
+                                continueWatching = cw,
+                                allShows = others,
+                                progress = computeProgress(cached),
+                                hasNewSeason = computeHasNewSeason(cached),
+                                noPhoneConnected = !discoveryStillPending,
+                                canLoadMore = false,
+                                isShowingStaleCache = true,
+                            )
+                        }
+                        else -> it.copy(
                             isLoading = false,
                             isLoadingMore = false,
-                            shows = cached,
-                            continueWatching = cw,
-                            allShows = others,
-                            progress = computeProgress(cached),
-                            hasNewSeason = computeHasNewSeason(cached),
-                            noPhoneConnected = true,
+                            noPhoneConnected = !discoveryStillPending,
                             canLoadMore = false,
-                            isShowingStaleCache = true,
+                            isShowingStaleCache = false,
                         )
                     }
-                    else -> it.copy(
-                        isLoading = false,
-                        isLoadingMore = false,
-                        noPhoneConnected = true,
-                        canLoadMore = false,
-                        isShowingStaleCache = false,
-                    )
                 }
                 is FailureReason.ApiError -> when {
                     cached != null -> {

--- a/app-tv/src/main/res/values-de/strings.xml
+++ b/app-tv/src/main/res/values-de/strings.xml
@@ -8,6 +8,7 @@
     <string name="tv_all_shows">Alle Serien</string>
     <string name="tv_no_shows">Keine Serien gefunden.\nVerbinde die WatchBuddy-App auf deinem Handy mit Trakt.</string>
     <string name="tv_no_phone">Kein Handy verbunden.\nStarte die WatchBuddy-App auf deinem Smartphone.\nFalls dein WLAN die Geräteerkennung blockiert, aktiviere Bluetooth auf beiden Geräten.</string>
+    <string name="tv_discovering_phone">Suche nach Handy…</string>
     <string name="tv_retry">Erneut versuchen</string>
     <string name="tv_last_watched">Zuletzt: %1$s, %2$s</string>
     <string name="tv_last_aired_episode">Ausgestrahlt: %1$s, %2$s</string>

--- a/app-tv/src/main/res/values-es/strings.xml
+++ b/app-tv/src/main/res/values-es/strings.xml
@@ -8,6 +8,7 @@
     <string name="tv_all_shows">Todas las series</string>
     <string name="tv_no_shows">No se encontraron series.\nConecta la aplicación WatchBuddy en tu teléfono con Trakt.</string>
     <string name="tv_no_phone">Ningún teléfono conectado.\nInicia la aplicación WatchBuddy en tu smartphone.\nSi tu Wi-Fi bloquea la detección de dispositivos, activa el Bluetooth en ambos dispositivos.</string>
+    <string name="tv_discovering_phone">Buscando teléfono…</string>
     <string name="tv_retry">Reintentar</string>
     <string name="tv_last_watched">Último: %1$s, %2$s</string>
     <string name="tv_last_aired_episode">Emitido: %1$s, %2$s</string>

--- a/app-tv/src/main/res/values-fr/strings.xml
+++ b/app-tv/src/main/res/values-fr/strings.xml
@@ -8,6 +8,7 @@
     <string name="tv_all_shows">Toutes les séries</string>
     <string name="tv_no_shows">Aucune série trouvée.\nConnectez l\'application WatchBuddy sur votre téléphone avec Trakt.</string>
     <string name="tv_no_phone">Aucun téléphone connecté.\nDémarrez l\'application WatchBuddy sur votre smartphone.\nSi votre Wi-Fi bloque la détection d\'appareils, activez le Bluetooth sur les deux appareils.</string>
+    <string name="tv_discovering_phone">Recherche du téléphone…</string>
     <string name="tv_retry">Réessayer</string>
     <string name="tv_last_watched">Dernier : %1$s, %2$s</string>
     <string name="tv_last_aired_episode">Diffusé : %1$s, %2$s</string>

--- a/app-tv/src/main/res/values/strings.xml
+++ b/app-tv/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="tv_all_shows">All Shows</string>
     <string name="tv_no_shows">No shows found.\nConnect the WatchBuddy app on your phone with Trakt.</string>
     <string name="tv_no_phone">No phone connected.\nStart the WatchBuddy app on your smartphone.\nIf your Wi-Fi blocks device discovery, turn on Bluetooth on both devices.</string>
+    <string name="tv_discovering_phone">Looking for phone…</string>
     <string name="tv_retry">Retry</string>
     <string name="tv_last_watched">Last: %1$s, %2$s</string>
     <string name="tv_last_aired_episode">Aired: %1$s, %2$s</string>

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelPersistedCacheTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelPersistedCacheTest.kt
@@ -46,6 +46,7 @@ class TvHomeViewModelPersistedCacheTest {
     private val preferencesRepository: StreamingPreferencesRepository = mockk()
     private val persistedShowCacheRepository: PersistedShowCacheRepository = mockk()
     private val phonesFlow = MutableStateFlow<List<PhoneDiscoveryManager.DiscoveredPhone>>(emptyList())
+    private val discoveryActiveFlow = MutableStateFlow(false)
     private val phoneApiService: PhoneApiService = mockk()
 
     private val testShows = listOf(
@@ -56,6 +57,7 @@ class TvHomeViewModelPersistedCacheTest {
     @BeforeEach
     fun setUp() {
         every { phoneDiscovery.discoveredPhones } returns phonesFlow
+        every { phoneDiscovery.discoveryActive } returns discoveryActiveFlow
         every { phoneDiscovery.startDiscovery() } just runs
         every { phoneDiscovery.stopDiscovery() } just runs
         every { phoneDiscovery.setEnabled(any()) } just runs

--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/home/TvHomeViewModelTest.kt
@@ -47,6 +47,7 @@ class TvHomeViewModelTest {
     private val preferencesRepository: StreamingPreferencesRepository = mockk()
     private val persistedShowCacheRepository: PersistedShowCacheRepository = mockk()
     private val phonesFlow = MutableStateFlow<List<PhoneDiscoveryManager.DiscoveredPhone>>(emptyList())
+    private val discoveryActiveFlow = MutableStateFlow(false)
     private val phoneApiService: PhoneApiService = mockk()
 
     private val testTraktShows = listOf(
@@ -58,6 +59,7 @@ class TvHomeViewModelTest {
     @BeforeEach
     fun setUp() {
         every { phoneDiscovery.discoveredPhones } returns phonesFlow
+        every { phoneDiscovery.discoveryActive } returns discoveryActiveFlow
         every { phoneDiscovery.startDiscovery() } just runs
         every { phoneDiscovery.stopDiscovery() } just runs
         every { phoneDiscovery.setEnabled(any()) } just runs


### PR DESCRIPTION
## Summary
- Add `isDiscoveryPending` to `TvHomeUiState` to signal that BLE discovery is running but no phone has been found yet
- Show a spinner + "Looking for phone…" indicator in the home screen header while discovery is pending, instead of silently rendering stale cached data without any loading cue
- Suppress the permanent `noPhoneConnected` state while discovery is still active; it only appears once discovery stops without finding a phone
- `observePhones` already re-triggers `doLoadShows` on any `bestDeviceId` change (including null → first phone), so the show list refreshes from the phone as soon as BLE discovery finds it — no polling delay
- Update `TvHomeViewModelTest` and `TvHomeViewModelPersistedCacheTest` to mock the new `discoveryActive` flow

## Test plan
- [ ] Open TV app with phone nearby: spinner + "Looking for phone…" appears in header during BLE scan
- [ ] Phone discovered within a few seconds: spinner disappears, active viewer chip and fresh show list appear
- [ ] Phone not found after discovery completes: "no phone connected" state shown correctly (no lingering spinner)
- [ ] Phone disconnects after being found: toggle reverts cleanly, no leftover pending state
- [ ] CI unit tests pass (TvHomeViewModelTest, TvHomeViewModelPersistedCacheTest)

Closes #739

> Note: Gradle scope skipped locally (no Android SDK); CI (`build-android.yml`) is the real gate for Kotlin/Android changes.

https://claude.ai/code/session_013PNZkpfbQfqXhidTsziQak

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXta1iYPcaBn2Z4aMpW6qd)_