### PR TITLE
feat(tv): improve show detail screen layout and usability

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -308,7 +308,7 @@ private fun ShowDetailContent(
     val episodeTitle = nextEpisode.episodeName
     Column(
         modifier = modifier.fillMaxWidth(0.55f).padding(end = 64.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        verticalArrangement = Arrangement.spacedBy(TvSpacing.itemGap)
     ) {
         Text(
             text = entry.show.title,
@@ -319,13 +319,17 @@ private fun ShowDetailContent(
             maxLines = 2,
             overflow = TextOverflow.Ellipsis
         )
-        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(TvSpacing.tightGap)) {
             entry.show.year?.let { MetaChip(it.toString()) }
             val watchedCount = entry.seasons.sumOf { it.episodes.size }
             MetaChip(pluralStringResource(R.plurals.tv_watched_episodes, watchedCount, watchedCount))
         }
-        Spacer(Modifier.height(8.dp))
-        Text(text = stringResource(R.string.tv_next_episode), fontSize = 14.sp, color = Color.White.copy(alpha = 0.5f))
+        Spacer(Modifier.height(TvSpacing.tightGap))
+        Text(
+            text = stringResource(R.string.tv_next_episode),
+            fontSize = 14.sp,
+            color = Color.White.copy(alpha = 0.6f),
+        )
         // AnimatedContent slides the episode info out left and slides new episode in from the right
         // whenever the episodeCode changes (driven by advancedEntry optimistic update).
         AnimatedContent(
@@ -336,20 +340,35 @@ private fun ShowDetailContent(
             },
             label = "next-episode",
         ) { code ->
+            // When the episode name is known, show it as the title with the code beneath.
+            // Otherwise promote the code to the title — never repeat the "Next episode" label.
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(
-                    text = episodeTitle ?: stringResource(R.string.tv_next_episode),
-                    fontSize = 20.sp,
-                    fontWeight = FontWeight.SemiBold,
-                    color = Color.White,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(text = code, fontSize = 14.sp, color = Color.White.copy(alpha = 0.6f))
+                if (episodeTitle != null) {
+                    Text(
+                        text = episodeTitle,
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color.White,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(text = code, fontSize = 14.sp, color = Color.White.copy(alpha = 0.6f))
+                } else {
+                    Text(
+                        text = code,
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = Color.White,
+                        maxLines = 1,
+                    )
+                }
             }
         }
-        Spacer(Modifier.height(8.dp))
-        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        Spacer(Modifier.height(TvSpacing.tightGap))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(TvSpacing.itemGap),
+            verticalArrangement = Arrangement.spacedBy(TvSpacing.tightGap),
+        ) {
             WatchNowButton(
                 state = watchNowState,
                 onClick = actions.onWatchNow,
@@ -360,9 +379,11 @@ private fun ShowDetailContent(
                 hasNextEpisode = nextEpisode.episodeCode != null,
                 onClick = actions.onMarkWatched,
             )
-            OutlinedButton(onClick = actions.onRecapClick) { Text(stringResource(R.string.tv_recap)) }
+            OutlinedButton(onClick = actions.onRecapClick) {
+                Text(stringResource(R.string.tv_recap), maxLines = 1, softWrap = false)
+            }
             OutlinedButton(onClick = actions.onAllEpisodesClick) {
-                Text(stringResource(R.string.tv_all_episodes))
+                Text(stringResource(R.string.tv_all_episodes), maxLines = 1, softWrap = false)
             }
         }
 
@@ -396,7 +417,12 @@ private fun WatchNowButton(
                     strokeWidth = 2.dp,
                 )
                 Spacer(Modifier.width(8.dp))
-                Text(text = stringResource(R.string.tv_watch_now), fontWeight = FontWeight.Bold)
+                Text(
+                    text = stringResource(R.string.tv_watch_now),
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    softWrap = false,
+                )
             }
         }
         is WatchNowState.Available -> {
@@ -405,7 +431,12 @@ private fun WatchNowButton(
                 modifier = Modifier.focusRequester(focusRequester),
                 colors = ButtonDefaults.colors(containerColor = MaterialTheme.colorScheme.primary),
             ) {
-                Text(text = stringResource(R.string.tv_watch_now), fontWeight = FontWeight.Bold)
+                Text(
+                    text = stringResource(R.string.tv_watch_now),
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    softWrap = false,
+                )
             }
         }
         is WatchNowState.Unavailable -> {
@@ -415,7 +446,12 @@ private fun WatchNowButton(
                 modifier = Modifier.focusRequester(focusRequester),
                 colors = ButtonDefaults.colors(containerColor = MaterialTheme.colorScheme.primary),
             ) {
-                Text(text = stringResource(R.string.tv_watch_now_unavailable), fontWeight = FontWeight.Bold)
+                Text(
+                    text = stringResource(R.string.tv_watch_now_unavailable),
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    softWrap = false,
+                )
             }
         }
         is WatchNowState.NoProvider -> {
@@ -425,7 +461,12 @@ private fun WatchNowButton(
                 modifier = Modifier.focusRequester(focusRequester),
                 colors = ButtonDefaults.colors(containerColor = MaterialTheme.colorScheme.primary),
             ) {
-                Text(text = stringResource(R.string.tv_watch_now_no_provider), fontWeight = FontWeight.Bold)
+                Text(
+                    text = stringResource(R.string.tv_watch_now_no_provider),
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    softWrap = false,
+                )
             }
         }
     }
@@ -459,7 +500,7 @@ private fun MarkWatchedButton(
             )
             Spacer(Modifier.width(8.dp))
         }
