### PR TITLE
docs: update CLAUDE.md for Android SDK availability in web sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,11 +201,7 @@ Once enabled, `.githooks/pre-commit` delegates to `scripts/precommit.sh` on ever
 
 If you change either workflow's `paths-filter`, update `scripts/precommit.sh` in the same commit.
 
-**Sandboxed environments without the Android SDK** (Claude Code on the web, ephemeral runners): `scripts/precommit.sh` detects a missing SDK (`ANDROID_HOME` / `ANDROID_SDK_ROOT` unset and no `sdk.dir=` in `local.properties`) and **skips only the Gradle scope** with a loud yellow warning, while still running backend and workflow-YAML checks. The commit is allowed to proceed and CI (`build-android.yml`) becomes the real gate for Kotlin/Android changes. Agents in this situation MUST:
-
-1. Run `./scripts/precommit.sh` (or let the hook run it); do not reach for `--no-verify`.
-2. Surface the skip notice in the PR description so reviewers know the Gradle scope wasn't exercised locally.
-3. Treat a red `Test & Build` check on the PR as a blocker — there's no local pre-flight to fall back on.
+**Claude Code on the web** runs with a full Android SDK (`ANDROID_HOME` is set), so `scripts/precommit.sh` executes all Gradle checks (tests, detekt, Android Lint) locally — the same as a developer machine. The SDK-skip fallback in the script is retained for local dev environments that genuinely lack the SDK, but web sessions must not rely on it.
 
 ### Git Workflow — IMPORTANT
 


### PR DESCRIPTION
## Summary

- The Claude Code on the web environment now provides a full Android SDK (`ANDROID_HOME=/root/android-sdk`), so `precommit.sh` runs all Gradle checks (tests, detekt, Android Lint) locally — no more skip-and-rely-on-CI fallback for web sessions.
- Replaces the outdated "Sandboxed environments without the Android SDK" block (5 lines) with a single sentence reflecting the current state.
- The SDK-skip fallback in `scripts/precommit.sh` itself is intentionally left in place for local dev machines that genuinely lack the SDK.

## Test plan

- [x] Verified `ANDROID_HOME=/root/android-sdk` and `sdkmanager --list_installed` returns `platform-tools 37.0.0`
- [x] `./gradlew help` completes successfully (Gradle 9.5.1, build-logic compiles)
- [x] `./gradlew :app-phone:assembleDebug --dry-run` exits 0
- [x] `./scripts/precommit.sh` runs without errors on the staged change (docs-only, no Gradle scope triggered — correct behaviour)

https://claude.ai/code/session_01JEGCekZbN1fzrbkqMezHsi

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEGCekZbN1fzrbkqMezHsi)_