### PR TITLE
chore(deps): bump kotlin, coil3, okhttp, litertlm, core-ktx, errorprone

### DIFF
--- a/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/LaunchProviderTest.kt
+++ b/app-tv/src/test/java/com/justb81/watchbuddy/tv/ui/showdetail/LaunchProviderTest.kt
@@ -3,12 +3,15 @@ package com.justb81.watchbuddy.tv.ui.showdetail
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import com.justb81.watchbuddy.core.model.ResolvedProvider
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkConstructor
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -51,6 +54,14 @@ class LaunchProviderTest {
         every { anyConstructed<Intent>().addFlags(any()) } answers { self as Intent }
         every { anyConstructed<Intent>().setPackage(any()) } answers { self as Intent }
 
+        // The cascade builds candidate URIs via the inlined `String.toUri()`, whose
+        // body (`Uri.parse(this)`) is compiled into this test's call site. The
+        // android.jar stub returns null, and the Kotlin compiler emits a non-null
+        // assertion on that platform-type result, so stub Uri.parse to return a
+        // (mock) Uri instead of letting the assertion throw.
+        mockkStatic(Uri::class)
+        every { Uri.parse(any()) } returns mockk(relaxed = true)
+
         every { context.packageManager } returns pm
         val intentSlot = slot<Intent>()
         every { context.startActivity(capture(intentSlot)) } answers {
@@ -65,6 +76,7 @@ class LaunchProviderTest {
     @AfterEach
     fun tearDown() {
         unmockkConstructor(Intent::class)
+        unmockkStatic(Uri::class)
         startedIntents.clear()
     }
 

--- a/build-logic/convention/src/main/kotlin/watchbuddy.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/watchbuddy.android.application.gradle.kts
@@ -102,6 +102,20 @@ kotlin {
     }
 }
 
+// Dagger/Hilt 2.59.2 (the latest release) bundles a kotlin-metadata-jvm that
+// reads Kotlin metadata only up to format 2.3.0. Kotlin 2.4.0 — and libraries
+// compiled with it, e.g. coil3 3.5.0 — emit 2.4.0 metadata, which makes Hilt's
+// annotation processor (hiltJavaCompileDebug) fail with "Provided Metadata
+// instance has version 2.4.0, while maximum supported version is 2.3.0". Force
+// the metadata reader to match the Kotlin version on every configuration,
+// including the Hilt aggregating task's annotation-processor classpath. Remove
+// once Dagger ships a release built against kotlin-metadata-jvm 2.4.0.
+configurations.configureEach {
+    resolutionStrategy {
+        force("org.jetbrains.kotlin:kotlin-metadata-jvm:${libs.versions.kotlin.get()}")
+    }
+}
+
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }

--- a/build-logic/convention/src/main/kotlin/watchbuddy.android.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/watchbuddy.android.library.gradle.kts
@@ -31,6 +31,20 @@ kotlin {
     }
 }
 
+// Dagger/Hilt 2.59.2 (the latest release) bundles a kotlin-metadata-jvm that
+// reads Kotlin metadata only up to format 2.3.0. Kotlin 2.4.0 — and libraries
+// compiled with it, e.g. coil3 3.5.0 — emit 2.4.0 metadata, which makes Hilt's
+// annotation processor (hiltJavaCompileDebug) fail with "Provided Metadata
+// instance has version 2.4.0, while maximum supported version is 2.3.0". Force
+// the metadata reader to match the Kotlin version on every configuration,
+// including the Hilt aggregating task's annotation-processor classpath. Remove
+// once Dagger ships a release built against kotlin-metadata-jvm 2.4.0.
+configurations.configureEach {
+    resolutionStrategy {
+        force("org.jetbrains.kotlin:kotlin-metadata-jvm:${libs.versions.kotlin.get()}")
+    }
+}
+
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "9.2.1"
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 ksp = "2.3.9"
 hilt = "2.59.2"
 compose-bom = "2026.05.01"
@@ -8,12 +8,12 @@ compose-tv = "1.1.0"
 lifecycle = "2.10.0"
 ktor = "3.5.0"
 retrofit = "3.0.0"
-okhttp = "5.3.2"
+okhttp = "5.4.0"
 coroutines = "1.11.0"
 serialization = "1.11.0"