-        Text(stringResource(R.string.tv_mark_watched))
+        Text(stringResource(R.string.tv_mark_watched), maxLines = 1, softWrap = false)
     }
 }
 
@@ -473,20 +514,12 @@ private fun AvailableOnSection(
 ) {
     when (state) {
         is ProviderListUiState.Loading -> {
-            Text(
-                text = stringResource(R.string.tv_available_at),
-                fontSize = 12.sp,
-                color = Color.White.copy(alpha = 0.4f),
-            )
+            ProviderSectionLabel()
         }
 
         is ProviderListUiState.Success -> {
-            Text(
-                text = stringResource(R.string.tv_available_at),
-                fontSize = 12.sp,
-                color = Color.White.copy(alpha = 0.4f),
-            )
-            LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            ProviderSectionLabel()
+            LazyRow(horizontalArrangement = Arrangement.spacedBy(TvSpacing.tightGap)) {
                 items(state.providers, key = { it.providerId }) { provider ->
                     val linkState = deepLinks[provider.providerId]
                     ProviderChip(
@@ -505,20 +538,34 @@ private fun AvailableOnSection(
         is ProviderListUiState.Empty -> {
             Text(
                 text = stringResource(R.string.tv_not_available_region),
-                fontSize = 12.sp,
-                color = Color.White.copy(alpha = 0.4f),
+                fontSize = 14.sp,
+                color = Color.White.copy(alpha = 0.6f),
             )
         }
 
         is ProviderListUiState.Error -> {
-            OutlinedButton(onClick = onRetry) {
-                Text(
-                    text = stringResource(R.string.tv_providers_retry),
-                    fontSize = 12.sp,
-                )
+            // Compact, focusable retry control rather than a full-width banner.
+            Column(verticalArrangement = Arrangement.spacedBy(TvSpacing.tightGap)) {
+                ProviderSectionLabel()
+                OutlinedButton(onClick = onRetry) {
+                    Text(
+                        text = stringResource(R.string.tv_providers_retry),
+                        fontSize = 14.sp,
+                        maxLines = 2,
+                    )
+                }
             }
         }
     }
+}
+
+@Composable
+private fun ProviderSectionLabel() {
+    Text(
+        text = stringResource(R.string.tv_available_at),
+        fontSize = 14.sp,
+        color = Color.White.copy(alpha = 0.6f),
+    )
 }
 
 @Composable
@@ -529,19 +576,19 @@ private fun ProviderLogo(provider: ResolvedProvider) {
             contentDescription = provider.name,
             contentScale = ContentScale.Fit,
             modifier = Modifier
-                .size(48.dp)
+                .size(56.dp)
                 .clip(RoundedCornerShape(4.dp))
         )
     } else {
         Box(
             modifier = Modifier
-                .size(48.dp)
+                .size(56.dp)
                 .background(MaterialTheme.colorScheme.surfaceVariant, RoundedCornerShape(4.dp)),
             contentAlignment = Alignment.Center,
         ) {
             Text(
                 text = provider.name.take(2).uppercase(),
-                fontSize = 14.sp,
+                fontSize = 16.sp,
                 fontWeight = FontWeight.Bold,
                 color = Color.White,
             )
@@ -573,7 +620,7 @@ private fun ProviderChip(
     Card(
         onClick = if (isEnabled) onClick else ({}),
         modifier = Modifier
-            .width(88.dp)
+            .width(96.dp)
             .border(borderWidth, borderColor, RoundedCornerShape(8.dp)),
         shape = CardDefaults.shape(RoundedCornerShape(8.dp)),
         colors = CardDefaults.colors(
@@ -598,7 +645,7 @@ private fun ProviderChip(
                 }
                 Text(
                     text = labelText,
-                    fontSize = 10.sp,
+                    fontSize = 12.sp,
                     color = if (isEnabled) Color.White.copy(alpha = 0.8f) else Color.White.copy(alpha = 0.4f),
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
@@ -606,7 +653,7 @@ private fun ProviderChip(
                 if (provider.isLastUsed) {
                     Text(
                         text = stringResource(R.string.tv_provider_last_used_label),
-                        fontSize = 9.sp,
+                        fontSize = 11.sp,
                         color = MaterialTheme.colorScheme.primary,
                         fontWeight = FontWeight.Medium,
                         maxLines = 1,
@@ -636,7 +683,7 @@ private fun ProviderChip(
 private fun JustWatchAttributionBadge() {
     Text(
         text = stringResource(R.string.tv_justwatch_attribution),
-        fontSize = 10.sp,
+        fontSize = 11.sp,
         color = Color.White.copy(alpha = 0.4f),
         modifier = Modifier.padding(top = 4.dp),
     )
@@ -651,9 +698,9 @@ private fun MetaChip(text: String, color: Color = MaterialTheme.colorScheme.surf
     ) {
         Text(
             text = text,
-            fontSize = 12.sp,
+            fontSize = 14.sp,
             color = Color.White.copy(alpha = 0.8f),
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
         )
     }
 }

--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt
@@ -325,67 +325,15 @@ private fun ShowDetailContent(
             MetaChip(pluralStringResource(R.plurals.tv_watched_episodes, watchedCount, watchedCount))
         }
         Spacer(Modifier.height(TvSpacing.tightGap))
-        Text(
-            text = stringResource(R.string.tv_next_episode),
-            fontSize = 14.sp,
-            color = Color.White.copy(alpha = 0.6f),
-        )
-        // AnimatedContent slides the episode info out left and slides new episode in from the right
-        // whenever the episodeCode changes (driven by advancedEntry optimistic update).
-        AnimatedContent(
-            targetState = episodeCode,
-            transitionSpec = {
-                (slideInHorizontally { it } + fadeIn()) togetherWith
-                    (slideOutHorizontally { -it } + fadeOut())
-            },
-            label = "next-episode",
-        ) { code ->
-            // When the episode name is known, show it as the title with the code beneath.
-            // Otherwise promote the code to the title — never repeat the "Next episode" label.
-            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                if (episodeTitle != null) {
-                    Text(
-                        text = episodeTitle,
-                        fontSize = 20.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        color = Color.White,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    Text(text = code, fontSize = 14.sp, color = Color.White.copy(alpha = 0.6f))
-                } else {
-                    Text(
-                        text = code,
-                        fontSize = 20.sp,
-                        fontWeight = FontWeight.SemiBold,
-                        color = Color.White,
-                        maxLines = 1,
-                    )
-                }
-            }
-        }
+        NextEpisodeSection(episodeCode = episodeCode, episodeTitle = episodeTitle)
         Spacer(Modifier.height(TvSpacing.tightGap))
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(TvSpacing.itemGap),
-            verticalArrangement = Arrangement.spacedBy(TvSpacing.tightGap),
-        ) {
-            WatchNowButton(
-                state = watchNowState,
-                onClick = actions.onWatchNow,
-                focusRequester = watchNowFocus,
-            )
-            MarkWatchedButton(
-                state = markState,
-                hasNextEpisode = nextEpisode.episodeCode != null,
-                onClick = actions.onMarkWatched,
-            )
-            OutlinedButton(onClick = actions.onRecapClick) {
-                Text(stringResource(R.string.tv_recap), maxLines = 1, softWrap = false)
-            }
-            OutlinedButton(onClick = actions.onAllEpisodesClick) {
-                Text(stringResource(R.string.tv_all_episodes), maxLines = 1, softWrap = false)
-            }
-        }
+        ActionButtons(
+            watchNowState = watchNowState,
+            markState = markState,
+            hasNextEpisode = nextEpisode.episodeCode != null,
+            watchNowFocus = watchNowFocus,
+            actions = actions,
+        )
 
         AvailableOnSection(
             state = providerState,
@@ -393,6 +341,81 @@ private fun ShowDetailContent(
             onProviderClick = actions.onProviderClick,
             onRetry = actions.onRetryProviders,
         )
+    }
+}
+
+@Composable
+private fun NextEpisodeSection(episodeCode: String, episodeTitle: String?) {
+    Text(
+        text = stringResource(R.string.tv_next_episode),
+        fontSize = 14.sp,
+        color = Color.White.copy(alpha = 0.6f),
+    )
+    // AnimatedContent slides the episode info out left and slides new episode in from the right
+    // whenever the episodeCode changes (driven by advancedEntry optimistic update).
+    AnimatedContent(
+        targetState = episodeCode,
+        transitionSpec = {
+            (slideInHorizontally { it } + fadeIn()) togetherWith
+                (slideOutHorizontally { -it } + fadeOut())
+        },
+        label = "next-episode",
+    ) { code ->
+        // When the episode name is known, show it as the title with the code beneath.
+        // Otherwise promote the code to the title — never repeat the "Next episode" label.
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            if (episodeTitle != null) {
+                Text(
+                    text = episodeTitle,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.White,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(text = code, fontSize = 14.sp, color = Color.White.copy(alpha = 0.6f))
+            } else {
+                Text(
+                    text = code,
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = Color.White,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalTvMaterial3Api::class)
+@Composable
+private fun ActionButtons(
+    watchNowState: WatchNowState,
+    markState: MarkWatchedState,
+    hasNextEpisode: Boolean,
+    watchNowFocus: FocusRequester,
+    actions: ShowDetailActions,
+) {
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(TvSpacing.itemGap),
+        verticalArrangement = Arrangement.spacedBy(TvSpacing.tightGap),
+    ) {
+        WatchNowButton(
+            state = watchNowState,
+            onClick = actions.onWatchNow,
+            focusRequester = watchNowFocus,
+        )
+        MarkWatchedButton(
+            state = markState,
+            hasNextEpisode = hasNextEpisode,
+            onClick = actions.onMarkWatched,
+        )
+        OutlinedButton(onClick = actions.onRecapClick) {
+            Text(stringResource(R.string.tv_recap), maxLines = 1, softWrap = false)
+        }
+        OutlinedButton(onClick = actions.onAllEpisodesClick) {
+            Text(stringResource(R.string.tv_all_episodes), maxLines = 1, softWrap = false)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Optimizes the Google TV show-detail screen (`ShowDetailScreen.kt`) for layout correctness and couch-distance usability. Motivated by a photo of the "Ghosts" detail page where the action buttons overflowed the column and the next-episode label was duplicated.

### Problems fixed
1. **Action-button row overflowed the column.** The four buttons (Watch now / Mark watched / Recap / All Episodes) were packed into a non-wrapping `Row` inside the 55%-width content column. The "Was bisher geschah…" (Recap) label broke character-by-character and the "Alle Folgen" button was pushed off-screen entirely.
   - Now laid out in a `FlowRow` (stable in Compose BOM 2026.05.01) that wraps cleanly to a second line, with `maxLines = 1` / `softWrap = false` on every button label so a button never breaks its own text mid-word.
2. **Duplicate "Nächste Folge" label.** When the next-episode name was missing, the bold title fell back to the same string as its own section label. Now the episode **code** is promoted to the title in that case; the label is never repeated.
3. **Provider error state was a full-width banner.** `ProviderListUiState.Error` rendered the whole sentence inside one stretched button. Now it's an "Available on:" label plus a compact, focusable retry button.
4. **Sub-TV-safe typography.** Raised provider chip labels (10→12sp), last-used badge (9→11sp), section labels (12→14sp), meta chips (12→14sp), and provider logos (48→56dp) to readable sizes; spacing now uses `TvSpacing` constants.

### Scope
- Single file changed: `app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/showdetail/ShowDetailScreen.kt`.
- No new strings, no `ShowDetailViewModel`/state changes. The split hero-image + content layout is preserved.

## Testing
⚠️ **The Android SDK is not available in this sandbox**, so `scripts/precommit.sh` skipped its Gradle scope (test / detekt / lintDebug) with a warning. CI's `Test & Build` (`build-android.yml`) is the real gate for this change — please treat a red check there as a blocker.

Manual TV verification to perform: confirm all four action buttons are fully readable and wrap rather than clip; the next-episode block shows the code (not a duplicated label) when no episode name is available; and the provider-error retry control is a compact focusable button.

https://claude.ai/code/session_01XwFEkTJnM114nUZugFwn7A

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwFEkTJnM114nUZugFwn7A)_