### PR TITLE
feat(tv): standardise screen layout spacing with TvSpacing tokens

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -22,6 +22,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.tv.material3.*
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
+import com.justb81.watchbuddy.tv.ui.theme.TvSpacing
 import com.justb81.watchbuddy.tv.data.CatalogSource
 import com.justb81.watchbuddy.tv.data.JustWatchOutcomeEvent
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
@@ -42,7 +43,7 @@ fun TvDiagnosticsScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 48.dp, vertical = 32.dp),
+                .padding(horizontal = TvSpacing.screenHorizontal, vertical = TvSpacing.screenVertical),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             item {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/diagnostics/TvDiagnosticsScreen.kt
@@ -22,10 +22,10 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.tv.material3.*
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.core.logging.DiagnosticLog
-import com.justb81.watchbuddy.tv.ui.theme.TvSpacing
 import com.justb81.watchbuddy.tv.data.CatalogSource
 import com.justb81.watchbuddy.tv.data.JustWatchOutcomeEvent
 import com.justb81.watchbuddy.tv.discovery.PhoneDiscoveryManager
+import com.justb81.watchbuddy.tv.ui.theme.TvSpacing
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -46,6 +46,7 @@ import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.progress.ShowProgress
 import com.justb81.watchbuddy.core.tmdb.TmdbImageHelper
 import com.justb81.watchbuddy.tv.ui.components.InitialsAvatar
+import com.justb81.watchbuddy.tv.ui.theme.TvSpacing
 import com.justb81.watchbuddy.tv.ui.theme.extendedColors
 import java.time.Instant
 import java.time.LocalDate
@@ -119,7 +120,7 @@ private fun TvHomeHeader(uiState: TvHomeUiState, onSettingsClick: () -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 48.dp, vertical = 24.dp),
+            .padding(horizontal = TvSpacing.screenHorizontal, vertical = TvSpacing.sectionGap),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
@@ -172,7 +173,7 @@ private fun TvHomeShelves(
     RestoreShelfFocusEffect(focusedShowKey, cwShelf, allShelf, allShowsExpanded)
 
     LazyColumn(
-        contentPadding = PaddingValues(horizontal = 48.dp, vertical = 16.dp),
+        contentPadding = PaddingValues(horizontal = TvSpacing.screenHorizontal, vertical = TvSpacing.itemGap),
         verticalArrangement = Arrangement.spacedBy(20.dp)
     ) {
         if (continueWatching.isNotEmpty()) {
@@ -392,7 +393,7 @@ private fun PhoneUnreachableBanner() {
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.errorContainer)
-            .padding(horizontal = 48.dp, vertical = 8.dp)
+            .padding(horizontal = TvSpacing.screenHorizontal, vertical = 8.dp)
     ) {
         Text(
             text = stringResource(R.string.tv_error_phone_unreachable),
@@ -408,7 +409,7 @@ private fun StaleCacheBanner() {
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.secondaryContainer)
-            .padding(horizontal = 48.dp, vertical = 8.dp)
+            .padding(horizontal = TvSpacing.screenHorizontal, vertical = 8.dp)
     ) {
         Text(
             text = stringResource(R.string.tv_stale_cache_banner),

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapScreen.kt
@@ -5,9 +5,11 @@ import android.webkit.WebViewClient
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -16,9 +18,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.compose.ui.graphics.Color
 import androidx.tv.material3.*
 import com.justb81.watchbuddy.R
 import com.justb81.watchbuddy.tv.ui.theme.TvSpacing

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/recap/RecapScreen.kt
@@ -21,6 +21,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.compose.ui.graphics.Color
 import androidx.tv.material3.*
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.tv.ui.theme.TvSpacing
 import com.justb81.watchbuddy.tv.ui.theme.extendedColors
 import com.justb81.watchbuddy.tv.ui.theme.toCssHex
 
@@ -58,7 +59,7 @@ fun RecapScreen(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 48.dp, vertical = 24.dp),
+                    .padding(horizontal = TvSpacing.screenHorizontal, vertical = TvSpacing.sectionGap),
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.SpaceBetween
             ) {
@@ -94,7 +95,7 @@ fun RecapScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(1f)
-                    .padding(horizontal = 48.dp, vertical = 0.dp),
+                    .padding(horizontal = TvSpacing.screenHorizontal, vertical = 0.dp),
                 contentAlignment = Alignment.Center
             ) {
                 when (val s = state) {

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/settings/TvSettingsScreen.kt
@@ -34,6 +34,7 @@ import androidx.tv.material3.OutlinedButton
 import androidx.tv.material3.Text
 import com.justb81.watchbuddy.BuildConfig
 import com.justb81.watchbuddy.R
+import com.justb81.watchbuddy.tv.ui.theme.TvSpacing
 
 private sealed interface SettingsRow {
     data class Toggle(
@@ -110,7 +111,7 @@ private fun TvSettingsBodyContent(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = 48.dp, vertical = 32.dp)
+                .padding(horizontal = TvSpacing.screenHorizontal, vertical = TvSpacing.screenVertical)
         ) {
             Text(
                 text = stringResource(R.string.tv_settings_title),
@@ -119,7 +120,7 @@ private fun TvSettingsBodyContent(
                 color = Color.White,
             )
 
-            Spacer(Modifier.height(24.dp))
+            Spacer(Modifier.height(TvSpacing.sectionGap))
 
             LazyColumn(
                 verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -133,7 +134,7 @@ private fun TvSettingsBodyContent(
                 }
             }
 
-            Spacer(Modifier.height(16.dp))
+            Spacer(Modifier.height(TvSpacing.itemGap))
 
             Text(
                 text = stringResource(

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/AllEpisodesScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/AllEpisodesScreen.kt
@@ -34,6 +34,7 @@ import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.TraktWatchedEntry
 import com.justb81.watchbuddy.tv.ui.components.SeasonEpisodeListPicker
 import com.justb81.watchbuddy.tv.ui.components.UserScopePickerDialog
+import com.justb81.watchbuddy.tv.ui.theme.TvSpacing
 
 @OptIn(ExperimentalTvMaterial3Api::class)
 @Composable
@@ -87,7 +88,7 @@ fun AllEpisodesScreen(
             onClick = onBack,
             modifier = Modifier
                 .align(Alignment.TopStart)
-                .padding(32.dp),
+                .padding(TvSpacing.backButtonInset),
         ) {
             Text(stringResource(R.string.tv_back_arrow))
         }
@@ -133,7 +134,7 @@ private fun AllEpisodesContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 64.dp, vertical = 48.dp)
+            .padding(horizontal = TvSpacing.screenHorizontal, vertical = TvSpacing.screenVertical)
     ) {
         Text(
             text = title,

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -44,6 +44,7 @@ import com.justb81.watchbuddy.core.deeplink.ProviderDeepLinkRewriter
 import com.justb81.watchbuddy.core.model.EnrichedShowEntry
 import com.justb81.watchbuddy.core.model.ResolvedProvider
 import com.justb81.watchbuddy.core.tmdb.TmdbImageHelper
+import com.justb81.watchbuddy.tv.ui.theme.TvSpacing
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -147,7 +148,7 @@ fun ShowDetailScreen(
         )
         OutlinedButton(
             onClick = onBack,
-            modifier = Modifier.align(Alignment.TopStart).padding(32.dp)
+            modifier = Modifier.align(Alignment.TopStart).padding(TvSpacing.backButtonInset)
         ) {
             Text(stringResource(R.string.tv_back_arrow))
         }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/theme/TvSpacing.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/theme/TvSpacing.kt
@@ -1,0 +1,12 @@
+package com.justb81.watchbuddy.tv.ui.theme
+
+import androidx.compose.ui.unit.dp
+
+object TvSpacing {
+    val screenHorizontal = 48.dp
+    val screenVertical = 32.dp
+    val sectionGap = 24.dp
+    val itemGap = 16.dp
+    val tightGap = 8.dp
+    val backButtonInset = 32.dp
+}


### PR DESCRIPTION
## Summary
- Create `TvSpacing` object with six role-named Dp constants (`screenHorizontal=48.dp`, `screenVertical=32.dp`, `sectionGap=24.dp`, `itemGap=16.dp`, `tightGap=8.dp`, `backButtonInset=32.dp`)
- Replace hardcoded dp literals in all 6 TV screens: TvHomeScreen, TvSettingsScreen, TvDiagnosticsScreen, RecapScreen, AllEpisodesScreen, ShowDetailScreen
- Scope limited to screen-level edge padding and primary gutters only; card-internal paddings, badge geometry, and component primitives remain as literals

## Test plan
- [ ] All six TV screens render correctly on 1080p emulator/device
- [ ] D-pad navigation works without focus issues on all screens
- [ ] Screen edge padding is visually consistent (48dp horizontal, 32dp vertical)
- [ ] Section and item gaps are uniform across screens

Closes #687

> Note: Gradle scope skipped locally (no Android SDK in CI runner); CI is the gate.

https://claude.ai/code/session_013PNZkpfbQfqXhidTsziQak

---
_Generated by [Claude Code](https://claude.ai/code/session_016TiLHBEpRKtjg6ig6A13m4)_