### PR TITLE
fix(phone): keep Trakt session alive when access token expires

### DIFF
--- a/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRepository.kt
+++ b/app-phone/src/main/java/com/justb81/watchbuddy/phone/auth/TokenRepository.kt
@@ -68,11 +68,21 @@ class TokenRepository @Inject constructor(
 
     fun getRefreshToken(): String? = decrypt(KEY_REFRESH_TOKEN, prefs.getString(KEY_REFRESH_TOKEN, null))
 
+    /**
+     * Returns `true` when a usable Trakt session is stored — i.e. an access token is
+     * present and either still unexpired or accompanied by a refresh token.
+     *
+     * Trakt access tokens are short-lived (currently 7 days). An expired one is renewed
+     * transparently by [com.justb81.watchbuddy.phone.auth.TokenRefreshManager] on the next
+     * authenticated call as long as a refresh token exists, so an expired access token with
+     * a refresh token must **not** be treated as disconnected: otherwise the user is bounced
+     * to onboarding (and `canWatch` flips off) every time the access token expires (~weekly).
+     */
     fun isTokenValid(): Boolean {
         val token = getAccessToken() ?: return false
         if (token.isBlank()) return false
-        val expiresAt = readExpiresAt()
-        return System.currentTimeMillis() < expiresAt
+        if (!getRefreshToken().isNullOrBlank()) return true
+        return System.currentTimeMillis() < readExpiresAt()
     }
 
     /**

--- a/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRepositoryTest.kt
+++ b/app-phone/src/test/java/com/justb81/watchbuddy/phone/auth/TokenRepositoryTest.kt
@@ -147,11 +147,24 @@ class TokenRepositoryTest {
         }
 
         @Test
-        fun `returns false when token has expired`() {
+        fun `returns false when token has expired and no refresh token is stored`() {
             every { mockPrefs.getString("access_token", null) } returns v1Ciphertext("expired")
+            every { mockPrefs.getString("refresh_token", null) } returns null
             every { mockPrefs.getString("expires_at", null) } returns
                 v1Ciphertext((System.currentTimeMillis() - 1_000L).toString())
             assertFalse(repository.isTokenValid())
+        }
+
+        @Test
+        fun `returns true when access token has expired but a refresh token is stored`() {
+            // Regression (#790): an expired access token must NOT read as disconnected while
+            // a refresh token can renew it — otherwise the user is bounced to onboarding
+            // every time the short-lived access token expires (~weekly).
+            every { mockPrefs.getString("access_token", null) } returns v1Ciphertext("expired-access")
+            every { mockPrefs.getString("refresh_token", null) } returns v1Ciphertext("refresh")
+            every { mockPrefs.getString("expires_at", null) } returns
+                v1Ciphertext((System.currentTimeMillis() - 1_000L).toString())
+            assertTrue(repository.isTokenValid())
         }
     }
 


### PR DESCRIPTION
## Problem

The app "loses the connection to Trakt every while" — recurring (≈ weekly), bouncing the user back to the onboarding/connect screen as if the token had been cleared.

## Root cause

The token is **not** being cleared from storage — `TokenRepository.clearTokens()` only runs on an explicit user "Disconnect."

The real bug is that the **connection check treats an expired access token as a lost session**, ignoring the refresh token that can renew it.

Trakt access tokens are short-lived: the device/backend diagnostics in issue #235 show `"expires_in": 604800` = **7 days**. Both connection checks used `TokenRepository.isTokenValid()`, which returned `false` the instant the access token expired:

- **`MainActivity`** — start-destination selection. After ~7 days a cold launch routes the user to **Onboarding**, which reads as "lost the Trakt connection."
- **`HomeViewModel.checkServiceConnections()`** — computes `canWatch`, which flips off weekly (disabling the "Watch with TV" companion toggle).

`TokenRefreshManager` already renews an expired-but-refreshable access token transparently on the next authenticated call (that path is correct and well-tested) — so the session is recoverable; it only *appeared* lost.

## Fix

Broaden `isTokenValid()` **in place** (no new method, no call-site changes): a session is usable when an access token is present **and** either still unexpired **or** accompanied by a refresh token. An expired access token with a refresh token must not count as disconnected.

```kotlin
fun isTokenValid(): Boolean {
    val token = getAccessToken() ?: return false
    if (token.isBlank()) return false
    if (!getRefreshToken().isNullOrBlank()) return true
    return System.currentTimeMillis() < readExpiresAt()
}
```

If the refresh token itself is genuinely dead (revoked / past Trakt's window), the next refresh fails and the existing Home "Connect to Trakt" path lets the user re-authenticate — strictly better than bouncing to onboarding on every weekly access-token expiry.

## Tests

- `TokenRepositoryTest`: expired access token **+** refresh token ⇒ `isTokenValid()` is `true` (the regression); expired **without** a refresh token ⇒ still `false`.

Net change is two files (`TokenRepository.kt` + its test). All Gradle unit tests, detekt, and Android Lint pass locally via `scripts/precommit.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1j7zz7MgDYY5xGhKvpR9W