### PR TITLE
fix: pin KSP to 2.3.8 to resolve CI build failure

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,11 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Wait 3 days after a new version is published before opening a PR.
+    # Prevents racing Maven Central CDN propagation for freshly-published
+    # plugin-marker artifacts (see #767).
+    cooldown:
+      default-days: 3
     commit-message:
       prefix: "chore(deps)"
     labels:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 agp = "9.2.1"
 kotlin = "2.3.21"
-ksp = "2.3.9"
+ksp = "2.3.8"
 hilt = "2.59.2"
 compose-bom = "2026.05.01"
 compose-tv = "1.1.0"


### PR DESCRIPTION
## Summary
- Pins KSP from 2.3.9 back to 2.3.8 in `gradle/libs.versions.toml` — the last known-green, Kotlin-2.3-aligned version
- Adds a 3-day Dependabot cooldown to the Gradle ecosystem entry in `.github/dependabot.yml` to prevent the same Maven Central CDN propagation race from recurring with future KSP (and other Gradle plugin) patch releases

## Root cause
KSP 2.3.9 was bumped by Dependabot (#765) but the Gradle plugin-marker POM (`com.google.devtools.ksp.gradle.plugin:2.3.9`) had not fully propagated through Maven Central CDN mirrors at the time CI ran. Gradle resolved the marker first, got a negative result, cached it, and every subsequent build failed with "Plugin not found in any of the following sources".

## Test plan
- [ ] CI `Test & Build` passes green
- [ ] Both phone and TV APKs compile successfully (Hilt annotation processing and Room schema generation use KSP)

Closes #767

> Note: Gradle scope skipped locally (no Android SDK in sandbox runner); CI (`build-android.yml`) is the real gate.

https://claude.ai/code/session_013PNZkpfbQfqXhidTsziQak

---
_Generated by [Claude Code](https://claude.ai/code/session_012QjZrtqE3444sGuFgJQHLe)_