-litertlm = "0.12.0"
+litertlm = "0.13.1"
 aicore = "0.0.1-exp02"
-coil3 = "3.4.0"
+coil3 = "3.5.0"
 navigation = "2.9.8"
 datastore = "1.2.1"
 work = "2.11.2"
@@ -24,7 +24,7 @@ turbine = "1.2.1"
 robolectric = "4.16.1"
 androidx-test-core = "1.7.0"
 androidx-arch-core = "2.2.0"
-errorprone-annotations = "2.49.0"
+errorprone-annotations = "2.50.0"
 gradlePlayPublisher = "4.0.0"
 detekt = "1.23.8"
 jsoup = "1.22.2"
@@ -33,7 +33,7 @@ androidx-tvprovider = "1.1.0"
 
 [libraries]
 # AndroidX Core
-androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version = "1.18.0" }
+androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version = "1.19.0" }
 androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
 androidx-lifecycle-runtime-compose = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }


### PR DESCRIPTION
## Summary

Consolidates the four open Dependabot PRs into one change and fixes the shared CI failure that blocked three of them. Supersedes:

- #774 — bump kotlin 2.3.21 → 2.4.0
- #780 — bump okhttp 5.3.2 → 5.4.0
- #782 — bump coil3 3.4.0 → 3.5.0
- #783 — bump the `gradle-minor-patch` group (kotlin, litertlm, errorprone-annotations, core-ktx)

### Version bumps

| Dependency | From → To |
|---|---|
| kotlin | 2.3.21 → 2.4.0 |
| okhttp | 5.3.2 → 5.4.0 |
| litertlm | 0.12.0 → 0.13.1 |
| coil3 | 3.4.0 → 3.5.0 |
| errorprone-annotations | 2.49.0 → 2.50.0 |
| androidx.core:core-ktx | 1.18.0 → 1.19.0 |

## Why the Dependabot PRs were failing

All three red PRs (#774, #782, #783) failed with the **same** error on `:app-{phone,tv}:hiltJavaCompileDebug`:

```
[Hilt] Provided Metadata instance has version 2.4.0, while maximum supported version is 2.3.0.
To support newer versions, update the kotlin-metadata-jvm library.
```

**Root cause:** Dagger/Hilt **2.59.2** (the latest published release — there is no newer Dagger on Maven Central) bundles a `kotlin-metadata-jvm` that reads Kotlin metadata only up to format **2.3.0**. Two independent bumps trip this:

- **Kotlin 2.4.0** (#774, #783) — our own compiled classes now carry 2.4.0 metadata.
- **coil3 3.5.0** (#782) — its prebuilt classes were compiled with Kotlin 2.4.0, so Hilt fails reading them even with Kotlin still at 2.3.21. This is why coil3 alone failed.

okhttp 5.4.0 (#780) passed on its own because nothing it contributes is read with the newer metadata format.

## Fixes

1. **Force `kotlin-metadata-jvm` to the Kotlin version** on every configuration in both convention plugins (`watchbuddy.android.library` / `watchbuddy.android.application`), so the Hilt aggregating task's annotation-processor classpath can read 2.4.0 metadata. Since 2.59.2 is the newest Dagger, bumping Hilt isn't an option; this is the documented workaround. The comment notes it should be removed once Dagger ships a release built against `kotlin-metadata-jvm` 2.4.0.
2. **Stub `Uri.parse` in `LaunchProviderTest`** — Kotlin 2.4.0 now materialises a non-null assertion on the inlined `String.toUri()` (→ `Uri.parse`) platform-type result. The `android.jar` stub returns `null` in unit tests, so the launch-cascade tests NPE'd. The test now stubs `Uri.parse` to a mock `Uri`.

## Verification

Run locally with the full Android SDK (same checks as CI's `Test & Build`):

- ✅ `./gradlew testDebugUnitTest`
- ✅ `./gradlew detektAll`
- ✅ `./gradlew :app-phone:lintDebug :app-tv:lintDebug`
- ✅ `./gradlew assembleDebug` (both APKs)
- ✅ `./scripts/precommit.sh`

Once this merges, Dependabot PRs #774, #780, #782 and #783 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0143JyRLhEMkFrCRnWnBpfiC)_