### PR TITLE
fix: restore last-focused show on TV home re-enter

### DIFF
--- a/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
+++ b/app-tv/src/main/java/com/justb81/watchbuddy/tv/ui/home/TvHomeScreen.kt
@@ -253,18 +253,33 @@ private fun RestoreShelfFocusEffect(
     allShowsExpanded: Boolean
 ) {
     LaunchedEffect(continueWatching.shows, allShows.shows, allShowsExpanded) {
-        val key = focusedShowKey ?: return@LaunchedEffect
-        val cwIndex = continueWatching.shows.indexOfFirst { it.focusKey() == key }
+        if (focusedShowKey == null) {
+            val firstCwKey = continueWatching.shows.firstOrNull()?.focusKey()
+            if (firstCwKey != null) {
+                continueWatching.listState.scrollToItem(0)
+                continueWatching.requesters[firstCwKey]?.requestFocus()
+                return@LaunchedEffect
+            }
+            if (allShowsExpanded) {
+                val firstAllKey = allShows.shows.firstOrNull()?.focusKey()
+                if (firstAllKey != null) {
+                    allShows.listState.scrollToItem(0)
+                    allShows.requesters[firstAllKey]?.requestFocus()
+                }
+            }
+            return@LaunchedEffect
+        }
+        val cwIndex = continueWatching.shows.indexOfFirst { it.focusKey() == focusedShowKey }
         if (cwIndex >= 0) {
             continueWatching.listState.scrollToItem(cwIndex)
-            continueWatching.requesters[key]?.requestFocus()
+            continueWatching.requesters[focusedShowKey]?.requestFocus()
             return@LaunchedEffect
         }
         if (allShowsExpanded) {
-            val allIndex = allShows.shows.indexOfFirst { it.focusKey() == key }
+            val allIndex = allShows.shows.indexOfFirst { it.focusKey() == focusedShowKey }
             if (allIndex >= 0) {
                 allShows.listState.scrollToItem(allIndex)
-                allShows.requesters[key]?.requestFocus()
+                allShows.requesters[focusedShowKey]?.requestFocus()
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fix D-pad focus always landing on an arbitrary show when entering the TV home screen for the first time or after returning from show detail
- Default focus to the first (most recently watched) show on initial load — first item in Continue Watching, or first item in All Shows if CW is empty and expanded
- Restore the last-focused show when navigating back from show detail (existing `focusedShowKey` tracking was already correct; the bug was that a null key skipped focus entirely instead of falling back to the first item)

## Test plan
- [ ] Open TV home screen — focus should land on the first show in the Continue Watching shelf
- [ ] If Continue Watching is empty but All Shows is expanded, focus should land on the first item there
- [ ] Focus a show that is not the first, navigate to show detail, press Back — focus should return to the previously focused show
- [ ] D-pad left/right navigation on home screen updates `focusedShowKey` and does not reset to middle
- [ ] App restart resets focus to first show (session-scoped only — `rememberSaveable` resets on process death)

> Note: Gradle scope skipped locally (no Android SDK in this environment); CI is the gate.

Closes #757
https://claude.ai/code/session_013PNZkpfbQfqXhidTsziQak

---
_Generated by [Claude Code](https://claude.ai/code/session_01GP8GqEzzsv1uZ5ZGbQWW1G)_