### PR TITLE
chore: ignore .claude/worktrees/ agent working directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Thumbs.db
 
 # Git worktrees created by agents
 /wt/
+/.claude/worktrees/


### PR DESCRIPTION
## Summary
- Add `/.claude/worktrees/` to `.gitignore` so temporary git worktrees created by agent isolation are not tracked

## Context
The agent isolation worktree tool creates temporary working directories under `.claude/worktrees/`. The existing `.gitignore` already covered `/wt/` but not this path, causing the stop hook to flag untracked files.

https://claude.ai/code/session_016TiLHBEpRKtjg6ig6A13m4

---
_Generated by [Claude Code](https://claude.ai/code/session_016TiLHBEpRKtjg6ig6A13m4)_